### PR TITLE
Server Team CRUD Endpoints

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,11 @@ keywords = ["agents", "ai", "akgentic", "infrastructure"]
 dependencies = [
     "akgentic>=0.1.0",
     "akgentic-team>=0.1.0",
+    "akgentic-catalog>=0.1.0",
+    "akgentic-agent>=0.1.0",
+    "akgentic-llm>=0.1.0",
+    "akgentic-tool>=0.1.0",
+    "fastapi>=0.100.0",
     "pydantic-settings>=2.0.0",
     "logfire>=0.1.0",
 ]
@@ -21,6 +26,7 @@ dev = [
     "pytest>=8.0.0",
     "pytest-asyncio>=0.23.0",
     "pytest-cov>=4.1.0",
+    "httpx>=0.27.0",
     "mypy>=1.8.0",
     "ruff>=0.1.0",
 ]
@@ -32,6 +38,10 @@ build-backend = "hatchling.build"
 [tool.uv.sources]
 akgentic = { workspace = true }
 akgentic-team = { workspace = true }
+akgentic-catalog = { workspace = true }
+akgentic-agent = { workspace = true }
+akgentic-llm = { workspace = true }
+akgentic-tool = { workspace = true }
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/akgentic"]

--- a/src/akgentic/infra/__init__.py
+++ b/src/akgentic/infra/__init__.py
@@ -21,7 +21,14 @@ from akgentic.infra.protocols import (
     PlacementStrategy,
     RecoveryPolicy,
 )
+from akgentic.infra.server.app import create_app
 from akgentic.infra.server.deps import CommunityServices, TierServices
+from akgentic.infra.server.models import (
+    CreateTeamRequest,
+    TeamListResponse,
+    TeamResponse,
+)
+from akgentic.infra.server.services.team_service import TeamService
 from akgentic.infra.server.settings import ServerSettings
 from akgentic.infra.wiring import wire_community
 
@@ -45,8 +52,13 @@ __all__ = [
     "TelemetrySubscriber",
     # Server
     "CommunityServices",
+    "CreateTeamRequest",
     "ServerSettings",
+    "TeamListResponse",
+    "TeamResponse",
+    "TeamService",
     "TierServices",
+    "create_app",
     # Wiring
     "wire_community",
 ]

--- a/src/akgentic/infra/__init__.py
+++ b/src/akgentic/infra/__init__.py
@@ -18,6 +18,7 @@ from akgentic.infra.protocols import (
     HealthMonitor,
     InteractionChannelAdapter,
     InteractionChannelIngestion,
+    JsonValue,
     PlacementStrategy,
     RecoveryPolicy,
 )
@@ -43,6 +44,7 @@ __all__ = [
     "HealthMonitor",
     "InteractionChannelAdapter",
     "InteractionChannelIngestion",
+    "JsonValue",
     "PlacementStrategy",
     "RecoveryPolicy",
     # Adapters

--- a/src/akgentic/infra/protocols/__init__.py
+++ b/src/akgentic/infra/protocols/__init__.py
@@ -9,6 +9,7 @@ from akgentic.infra.protocols.channels import (
     ChannelRegistry,
     InteractionChannelAdapter,
     InteractionChannelIngestion,
+    JsonValue,
 )
 from akgentic.infra.protocols.health import HealthMonitor
 from akgentic.infra.protocols.placement import PlacementStrategy
@@ -22,6 +23,7 @@ __all__ = [
     "HealthMonitor",
     "InteractionChannelAdapter",
     "InteractionChannelIngestion",
+    "JsonValue",
     "PlacementStrategy",
     "RecoveryPolicy",
 ]

--- a/src/akgentic/infra/protocols/channels.py
+++ b/src/akgentic/infra/protocols/channels.py
@@ -3,9 +3,12 @@
 from __future__ import annotations
 
 import uuid
-from typing import Any, Protocol
+from typing import Protocol
 
 from pydantic import BaseModel, Field
+
+# Recursive JSON-safe type for webhook payloads — replaces dict[str, Any].
+JsonValue = str | int | float | bool | None | list["JsonValue"] | dict[str, "JsonValue"]
 
 
 class ChannelMessage(BaseModel):
@@ -55,7 +58,7 @@ class ChannelParser(Protocol):
     Runs in FastAPI async context — uses async signatures.
     """
 
-    async def parse(self, payload: dict[str, Any]) -> ChannelMessage:
+    async def parse(self, payload: dict[str, JsonValue]) -> ChannelMessage:
         """Parse a raw webhook payload into a structured channel message.
 
         Args:

--- a/src/akgentic/infra/server/__init__.py
+++ b/src/akgentic/infra/server/__init__.py
@@ -1,1 +1,24 @@
-"""Server module — implemented in future stories."""
+"""Server module — FastAPI application, models, routes, and services."""
+
+from __future__ import annotations
+
+from akgentic.infra.server.app import create_app
+from akgentic.infra.server.deps import CommunityServices, TierServices
+from akgentic.infra.server.models import (
+    CreateTeamRequest,
+    TeamListResponse,
+    TeamResponse,
+)
+from akgentic.infra.server.services.team_service import TeamService
+from akgentic.infra.server.settings import ServerSettings
+
+__all__ = [
+    "CommunityServices",
+    "CreateTeamRequest",
+    "ServerSettings",
+    "TeamListResponse",
+    "TeamResponse",
+    "TeamService",
+    "TierServices",
+    "create_app",
+]

--- a/src/akgentic/infra/server/app.py
+++ b/src/akgentic/infra/server/app.py
@@ -1,0 +1,46 @@
+"""FastAPI application factory for the akgentic-infra server."""
+
+from __future__ import annotations
+
+from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
+
+from akgentic.infra.server.deps import CommunityServices
+from akgentic.infra.server.routes.teams import router as teams_router
+from akgentic.infra.server.services.team_service import TeamService
+
+
+def create_app(
+    services: CommunityServices,
+    team_service: TeamService,
+    cors_origins: list[str] | None = None,
+) -> FastAPI:
+    """Create and configure the FastAPI application.
+
+    Args:
+        services: Wired community services container.
+        team_service: Pre-built team service for dependency injection.
+        cors_origins: Allowed CORS origins. Defaults to ["*"] for community tier.
+
+    Returns:
+        Configured FastAPI application instance.
+    """
+    app = FastAPI(title="Akgentic Platform API")
+
+    if cors_origins is None:
+        cors_origins = ["*"]
+
+    app.add_middleware(
+        CORSMiddleware,
+        allow_origins=cors_origins,
+        allow_credentials=True,
+        allow_methods=["*"],
+        allow_headers=["*"],
+    )
+
+    app.state.services = services
+    app.state.team_service = team_service
+
+    app.include_router(teams_router)
+
+    return app

--- a/src/akgentic/infra/server/deps.py
+++ b/src/akgentic/infra/server/deps.py
@@ -10,6 +10,7 @@ from akgentic.catalog.services import (
     TemplateCatalog,
     ToolCatalog,
 )
+from akgentic.core import ActorSystem
 from akgentic.infra.protocols.auth import AuthStrategy
 from akgentic.infra.protocols.placement import PlacementStrategy
 from akgentic.team.manager import TeamManager
@@ -51,6 +52,9 @@ class CommunityServices(TierServices):
     catalogs for single-process deployment.
     """
 
+    actor_system: ActorSystem = Field(
+        description="Actor system for managing agent lifecycle"
+    )
     team_manager: TeamManager = Field(
         description="Team lifecycle manager (embedded, in-process)"
     )

--- a/src/akgentic/infra/server/deps.py
+++ b/src/akgentic/infra/server/deps.py
@@ -4,6 +4,12 @@ from __future__ import annotations
 
 from pydantic import BaseModel, ConfigDict, Field
 
+from akgentic.catalog.services import (
+    AgentCatalog,
+    TeamCatalog,
+    TemplateCatalog,
+    ToolCatalog,
+)
 from akgentic.infra.protocols.auth import AuthStrategy
 from akgentic.infra.protocols.placement import PlacementStrategy
 from akgentic.team.manager import TeamManager
@@ -39,11 +45,24 @@ class TierServices(BaseModel):
 
 
 class CommunityServices(TierServices):
-    """Community-tier service container with embedded TeamManager.
+    """Community-tier service container with embedded TeamManager and catalogs.
 
-    Extends TierServices with an in-process TeamManager for single-process deployment.
+    Extends TierServices with an in-process TeamManager and YAML-backed
+    catalogs for single-process deployment.
     """
 
     team_manager: TeamManager = Field(
         description="Team lifecycle manager (embedded, in-process)"
+    )
+    team_catalog: TeamCatalog = Field(
+        description="Catalog service for team entry resolution"
+    )
+    agent_catalog: AgentCatalog = Field(
+        description="Catalog service for agent entry resolution"
+    )
+    tool_catalog: ToolCatalog = Field(
+        description="Catalog service for tool entry resolution"
+    )
+    template_catalog: TemplateCatalog = Field(
+        description="Catalog service for template entry resolution"
     )

--- a/src/akgentic/infra/server/models.py
+++ b/src/akgentic/infra/server/models.py
@@ -1,0 +1,35 @@
+"""Pydantic request/response models for the REST API."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+
+from pydantic import BaseModel, Field
+
+
+class CreateTeamRequest(BaseModel):
+    """Request body for POST /teams."""
+
+    catalog_entry_id: str = Field(description="Catalog entry ID to resolve into a TeamCard")
+    params: dict[str, str] = Field(
+        default_factory=dict,
+        description="Pass-through configuration parameters",
+    )
+
+
+class TeamResponse(BaseModel):
+    """Serialized team metadata returned by team endpoints."""
+
+    team_id: uuid.UUID = Field(description="Unique team identifier")
+    name: str = Field(description="Human-readable team name")
+    status: str = Field(description="Current team lifecycle status")
+    user_id: str = Field(description="Owner user identifier")
+    created_at: datetime = Field(description="Team creation timestamp")
+    updated_at: datetime = Field(description="Last status change timestamp")
+
+
+class TeamListResponse(BaseModel):
+    """Response body for GET /teams."""
+
+    teams: list[TeamResponse] = Field(description="List of team metadata entries")

--- a/src/akgentic/infra/server/routes/__init__.py
+++ b/src/akgentic/infra/server/routes/__init__.py
@@ -1,0 +1,1 @@
+"""REST API route modules."""

--- a/src/akgentic/infra/server/routes/teams.py
+++ b/src/akgentic/infra/server/routes/teams.py
@@ -1,0 +1,84 @@
+"""Team CRUD endpoints — create, list, get, and delete teams."""
+
+from __future__ import annotations
+
+import uuid
+
+from fastapi import APIRouter, Depends, HTTPException, Request
+
+from akgentic.catalog.models.errors import EntryNotFoundError
+from akgentic.infra.server.models import (
+    CreateTeamRequest,
+    TeamListResponse,
+    TeamResponse,
+)
+from akgentic.infra.server.services.team_service import TeamService
+from akgentic.team.models import Process
+
+router = APIRouter(prefix="/teams", tags=["teams"])
+
+
+def get_team_service(request: Request) -> TeamService:
+    """FastAPI dependency: extract TeamService from app.state."""
+    return request.app.state.team_service  # type: ignore[no-any-return]
+
+
+def _process_to_response(process: Process) -> TeamResponse:
+    """Convert a Process model to a TeamResponse."""
+    return TeamResponse(
+        team_id=process.team_id,
+        name=process.team_card.name,
+        status=process.status.value,
+        user_id=process.user_id,
+        created_at=process.created_at,
+        updated_at=process.updated_at,
+    )
+
+
+@router.post("/", status_code=201, response_model=TeamResponse)
+def create_team(
+    body: CreateTeamRequest,
+    service: TeamService = Depends(get_team_service),
+) -> TeamResponse:
+    """Create a new team from a catalog entry."""
+    try:
+        process = service.create_team(
+            catalog_entry_id=body.catalog_entry_id,
+            user_id="anonymous",
+        )
+    except EntryNotFoundError:
+        raise HTTPException(status_code=404, detail="Catalog entry not found")
+    return _process_to_response(process)
+
+
+@router.get("/", response_model=TeamListResponse)
+def list_teams(
+    service: TeamService = Depends(get_team_service),
+) -> TeamListResponse:
+    """List all teams for the current user."""
+    processes = service.list_teams(user_id="anonymous")
+    return TeamListResponse(teams=[_process_to_response(p) for p in processes])
+
+
+@router.get("/{team_id}", response_model=TeamResponse)
+def get_team(
+    team_id: uuid.UUID,
+    service: TeamService = Depends(get_team_service),
+) -> TeamResponse:
+    """Get a single team by ID."""
+    process = service.get_team(team_id)
+    if process is None:
+        raise HTTPException(status_code=404, detail="Team not found")
+    return _process_to_response(process)
+
+
+@router.delete("/{team_id}", status_code=204)
+def delete_team(
+    team_id: uuid.UUID,
+    service: TeamService = Depends(get_team_service),
+) -> None:
+    """Stop and delete a team."""
+    try:
+        service.delete_team(team_id)
+    except ValueError:
+        raise HTTPException(status_code=404, detail="Team not found")

--- a/src/akgentic/infra/server/routes/teams.py
+++ b/src/akgentic/infra/server/routes/teams.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import uuid
+from typing import cast
 
 from fastapi import APIRouter, Depends, HTTPException, Request
 
@@ -20,7 +21,7 @@ router = APIRouter(prefix="/teams", tags=["teams"])
 
 def get_team_service(request: Request) -> TeamService:
     """FastAPI dependency: extract TeamService from app.state."""
-    return request.app.state.team_service  # type: ignore[no-any-return]
+    return cast(TeamService, request.app.state.team_service)
 
 
 def _process_to_response(process: Process) -> TeamResponse:
@@ -44,10 +45,10 @@ def create_team(
     try:
         process = service.create_team(
             catalog_entry_id=body.catalog_entry_id,
-            user_id="anonymous",
+            user_id="anonymous",  # Community tier: no auth, single-user
         )
     except EntryNotFoundError:
-        raise HTTPException(status_code=404, detail="Catalog entry not found")
+        raise HTTPException(status_code=404, detail="Catalog entry not found") from None
     return _process_to_response(process)
 
 
@@ -56,7 +57,7 @@ def list_teams(
     service: TeamService = Depends(get_team_service),
 ) -> TeamListResponse:
     """List all teams for the current user."""
-    processes = service.list_teams(user_id="anonymous")
+    processes = service.list_teams(user_id="anonymous")  # Community tier: no auth
     return TeamListResponse(teams=[_process_to_response(p) for p in processes])
 
 
@@ -81,4 +82,4 @@ def delete_team(
     try:
         service.delete_team(team_id)
     except ValueError:
-        raise HTTPException(status_code=404, detail="Team not found")
+        raise HTTPException(status_code=404, detail="Team not found") from None

--- a/src/akgentic/infra/server/services/__init__.py
+++ b/src/akgentic/infra/server/services/__init__.py
@@ -1,0 +1,1 @@
+"""Service layer for the REST API."""

--- a/src/akgentic/infra/server/services/team_service.py
+++ b/src/akgentic/infra/server/services/team_service.py
@@ -1,0 +1,79 @@
+"""TeamService — orchestrates catalog resolution and TeamManager delegation."""
+
+from __future__ import annotations
+
+import uuid
+
+from akgentic.catalog.models.errors import EntryNotFoundError
+from akgentic.catalog.services import (
+    AgentCatalog,
+    TeamCatalog,
+    TemplateCatalog,
+    ToolCatalog,
+)
+from akgentic.infra.server.deps import CommunityServices
+from akgentic.team.models import Process, TeamStatus
+
+
+class TeamService:
+    """Service layer bridging catalog resolution with team lifecycle management.
+
+    Resolves catalog entry IDs to TeamCards, delegates lifecycle operations
+    to TeamManager, and queries EventStore for listing.
+    """
+
+    def __init__(
+        self,
+        services: CommunityServices,
+        team_catalog: TeamCatalog,
+        agent_catalog: AgentCatalog,
+        tool_catalog: ToolCatalog | None = None,
+        template_catalog: TemplateCatalog | None = None,
+    ) -> None:
+        self._services = services
+        self._team_catalog = team_catalog
+        self._agent_catalog = agent_catalog
+        self._tool_catalog = tool_catalog
+        self._template_catalog = template_catalog
+
+    def create_team(self, catalog_entry_id: str, user_id: str) -> Process:
+        """Resolve catalog entry and create a running team.
+
+        Raises:
+            EntryNotFoundError: If catalog_entry_id is not found.
+        """
+        entry = self._team_catalog.get(catalog_entry_id)
+        if entry is None:
+            raise EntryNotFoundError(catalog_entry_id)
+        team_card = entry.to_team_card(
+            self._agent_catalog, self._tool_catalog, self._template_catalog
+        )
+        runtime = self._services.team_manager.create_team(team_card, user_id)
+        process = self._services.team_manager.get_team(runtime.id)
+        if process is None:  # pragma: no cover
+            msg = f"Team {runtime.id} was created but not found in event store"
+            raise RuntimeError(msg)
+        return process
+
+    def list_teams(self, user_id: str) -> list[Process]:
+        """List all teams for a given user."""
+        all_teams = self._services.event_store.list_teams()
+        return [t for t in all_teams if t.user_id == user_id]
+
+    def get_team(self, team_id: uuid.UUID) -> Process | None:
+        """Get a single team by ID."""
+        return self._services.team_manager.get_team(team_id)
+
+    def delete_team(self, team_id: uuid.UUID) -> None:
+        """Stop (if running) and delete a team.
+
+        Raises:
+            ValueError: If team not found or already deleted.
+        """
+        process = self._services.team_manager.get_team(team_id)
+        if process is None:
+            msg = f"Team {team_id} not found"
+            raise ValueError(msg)
+        if process.status == TeamStatus.RUNNING:
+            self._services.team_manager.stop_team(team_id)
+        self._services.team_manager.delete_team(team_id)

--- a/src/akgentic/infra/server/settings.py
+++ b/src/akgentic/infra/server/settings.py
@@ -33,3 +33,7 @@ class ServerSettings(BaseSettings):
         default=Path("workspaces"),
         description="Root directory for team workspace storage",
     )
+    cors_origins: list[str] = Field(
+        default=["*"],
+        description="Allowed CORS origins for the HTTP server",
+    )

--- a/src/akgentic/infra/wiring.py
+++ b/src/akgentic/infra/wiring.py
@@ -2,6 +2,18 @@
 
 from __future__ import annotations
 
+from akgentic.catalog.repositories.yaml import (
+    YamlAgentCatalogRepository,
+    YamlTeamCatalogRepository,
+    YamlTemplateCatalogRepository,
+    YamlToolCatalogRepository,
+)
+from akgentic.catalog.services import (
+    AgentCatalog,
+    TeamCatalog,
+    TemplateCatalog,
+    ToolCatalog,
+)
 from akgentic.core import ActorSystem, EventSubscriber
 from akgentic.infra.adapters.local_placement import LocalPlacement
 from akgentic.infra.adapters.local_service_registry import LocalServiceRegistry
@@ -24,6 +36,7 @@ def wire_community(settings: ServerSettings) -> CommunityServices:
     5. TeamManager
     6. PlacementStrategy (LocalPlacement)
     7. AuthStrategy (NoAuth)
+    8. Catalogs: Template + Tool → Agent → Team
 
     Args:
         settings: Server configuration
@@ -44,10 +57,31 @@ def wire_community(settings: ServerSettings) -> CommunityServices:
     placement = LocalPlacement()
     auth = NoAuth()
 
+    catalog_root = settings.workspaces_root / "catalog"
+    template_catalog = TemplateCatalog(
+        repository=YamlTemplateCatalogRepository(catalog_dir=catalog_root / "templates"),
+    )
+    tool_catalog = ToolCatalog(
+        repository=YamlToolCatalogRepository(catalog_dir=catalog_root / "tools"),
+    )
+    agent_catalog = AgentCatalog(
+        repository=YamlAgentCatalogRepository(catalog_dir=catalog_root / "agents"),
+        template_catalog=template_catalog,
+        tool_catalog=tool_catalog,
+    )
+    team_catalog = TeamCatalog(
+        repository=YamlTeamCatalogRepository(catalog_dir=catalog_root / "teams"),
+        agent_catalog=agent_catalog,
+    )
+
     return CommunityServices(
         placement=placement,
         service_registry=service_registry,
         auth=auth,
         event_store=event_store,
         team_manager=team_manager,
+        team_catalog=team_catalog,
+        agent_catalog=agent_catalog,
+        tool_catalog=tool_catalog,
+        template_catalog=template_catalog,
     )

--- a/src/akgentic/infra/wiring.py
+++ b/src/akgentic/infra/wiring.py
@@ -79,6 +79,7 @@ def wire_community(settings: ServerSettings) -> CommunityServices:
         service_registry=service_registry,
         auth=auth,
         event_store=event_store,
+        actor_system=actor_system,
         team_manager=team_manager,
         team_catalog=team_catalog,
         agent_catalog=agent_catalog,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,12 +5,14 @@ from __future__ import annotations
 from collections.abc import Generator
 from pathlib import Path
 
+import pykka
 import pytest
 import yaml
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
 from akgentic.infra.server.app import create_app
+from akgentic.infra.server.deps import CommunityServices
 from akgentic.infra.server.services.team_service import TeamService
 from akgentic.infra.server.settings import ServerSettings
 from akgentic.infra.wiring import wire_community
@@ -90,36 +92,29 @@ def seeded_settings(tmp_path: Path) -> ServerSettings:
 @pytest.fixture()
 def community_services(
     seeded_settings: ServerSettings,
-) -> Generator[object, None, None]:
+) -> Generator[CommunityServices, None, None]:
     """Wired community services with seeded catalog data."""
-    from akgentic.infra.server.deps import CommunityServices
-
-    services: CommunityServices = wire_community(seeded_settings)
+    services = wire_community(seeded_settings)
     yield services
+    pykka.ActorRegistry.stop_all()
 
 
 @pytest.fixture()
-def team_service(community_services: object) -> TeamService:
+def team_service(community_services: CommunityServices) -> TeamService:
     """TeamService wired to community services."""
-    from akgentic.infra.server.deps import CommunityServices
-
-    svc: CommunityServices = community_services  # type: ignore[assignment]
     return TeamService(
-        services=svc,
-        team_catalog=svc.team_catalog,
-        agent_catalog=svc.agent_catalog,
-        tool_catalog=svc.tool_catalog,
-        template_catalog=svc.template_catalog,
+        services=community_services,
+        team_catalog=community_services.team_catalog,
+        agent_catalog=community_services.agent_catalog,
+        tool_catalog=community_services.tool_catalog,
+        template_catalog=community_services.template_catalog,
     )
 
 
 @pytest.fixture()
-def app(community_services: object, team_service: TeamService) -> FastAPI:
+def app(community_services: CommunityServices, team_service: TeamService) -> FastAPI:
     """FastAPI app with wired services."""
-    from akgentic.infra.server.deps import CommunityServices
-
-    svc: CommunityServices = community_services  # type: ignore[assignment]
-    return create_app(svc, team_service)
+    return create_app(community_services, team_service)
 
 
 @pytest.fixture()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,128 @@
+"""Shared test fixtures for akgentic-infra tests."""
+
+from __future__ import annotations
+
+from collections.abc import Generator
+from pathlib import Path
+
+import pytest
+import yaml
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from akgentic.infra.server.app import create_app
+from akgentic.infra.server.services.team_service import TeamService
+from akgentic.infra.server.settings import ServerSettings
+from akgentic.infra.wiring import wire_community
+
+
+def _write_yaml(path: Path, data: dict[str, object]) -> None:
+    """Write a single YAML entry file."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(yaml.dump(data, default_flow_style=False))
+
+
+def _seed_catalog(catalog_root: Path) -> None:
+    """Create minimal YAML catalog entries for a test team."""
+    _write_yaml(
+        catalog_root / "agents" / "human-proxy.yaml",
+        {
+            "id": "human-proxy",
+            "tool_ids": [],
+            "card": {
+                "role": "Human",
+                "description": "Human user interface",
+                "skills": [],
+                "agent_class": "akgentic.agent.HumanProxy",
+                "config": {"name": "@Human", "role": "Human"},
+                "routes_to": ["@Manager"],
+            },
+        },
+    )
+    _write_yaml(
+        catalog_root / "agents" / "manager.yaml",
+        {
+            "id": "manager",
+            "tool_ids": [],
+            "card": {
+                "role": "Manager",
+                "description": "Test manager agent",
+                "skills": ["coordination"],
+                "agent_class": "akgentic.agent.BaseAgent",
+                "config": {"name": "@Manager", "role": "Manager"},
+                "routes_to": [],
+            },
+        },
+    )
+    _write_yaml(
+        catalog_root / "teams" / "test-team.yaml",
+        {
+            "id": "test-team",
+            "name": "Test Team",
+            "entry_point": "human-proxy",
+            "message_types": ["akgentic.core.messages.UserMessage"],
+            "members": [
+                {"agent_id": "human-proxy"},
+                {"agent_id": "manager"},
+            ],
+            "profiles": [],
+        },
+    )
+    # Empty dirs for templates and tools (no entries needed for this team)
+    (catalog_root / "templates").mkdir(parents=True, exist_ok=True)
+    (catalog_root / "tools").mkdir(parents=True, exist_ok=True)
+
+
+@pytest.fixture()
+def server_settings(tmp_path: Path) -> ServerSettings:
+    """Server settings with tmp_path-based workspaces."""
+    return ServerSettings(workspaces_root=tmp_path / "workspaces")
+
+
+@pytest.fixture()
+def seeded_settings(tmp_path: Path) -> ServerSettings:
+    """Server settings with pre-seeded catalog YAML files."""
+    settings = ServerSettings(workspaces_root=tmp_path / "workspaces")
+    _seed_catalog(settings.workspaces_root / "catalog")
+    return settings
+
+
+@pytest.fixture()
+def community_services(
+    seeded_settings: ServerSettings,
+) -> Generator[object, None, None]:
+    """Wired community services with seeded catalog data."""
+    from akgentic.infra.server.deps import CommunityServices
+
+    services: CommunityServices = wire_community(seeded_settings)
+    yield services
+
+
+@pytest.fixture()
+def team_service(community_services: object) -> TeamService:
+    """TeamService wired to community services."""
+    from akgentic.infra.server.deps import CommunityServices
+
+    svc: CommunityServices = community_services  # type: ignore[assignment]
+    return TeamService(
+        services=svc,
+        team_catalog=svc.team_catalog,
+        agent_catalog=svc.agent_catalog,
+        tool_catalog=svc.tool_catalog,
+        template_catalog=svc.template_catalog,
+    )
+
+
+@pytest.fixture()
+def app(community_services: object, team_service: TeamService) -> FastAPI:
+    """FastAPI app with wired services."""
+    from akgentic.infra.server.deps import CommunityServices
+
+    svc: CommunityServices = community_services  # type: ignore[assignment]
+    return create_app(svc, team_service)
+
+
+@pytest.fixture()
+def client(app: FastAPI) -> TestClient:
+    """Sync HTTP test client."""
+    return TestClient(app)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from collections.abc import Generator
 from pathlib import Path
 
-import pykka
 import pytest
 import yaml
 from fastapi import FastAPI
@@ -96,7 +95,7 @@ def community_services(
     """Wired community services with seeded catalog data."""
     services = wire_community(seeded_settings)
     yield services
-    pykka.ActorRegistry.stop_all()
+    services.actor_system.shutdown()
 
 
 @pytest.fixture()

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -10,12 +10,11 @@ from akgentic.infra.server.services.team_service import TeamService
 
 
 def test_create_app_returns_fastapi(
-    community_services: object,
+    community_services: CommunityServices,
     team_service: TeamService,
 ) -> None:
     """create_app returns a FastAPI instance with routes mounted."""
-    svc: CommunityServices = community_services  # type: ignore[assignment]
-    app = create_app(svc, team_service)
+    app = create_app(community_services, team_service)
     assert app.title == "Akgentic Platform API"
     route_paths = [r.path for r in app.routes]  # type: ignore[union-attr]
     assert "/teams/" in route_paths
@@ -36,12 +35,11 @@ def test_cors_headers_present(client: TestClient) -> None:
 
 
 def test_custom_cors_origins(
-    community_services: object,
+    community_services: CommunityServices,
     team_service: TeamService,
 ) -> None:
     """create_app respects custom cors_origins."""
-    svc: CommunityServices = community_services  # type: ignore[assignment]
-    app = create_app(svc, team_service, cors_origins=["http://example.com"])
+    app = create_app(community_services, team_service, cors_origins=["http://example.com"])
     test_client = TestClient(app)
     resp = test_client.options(
         "/teams/",

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,0 +1,53 @@
+"""Tests for the FastAPI application factory and CORS middleware."""
+
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+from akgentic.infra.server.app import create_app
+from akgentic.infra.server.deps import CommunityServices
+from akgentic.infra.server.services.team_service import TeamService
+
+
+def test_create_app_returns_fastapi(
+    community_services: object,
+    team_service: TeamService,
+) -> None:
+    """create_app returns a FastAPI instance with routes mounted."""
+    svc: CommunityServices = community_services  # type: ignore[assignment]
+    app = create_app(svc, team_service)
+    assert app.title == "Akgentic Platform API"
+    route_paths = [r.path for r in app.routes]  # type: ignore[union-attr]
+    assert "/teams/" in route_paths
+    assert "/teams/{team_id}" in route_paths
+
+
+def test_cors_headers_present(client: TestClient) -> None:
+    """Responses include CORS headers for allowed origins."""
+    resp = client.options(
+        "/teams/",
+        headers={
+            "Origin": "http://localhost:4200",
+            "Access-Control-Request-Method": "POST",
+        },
+    )
+    # When allow_origins=["*"], Starlette reflects the request Origin
+    assert "access-control-allow-origin" in resp.headers
+
+
+def test_custom_cors_origins(
+    community_services: object,
+    team_service: TeamService,
+) -> None:
+    """create_app respects custom cors_origins."""
+    svc: CommunityServices = community_services  # type: ignore[assignment]
+    app = create_app(svc, team_service, cors_origins=["http://example.com"])
+    test_client = TestClient(app)
+    resp = test_client.options(
+        "/teams/",
+        headers={
+            "Origin": "http://example.com",
+            "Access-Control-Request-Method": "GET",
+        },
+    )
+    assert resp.headers.get("access-control-allow-origin") == "http://example.com"

--- a/tests/test_local_service_registry.py
+++ b/tests/test_local_service_registry.py
@@ -4,8 +4,9 @@ from __future__ import annotations
 
 import uuid
 
-from akgentic.infra.adapters.local_service_registry import LocalServiceRegistry
 from akgentic.team.ports import ServiceRegistry
+
+from akgentic.infra.adapters.local_service_registry import LocalServiceRegistry
 
 
 class TestLocalServiceRegistryProtocolCompliance:

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -59,3 +59,23 @@ def test_infra_all_includes_wiring() -> None:
     from akgentic import infra
 
     assert "wire_community" in infra.__all__
+
+
+def test_infra_all_includes_server_app_and_models() -> None:
+    """akgentic.infra.__all__ includes create_app, request/response models, and TeamService."""
+    from akgentic import infra
+
+    expected = (
+        "create_app", "CreateTeamRequest", "TeamResponse",
+        "TeamListResponse", "TeamService",
+    )
+    for name in expected:
+        assert name in infra.__all__, f"Missing export: {name}"
+
+
+def test_server_module_exports() -> None:
+    """akgentic.infra.server.__all__ includes all server-layer symbols."""
+    from akgentic.infra import server
+
+    for name in server.__all__:
+        assert hasattr(server, name), f"Missing export: {name}"

--- a/tests/test_server_models.py
+++ b/tests/test_server_models.py
@@ -1,0 +1,68 @@
+"""Tests for REST API request/response models."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+
+from akgentic.infra.server.models import (
+    CreateTeamRequest,
+    TeamListResponse,
+    TeamResponse,
+)
+
+
+def test_create_team_request_minimal() -> None:
+    """CreateTeamRequest requires only catalog_entry_id."""
+    req = CreateTeamRequest(catalog_entry_id="test-team")
+    assert req.catalog_entry_id == "test-team"
+    assert req.params == {}
+
+
+def test_create_team_request_with_params() -> None:
+    """CreateTeamRequest accepts optional params."""
+    req = CreateTeamRequest(
+        catalog_entry_id="test-team",
+        params={"key": "value"},
+    )
+    assert req.params == {"key": "value"}
+
+
+def test_team_response_serialization() -> None:
+    """TeamResponse serializes all fields correctly."""
+    tid = uuid.uuid4()
+    now = datetime.now(tz=UTC)
+    resp = TeamResponse(
+        team_id=tid,
+        name="Test",
+        status="running",
+        user_id="anonymous",
+        created_at=now,
+        updated_at=now,
+    )
+    data = resp.model_dump(mode="json")
+    assert data["team_id"] == str(tid)
+    assert data["status"] == "running"
+
+
+def test_team_list_response_empty() -> None:
+    """TeamListResponse can hold an empty list."""
+    resp = TeamListResponse(teams=[])
+    assert resp.teams == []
+
+
+def test_team_list_response_with_items() -> None:
+    """TeamListResponse serializes a list of TeamResponses."""
+    tid = uuid.uuid4()
+    now = datetime.now(tz=UTC)
+    item = TeamResponse(
+        team_id=tid,
+        name="A",
+        status="running",
+        user_id="u",
+        created_at=now,
+        updated_at=now,
+    )
+    resp = TeamListResponse(teams=[item])
+    assert len(resp.teams) == 1
+    assert resp.teams[0].team_id == tid

--- a/tests/test_team_routes.py
+++ b/tests/test_team_routes.py
@@ -61,6 +61,9 @@ def test_delete_team_success(client: TestClient) -> None:
     team_id = create_resp.json()["team_id"]
     resp = client.delete(f"/teams/{team_id}")
     assert resp.status_code == 204
+    # Verify team is actually gone
+    get_resp = client.get(f"/teams/{team_id}")
+    assert get_resp.status_code == 404
 
 
 def test_delete_team_not_found(client: TestClient) -> None:

--- a/tests/test_team_routes.py
+++ b/tests/test_team_routes.py
@@ -1,0 +1,69 @@
+"""Tests for team CRUD endpoints using FastAPI TestClient."""
+
+from __future__ import annotations
+
+import uuid
+
+from fastapi.testclient import TestClient
+
+
+def test_create_team_success(client: TestClient) -> None:
+    """POST /teams with valid catalog entry returns 201."""
+    resp = client.post("/teams/", json={"catalog_entry_id": "test-team"})
+    assert resp.status_code == 201
+    data = resp.json()
+    assert "team_id" in data
+    assert data["status"] == "running"
+    assert data["name"] == "Test Team"
+
+
+def test_create_team_invalid_entry(client: TestClient) -> None:
+    """POST /teams with unknown catalog entry returns 404."""
+    resp = client.post("/teams/", json={"catalog_entry_id": "nonexistent"})
+    assert resp.status_code == 404
+
+
+def test_list_teams_empty(client: TestClient) -> None:
+    """GET /teams returns empty list when no teams exist."""
+    resp = client.get("/teams/")
+    assert resp.status_code == 200
+    assert resp.json()["teams"] == []
+
+
+def test_list_teams_after_create(client: TestClient) -> None:
+    """GET /teams returns created teams."""
+    client.post("/teams/", json={"catalog_entry_id": "test-team"})
+    resp = client.get("/teams/")
+    assert resp.status_code == 200
+    teams = resp.json()["teams"]
+    assert len(teams) == 1
+    assert teams[0]["name"] == "Test Team"
+
+
+def test_get_team_success(client: TestClient) -> None:
+    """GET /teams/{id} returns team detail."""
+    create_resp = client.post("/teams/", json={"catalog_entry_id": "test-team"})
+    team_id = create_resp.json()["team_id"]
+    resp = client.get(f"/teams/{team_id}")
+    assert resp.status_code == 200
+    assert resp.json()["team_id"] == team_id
+
+
+def test_get_team_not_found(client: TestClient) -> None:
+    """GET /teams/{id} returns 404 for unknown team."""
+    resp = client.get(f"/teams/{uuid.uuid4()}")
+    assert resp.status_code == 404
+
+
+def test_delete_team_success(client: TestClient) -> None:
+    """DELETE /teams/{id} returns 204 and removes team."""
+    create_resp = client.post("/teams/", json={"catalog_entry_id": "test-team"})
+    team_id = create_resp.json()["team_id"]
+    resp = client.delete(f"/teams/{team_id}")
+    assert resp.status_code == 204
+
+
+def test_delete_team_not_found(client: TestClient) -> None:
+    """DELETE /teams/{id} returns 404 for unknown team."""
+    resp = client.delete(f"/teams/{uuid.uuid4()}")
+    assert resp.status_code == 404

--- a/tests/test_team_service.py
+++ b/tests/test_team_service.py
@@ -66,6 +66,15 @@ def test_delete_team_stops_and_deletes(team_service: TeamService) -> None:
     assert after is None
 
 
+def test_delete_stopped_team(team_service: TeamService) -> None:
+    """delete_team handles an already-stopped team without calling stop_team."""
+    process = team_service.create_team("test-team", user_id="anonymous")
+    team_service._services.team_manager.stop_team(process.team_id)
+    team_service.delete_team(process.team_id)
+    after = team_service.get_team(process.team_id)
+    assert after is None
+
+
 def test_delete_team_not_found_raises(team_service: TeamService) -> None:
     """delete_team raises ValueError for a nonexistent team ID."""
     with pytest.raises(ValueError, match="not found"):

--- a/tests/test_team_service.py
+++ b/tests/test_team_service.py
@@ -1,0 +1,72 @@
+"""Tests for TeamService — service layer with real in-memory adapters."""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from akgentic.catalog.models.errors import EntryNotFoundError
+from akgentic.team.models import TeamStatus
+
+from akgentic.infra.server.services.team_service import TeamService
+
+
+def test_create_team_returns_process(team_service: TeamService) -> None:
+    """Creating a team with a valid catalog entry returns a Process."""
+    process = team_service.create_team("test-team", user_id="anonymous")
+    assert process.team_id is not None
+    assert process.status == TeamStatus.RUNNING
+    assert process.user_id == "anonymous"
+    assert process.team_card.name == "Test Team"
+
+
+def test_create_team_invalid_entry_raises(team_service: TeamService) -> None:
+    """Creating a team with an invalid catalog entry raises EntryNotFoundError."""
+    with pytest.raises(EntryNotFoundError):
+        team_service.create_team("nonexistent", user_id="anonymous")
+
+
+def test_list_teams_empty(team_service: TeamService) -> None:
+    """Listing teams when none exist returns empty list."""
+    result = team_service.list_teams(user_id="anonymous")
+    assert result == []
+
+
+def test_list_teams_filters_by_user(team_service: TeamService) -> None:
+    """list_teams returns only teams belonging to the given user."""
+    team_service.create_team("test-team", user_id="alice")
+    team_service.create_team("test-team", user_id="bob")
+    alice_teams = team_service.list_teams(user_id="alice")
+    bob_teams = team_service.list_teams(user_id="bob")
+    assert len(alice_teams) == 1
+    assert len(bob_teams) == 1
+    assert alice_teams[0].user_id == "alice"
+
+
+def test_get_team_found(team_service: TeamService) -> None:
+    """get_team returns the Process for an existing team."""
+    process = team_service.create_team("test-team", user_id="anonymous")
+    found = team_service.get_team(process.team_id)
+    assert found is not None
+    assert found.team_id == process.team_id
+
+
+def test_get_team_not_found(team_service: TeamService) -> None:
+    """get_team returns None for a nonexistent team ID."""
+    result = team_service.get_team(uuid.uuid4())
+    assert result is None
+
+
+def test_delete_team_stops_and_deletes(team_service: TeamService) -> None:
+    """delete_team stops a running team and purges it from the event store."""
+    process = team_service.create_team("test-team", user_id="anonymous")
+    team_service.delete_team(process.team_id)
+    # After deletion, the team is fully purged from the event store
+    after = team_service.get_team(process.team_id)
+    assert after is None
+
+
+def test_delete_team_not_found_raises(team_service: TeamService) -> None:
+    """delete_team raises ValueError for a nonexistent team ID."""
+    with pytest.raises(ValueError, match="not found"):
+        team_service.delete_team(uuid.uuid4())

--- a/tests/test_wiring.py
+++ b/tests/test_wiring.py
@@ -6,6 +6,8 @@ from collections.abc import Generator
 from pathlib import Path
 
 import pytest
+from akgentic.team.manager import TeamManager
+from akgentic.team.repositories.yaml import YamlEventStore
 
 from akgentic.infra.adapters.local_placement import LocalPlacement
 from akgentic.infra.adapters.local_service_registry import LocalServiceRegistry
@@ -13,8 +15,6 @@ from akgentic.infra.adapters.no_auth import NoAuth
 from akgentic.infra.server.deps import CommunityServices
 from akgentic.infra.server.settings import ServerSettings
 from akgentic.infra.wiring import wire_community
-from akgentic.team.manager import TeamManager
-from akgentic.team.repositories.yaml import YamlEventStore
 
 
 class TestWireCommunity:


### PR DESCRIPTION
## Summary

- REST API endpoints for team lifecycle management: `POST /teams`, `GET /teams`, `GET /teams/{id}`, `DELETE /teams/{id}`
- Pydantic request/response models with full Field descriptions
- TeamService layer bridging catalog resolution with TeamManager delegation
- FastAPI app factory with configurable CORS middleware
- CommunityServices extended with 4 YAML-backed catalog fields
- wire_community() updated with catalog construction (templates+tools → agents → teams)
- 112 tests passing, 99.66% coverage, ruff clean, mypy strict clean

Closes #6