### PR TITLE
Server — Team Action Endpoints

### DIFF
--- a/src/akgentic/infra/__init__.py
+++ b/src/akgentic/infra/__init__.py
@@ -26,6 +26,10 @@ from akgentic.infra.server.app import create_app
 from akgentic.infra.server.deps import CommunityServices, TierServices
 from akgentic.infra.server.models import (
     CreateTeamRequest,
+    EventListResponse,
+    EventResponse,
+    HumanInputRequest,
+    SendMessageRequest,
     TeamListResponse,
     TeamResponse,
 )
@@ -55,6 +59,10 @@ __all__ = [
     # Server
     "CommunityServices",
     "CreateTeamRequest",
+    "EventListResponse",
+    "EventResponse",
+    "HumanInputRequest",
+    "SendMessageRequest",
     "ServerSettings",
     "TeamListResponse",
     "TeamResponse",

--- a/src/akgentic/infra/server/__init__.py
+++ b/src/akgentic/infra/server/__init__.py
@@ -6,6 +6,10 @@ from akgentic.infra.server.app import create_app
 from akgentic.infra.server.deps import CommunityServices, TierServices
 from akgentic.infra.server.models import (
     CreateTeamRequest,
+    EventListResponse,
+    EventResponse,
+    HumanInputRequest,
+    SendMessageRequest,
     TeamListResponse,
     TeamResponse,
 )
@@ -15,6 +19,10 @@ from akgentic.infra.server.settings import ServerSettings
 __all__ = [
     "CommunityServices",
     "CreateTeamRequest",
+    "EventListResponse",
+    "EventResponse",
+    "HumanInputRequest",
+    "SendMessageRequest",
     "ServerSettings",
     "TeamListResponse",
     "TeamResponse",

--- a/src/akgentic/infra/server/models.py
+++ b/src/akgentic/infra/server/models.py
@@ -33,3 +33,31 @@ class TeamListResponse(BaseModel):
     """Response body for GET /teams."""
 
     teams: list[TeamResponse] = Field(description="List of team metadata entries")
+
+
+class SendMessageRequest(BaseModel):
+    """Request body for POST /teams/{team_id}/message."""
+
+    content: str = Field(description="Message content to send to the team")
+
+
+class HumanInputRequest(BaseModel):
+    """Request body for POST /teams/{team_id}/human-input."""
+
+    content: str = Field(description="Human response content")
+    message_id: str = Field(description="ID of the original message being answered")
+
+
+class EventResponse(BaseModel):
+    """Serialized form of a PersistedEvent."""
+
+    team_id: uuid.UUID = Field(description="Team instance this event belongs to")
+    sequence: int = Field(description="Monotonically increasing event sequence number")
+    event: dict[str, object] = Field(description="Serialized event payload")
+    timestamp: datetime = Field(description="Timestamp when the event was persisted")
+
+
+class EventListResponse(BaseModel):
+    """Response body for GET /teams/{team_id}/events."""
+
+    events: list[EventResponse] = Field(description="List of persisted events")

--- a/src/akgentic/infra/server/routes/teams.py
+++ b/src/akgentic/infra/server/routes/teams.py
@@ -1,4 +1,4 @@
-"""Team CRUD endpoints — create, list, get, and delete teams."""
+"""Team CRUD and action endpoints — create, list, get, delete, message, stop, restore, events."""
 
 from __future__ import annotations
 
@@ -10,6 +10,10 @@ from fastapi import APIRouter, Depends, HTTPException, Request
 from akgentic.catalog.models.errors import EntryNotFoundError
 from akgentic.infra.server.models import (
     CreateTeamRequest,
+    EventListResponse,
+    EventResponse,
+    HumanInputRequest,
+    SendMessageRequest,
     TeamListResponse,
     TeamResponse,
 )
@@ -83,3 +87,93 @@ def delete_team(
         service.delete_team(team_id)
     except ValueError:
         raise HTTPException(status_code=404, detail="Team not found") from None
+
+
+# --- Action Endpoints ---
+
+
+@router.post("/{team_id}/message", status_code=204)
+def send_message(
+    team_id: uuid.UUID,
+    body: SendMessageRequest,
+    service: TeamService = Depends(get_team_service),
+) -> None:
+    """Send a message to a running team."""
+    try:
+        service.send_message(team_id, body.content)
+    except ValueError as exc:
+        _raise_action_error(exc)
+
+
+@router.post("/{team_id}/human-input", status_code=204)
+def human_input(
+    team_id: uuid.UUID,
+    body: HumanInputRequest,
+    service: TeamService = Depends(get_team_service),
+) -> None:
+    """Provide human input in response to an agent request."""
+    try:
+        service.process_human_input(team_id, body.content, body.message_id)
+    except ValueError as exc:
+        _raise_action_error(exc)
+
+
+@router.post("/{team_id}/stop", status_code=204)
+def stop_team(
+    team_id: uuid.UUID,
+    service: TeamService = Depends(get_team_service),
+) -> None:
+    """Stop a running team without deleting persisted data."""
+    try:
+        service.stop_team(team_id)
+    except ValueError as exc:
+        _raise_action_error(exc)
+
+
+@router.post("/{team_id}/restore", status_code=200, response_model=TeamResponse)
+def restore_team(
+    team_id: uuid.UUID,
+    service: TeamService = Depends(get_team_service),
+) -> TeamResponse:
+    """Restore a stopped team."""
+    try:
+        process = service.restore_team(team_id)
+    except ValueError as exc:
+        _raise_action_error(exc)
+        raise  # unreachable, satisfies type checker
+    return _process_to_response(process)
+
+
+@router.get("/{team_id}/events", response_model=EventListResponse)
+def get_events(
+    team_id: uuid.UUID,
+    service: TeamService = Depends(get_team_service),
+) -> EventListResponse:
+    """Get all persisted events for a team."""
+    try:
+        events = service.get_events(team_id)
+    except ValueError:
+        raise HTTPException(status_code=404, detail="Team not found") from None
+    return EventListResponse(
+        events=[
+            EventResponse(
+                team_id=ev.team_id,
+                sequence=ev.sequence,
+                event=ev.event.model_dump(mode="json"),
+                timestamp=ev.timestamp,
+            )
+            for ev in events
+        ]
+    )
+
+
+def _raise_action_error(exc: ValueError) -> None:
+    """Map ValueError messages to appropriate HTTP status codes.
+
+    Raises:
+        HTTPException: 404 for not-found errors, 409 for state conflicts.
+    """
+    detail = str(exc)
+    if "not found" in detail:
+        raise HTTPException(status_code=404, detail=detail) from None
+    raise HTTPException(status_code=409, detail=detail) from None

--- a/src/akgentic/infra/server/routes/teams.py
+++ b/src/akgentic/infra/server/routes/teams.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import uuid
-from typing import cast
+from typing import NoReturn, cast
 
 from fastapi import APIRouter, Depends, HTTPException, Request
 
@@ -140,7 +140,6 @@ def restore_team(
         process = service.restore_team(team_id)
     except ValueError as exc:
         _raise_action_error(exc)
-        raise  # unreachable, satisfies type checker
     return _process_to_response(process)
 
 
@@ -167,13 +166,13 @@ def get_events(
     )
 
 
-def _raise_action_error(exc: ValueError) -> None:
+def _raise_action_error(exc: ValueError) -> NoReturn:
     """Map ValueError messages to appropriate HTTP status codes.
 
     Raises:
-        HTTPException: 404 for not-found errors, 409 for state conflicts.
+        HTTPException: 404 for not-found/deleted errors, 409 for state conflicts.
     """
     detail = str(exc)
-    if "not found" in detail:
+    if "not found" in detail or "deleted" in detail:
         raise HTTPException(status_code=404, detail=detail) from None
     raise HTTPException(status_code=409, detail=detail) from None

--- a/src/akgentic/infra/server/services/team_service.py
+++ b/src/akgentic/infra/server/services/team_service.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import uuid
 
+from akgentic.agent import HumanProxy
 from akgentic.catalog.models.errors import EntryNotFoundError
 from akgentic.catalog.services import (
     AgentCatalog,
@@ -11,15 +12,18 @@ from akgentic.catalog.services import (
     TemplateCatalog,
     ToolCatalog,
 )
+from akgentic.core.actor_address import ActorAddress
+from akgentic.core.messages.message import Message
 from akgentic.infra.server.deps import CommunityServices
-from akgentic.team.models import Process, TeamStatus
+from akgentic.team.models import PersistedEvent, Process, TeamRuntime, TeamStatus
 
 
 class TeamService:
     """Service layer bridging catalog resolution with team lifecycle management.
 
     Resolves catalog entry IDs to TeamCards, delegates lifecycle operations
-    to TeamManager, and queries EventStore for listing.
+    to TeamManager, and queries EventStore for listing. Caches TeamRuntime
+    instances for action endpoints that require a live runtime handle.
     """
 
     def __init__(
@@ -35,6 +39,7 @@ class TeamService:
         self._agent_catalog = agent_catalog
         self._tool_catalog = tool_catalog
         self._template_catalog = template_catalog
+        self._runtimes: dict[uuid.UUID, TeamRuntime] = {}
 
     def create_team(self, catalog_entry_id: str, user_id: str) -> Process:
         """Resolve catalog entry and create a running team.
@@ -49,6 +54,7 @@ class TeamService:
             self._agent_catalog, self._tool_catalog, self._template_catalog
         )
         runtime = self._services.team_manager.create_team(team_card, user_id)
+        self._runtimes[runtime.id] = runtime
         process = self._services.team_manager.get_team(runtime.id)
         if process is None:  # pragma: no cover
             msg = f"Team {runtime.id} was created but not found in event store"
@@ -76,4 +82,132 @@ class TeamService:
             raise ValueError(msg)
         if process.status == TeamStatus.RUNNING:
             self._services.team_manager.stop_team(team_id)
+        self._runtimes.pop(team_id, None)
         self._services.team_manager.delete_team(team_id)
+
+    def send_message(self, team_id: uuid.UUID, content: str) -> None:
+        """Send a message to a running team.
+
+        Raises:
+            ValueError: If team not found or not running.
+        """
+        runtime = self._get_running_runtime(team_id)
+        runtime.send(content)
+
+    def process_human_input(
+        self, team_id: uuid.UUID, content: str, message_id: str,
+    ) -> None:
+        """Route human input to HumanProxy for a specific message.
+
+        Raises:
+            ValueError: If team not found, not running, or message not found.
+        """
+        runtime = self._get_running_runtime(team_id)
+        original_message = self._find_message(team_id, message_id)
+        human_addr = self._find_human_proxy_addr(runtime)
+        proxy = runtime.actor_system.proxy_ask(human_addr, HumanProxy)
+        proxy.process_human_input(content, original_message)
+
+    def stop_team(self, team_id: uuid.UUID) -> None:
+        """Stop a running team without deleting persisted data.
+
+        Raises:
+            ValueError: If team not found or not in a stoppable state.
+        """
+        process = self._services.team_manager.get_team(team_id)
+        if process is None:
+            msg = f"Team {team_id} not found"
+            raise ValueError(msg)
+        if process.status == TeamStatus.STOPPED:
+            msg = f"Team {team_id} is already stopped"
+            raise ValueError(msg)
+        if process.status == TeamStatus.DELETED:
+            msg = f"Team {team_id} has been deleted"
+            raise ValueError(msg)
+        self._services.team_manager.stop_team(team_id)
+        self._runtimes.pop(team_id, None)
+
+    def restore_team(self, team_id: uuid.UUID) -> Process:
+        """Restore a stopped team.
+
+        Raises:
+            ValueError: If team not found or not in a restorable state.
+        """
+        process = self._services.team_manager.get_team(team_id)
+        if process is None:
+            msg = f"Team {team_id} not found"
+            raise ValueError(msg)
+        if process.status == TeamStatus.RUNNING:
+            msg = f"Team {team_id} is already running"
+            raise ValueError(msg)
+        if process.status == TeamStatus.DELETED:
+            msg = f"Team {team_id} has been deleted"
+            raise ValueError(msg)
+        runtime = self._services.team_manager.resume_team(team_id)
+        self._runtimes[runtime.id] = runtime
+        updated = self._services.team_manager.get_team(team_id)
+        if updated is None:  # pragma: no cover
+            msg = f"Team {team_id} was restored but not found in event store"
+            raise RuntimeError(msg)
+        return updated
+
+    def get_events(self, team_id: uuid.UUID) -> list[PersistedEvent]:
+        """Get all persisted events for a team.
+
+        Raises:
+            ValueError: If team not found.
+        """
+        process = self._services.team_manager.get_team(team_id)
+        if process is None:
+            msg = f"Team {team_id} not found"
+            raise ValueError(msg)
+        return self._services.event_store.load_events(team_id)
+
+    def _get_running_runtime(self, team_id: uuid.UUID) -> TeamRuntime:
+        """Look up a cached runtime, verifying the team is running.
+
+        Raises:
+            ValueError: If team not found or not running.
+        """
+        process = self._services.team_manager.get_team(team_id)
+        if process is None:
+            msg = f"Team {team_id} not found"
+            raise ValueError(msg)
+        if process.status != TeamStatus.RUNNING:
+            msg = f"Team {team_id} is not running"
+            raise ValueError(msg)
+        runtime = self._runtimes.get(team_id)
+        if runtime is None:
+            msg = f"Team {team_id} runtime not cached"
+            raise ValueError(msg)
+        return runtime
+
+    def _find_message(self, team_id: uuid.UUID, message_id: str) -> Message:
+        """Find a message by ID in persisted events.
+
+        Raises:
+            ValueError: If message not found.
+        """
+        events = self._services.event_store.load_events(team_id)
+        for ev in events:
+            if str(ev.event.id) == message_id:
+                return ev.event
+        msg = f"Message {message_id} not found"
+        raise ValueError(msg)
+
+    def _find_human_proxy_addr(self, runtime: TeamRuntime) -> ActorAddress:
+        """Find the HumanProxy actor address in a runtime.
+
+        Walks the team card members to find the agent whose class is
+        HumanProxy, then looks up its address in runtime.addrs.
+
+        Raises:
+            ValueError: If no HumanProxy found in team.
+        """
+        for name, card in runtime.team.agent_cards.items():
+            if card.get_agent_class() is HumanProxy:
+                addr = runtime.addrs.get(name)
+                if addr is not None:
+                    return addr
+        msg = "No HumanProxy found in team"
+        raise ValueError(msg)

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -68,6 +68,8 @@ def test_infra_all_includes_server_app_and_models() -> None:
     expected = (
         "create_app", "CreateTeamRequest", "TeamResponse",
         "TeamListResponse", "TeamService",
+        "SendMessageRequest", "HumanInputRequest",
+        "EventResponse", "EventListResponse",
     )
     for name in expected:
         assert name in infra.__all__, f"Missing export: {name}"

--- a/tests/test_server_models.py
+++ b/tests/test_server_models.py
@@ -7,6 +7,10 @@ from datetime import UTC, datetime
 
 from akgentic.infra.server.models import (
     CreateTeamRequest,
+    EventListResponse,
+    EventResponse,
+    HumanInputRequest,
+    SendMessageRequest,
     TeamListResponse,
     TeamResponse,
 )
@@ -66,3 +70,53 @@ def test_team_list_response_with_items() -> None:
     resp = TeamListResponse(teams=[item])
     assert len(resp.teams) == 1
     assert resp.teams[0].team_id == tid
+
+
+def test_send_message_request() -> None:
+    """SendMessageRequest requires content."""
+    req = SendMessageRequest(content="hello")
+    assert req.content == "hello"
+
+
+def test_human_input_request() -> None:
+    """HumanInputRequest requires content and message_id."""
+    req = HumanInputRequest(content="yes", message_id="msg-123")
+    assert req.content == "yes"
+    assert req.message_id == "msg-123"
+
+
+def test_event_response_serialization() -> None:
+    """EventResponse serializes all fields correctly."""
+    tid = uuid.uuid4()
+    now = datetime.now(tz=UTC)
+    resp = EventResponse(
+        team_id=tid,
+        sequence=1,
+        event={"type": "UserMessage", "content": "hello"},
+        timestamp=now,
+    )
+    data = resp.model_dump(mode="json")
+    assert data["team_id"] == str(tid)
+    assert data["sequence"] == 1
+    assert data["event"]["type"] == "UserMessage"
+
+
+def test_event_list_response_empty() -> None:
+    """EventListResponse can hold an empty list."""
+    resp = EventListResponse(events=[])
+    assert resp.events == []
+
+
+def test_event_list_response_with_items() -> None:
+    """EventListResponse serializes a list of EventResponses."""
+    tid = uuid.uuid4()
+    now = datetime.now(tz=UTC)
+    item = EventResponse(
+        team_id=tid,
+        sequence=0,
+        event={"type": "test"},
+        timestamp=now,
+    )
+    resp = EventListResponse(events=[item])
+    assert len(resp.events) == 1
+    assert resp.events[0].team_id == tid

--- a/tests/test_team_action_routes.py
+++ b/tests/test_team_action_routes.py
@@ -123,6 +123,24 @@ def test_get_events_not_found(client: TestClient) -> None:
     assert resp.status_code == 404
 
 
+def test_stop_deleted_team(client: TestClient) -> None:
+    """POST /teams/{id}/stop on deleted team returns 404."""
+    create_resp = client.post("/teams/", json={"catalog_entry_id": "test-team"})
+    team_id = create_resp.json()["team_id"]
+    client.delete(f"/teams/{team_id}")
+    resp = client.post(f"/teams/{team_id}/stop")
+    assert resp.status_code == 404
+
+
+def test_restore_deleted_team(client: TestClient) -> None:
+    """POST /teams/{id}/restore on deleted team returns 404."""
+    create_resp = client.post("/teams/", json={"catalog_entry_id": "test-team"})
+    team_id = create_resp.json()["team_id"]
+    client.delete(f"/teams/{team_id}")
+    resp = client.post(f"/teams/{team_id}/restore")
+    assert resp.status_code == 404
+
+
 def test_get_events_running_team(client: TestClient) -> None:
     """GET /teams/{id}/events on running team returns events."""
     create_resp = client.post("/teams/", json={"catalog_entry_id": "test-team"})

--- a/tests/test_team_action_routes.py
+++ b/tests/test_team_action_routes.py
@@ -1,0 +1,132 @@
+"""Tests for team action endpoints using FastAPI TestClient."""
+
+from __future__ import annotations
+
+import uuid
+
+from fastapi.testclient import TestClient
+
+
+def test_send_message_success(client: TestClient) -> None:
+    """POST /teams/{id}/message on running team returns 204."""
+    create_resp = client.post("/teams/", json={"catalog_entry_id": "test-team"})
+    team_id = create_resp.json()["team_id"]
+    resp = client.post(f"/teams/{team_id}/message", json={"content": "hello"})
+    assert resp.status_code == 204
+
+
+def test_send_message_not_found(client: TestClient) -> None:
+    """POST /teams/{id}/message on non-existent team returns 404."""
+    resp = client.post(
+        f"/teams/{uuid.uuid4()}/message", json={"content": "hello"},
+    )
+    assert resp.status_code == 404
+
+
+def test_send_message_stopped_team(client: TestClient) -> None:
+    """POST /teams/{id}/message on stopped team returns 409."""
+    create_resp = client.post("/teams/", json={"catalog_entry_id": "test-team"})
+    team_id = create_resp.json()["team_id"]
+    client.post(f"/teams/{team_id}/stop")
+    resp = client.post(f"/teams/{team_id}/message", json={"content": "hello"})
+    assert resp.status_code == 409
+
+
+def test_human_input_not_found_team(client: TestClient) -> None:
+    """POST /teams/{id}/human-input on non-existent team returns 404."""
+    resp = client.post(
+        f"/teams/{uuid.uuid4()}/human-input",
+        json={"content": "yes", "message_id": "abc"},
+    )
+    assert resp.status_code == 404
+
+
+def test_human_input_invalid_message(client: TestClient) -> None:
+    """POST /teams/{id}/human-input with invalid message_id returns 404."""
+    create_resp = client.post("/teams/", json={"catalog_entry_id": "test-team"})
+    team_id = create_resp.json()["team_id"]
+    resp = client.post(
+        f"/teams/{team_id}/human-input",
+        json={"content": "yes", "message_id": "nonexistent"},
+    )
+    assert resp.status_code == 404
+
+
+def test_stop_team_success(client: TestClient) -> None:
+    """POST /teams/{id}/stop on running team returns 204."""
+    create_resp = client.post("/teams/", json={"catalog_entry_id": "test-team"})
+    team_id = create_resp.json()["team_id"]
+    resp = client.post(f"/teams/{team_id}/stop")
+    assert resp.status_code == 204
+    # Verify team is now stopped
+    get_resp = client.get(f"/teams/{team_id}")
+    assert get_resp.json()["status"] == "stopped"
+
+
+def test_stop_team_already_stopped(client: TestClient) -> None:
+    """POST /teams/{id}/stop on already stopped team returns 409."""
+    create_resp = client.post("/teams/", json={"catalog_entry_id": "test-team"})
+    team_id = create_resp.json()["team_id"]
+    client.post(f"/teams/{team_id}/stop")
+    resp = client.post(f"/teams/{team_id}/stop")
+    assert resp.status_code == 409
+
+
+def test_stop_team_not_found(client: TestClient) -> None:
+    """POST /teams/{id}/stop on non-existent team returns 404."""
+    resp = client.post(f"/teams/{uuid.uuid4()}/stop")
+    assert resp.status_code == 404
+
+
+def test_restore_team_success(client: TestClient) -> None:
+    """POST /teams/{id}/restore on stopped team returns 200 + TeamResponse."""
+    create_resp = client.post("/teams/", json={"catalog_entry_id": "test-team"})
+    team_id = create_resp.json()["team_id"]
+    client.post(f"/teams/{team_id}/stop")
+    resp = client.post(f"/teams/{team_id}/restore")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["team_id"] == team_id
+    assert data["status"] == "running"
+
+
+def test_restore_team_already_running(client: TestClient) -> None:
+    """POST /teams/{id}/restore on already running team returns 409."""
+    create_resp = client.post("/teams/", json={"catalog_entry_id": "test-team"})
+    team_id = create_resp.json()["team_id"]
+    resp = client.post(f"/teams/{team_id}/restore")
+    assert resp.status_code == 409
+
+
+def test_restore_team_not_found(client: TestClient) -> None:
+    """POST /teams/{id}/restore on non-existent team returns 404."""
+    resp = client.post(f"/teams/{uuid.uuid4()}/restore")
+    assert resp.status_code == 404
+
+
+def test_get_events_success(client: TestClient) -> None:
+    """GET /teams/{id}/events returns events for a team."""
+    create_resp = client.post("/teams/", json={"catalog_entry_id": "test-team"})
+    team_id = create_resp.json()["team_id"]
+    # Stop team first so events are flushed
+    client.post(f"/teams/{team_id}/stop")
+    resp = client.get(f"/teams/{team_id}/events")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "events" in data
+    assert isinstance(data["events"], list)
+
+
+def test_get_events_not_found(client: TestClient) -> None:
+    """GET /teams/{id}/events on non-existent team returns 404."""
+    resp = client.get(f"/teams/{uuid.uuid4()}/events")
+    assert resp.status_code == 404
+
+
+def test_get_events_running_team(client: TestClient) -> None:
+    """GET /teams/{id}/events on running team returns events."""
+    create_resp = client.post("/teams/", json={"catalog_entry_id": "test-team"})
+    team_id = create_resp.json()["team_id"]
+    resp = client.get(f"/teams/{team_id}/events")
+    assert resp.status_code == 200
+    assert isinstance(resp.json()["events"], list)

--- a/tests/test_team_action_service.py
+++ b/tests/test_team_action_service.py
@@ -1,0 +1,145 @@
+"""Tests for TeamService action methods with real in-memory adapters."""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from akgentic.team.models import TeamStatus
+
+from akgentic.infra.server.services.team_service import TeamService
+
+
+def test_send_message_success(team_service: TeamService) -> None:
+    """send_message delivers to a running team without error."""
+    process = team_service.create_team("test-team", user_id="anonymous")
+    # Should not raise
+    team_service.send_message(process.team_id, "hello")
+
+
+def test_send_message_not_found(team_service: TeamService) -> None:
+    """send_message raises ValueError for non-existent team."""
+    with pytest.raises(ValueError, match="not found"):
+        team_service.send_message(uuid.uuid4(), "hello")
+
+
+def test_send_message_stopped_team(team_service: TeamService) -> None:
+    """send_message raises ValueError for stopped team."""
+    process = team_service.create_team("test-team", user_id="anonymous")
+    team_service.stop_team(process.team_id)
+    with pytest.raises(ValueError, match="not running"):
+        team_service.send_message(process.team_id, "hello")
+
+
+def test_stop_team_success(team_service: TeamService) -> None:
+    """stop_team transitions a running team to stopped."""
+    process = team_service.create_team("test-team", user_id="anonymous")
+    team_service.stop_team(process.team_id)
+    after = team_service.get_team(process.team_id)
+    assert after is not None
+    assert after.status == TeamStatus.STOPPED
+
+
+def test_stop_team_not_found(team_service: TeamService) -> None:
+    """stop_team raises ValueError for non-existent team."""
+    with pytest.raises(ValueError, match="not found"):
+        team_service.stop_team(uuid.uuid4())
+
+
+def test_stop_team_already_stopped(team_service: TeamService) -> None:
+    """stop_team raises ValueError for already stopped team."""
+    process = team_service.create_team("test-team", user_id="anonymous")
+    team_service.stop_team(process.team_id)
+    with pytest.raises(ValueError, match="already stopped"):
+        team_service.stop_team(process.team_id)
+
+
+def test_restore_team_success(team_service: TeamService) -> None:
+    """restore_team transitions a stopped team back to running."""
+    process = team_service.create_team("test-team", user_id="anonymous")
+    team_service.stop_team(process.team_id)
+    restored = team_service.restore_team(process.team_id)
+    assert restored.status == TeamStatus.RUNNING
+
+
+def test_restore_team_not_found(team_service: TeamService) -> None:
+    """restore_team raises ValueError for non-existent team."""
+    with pytest.raises(ValueError, match="not found"):
+        team_service.restore_team(uuid.uuid4())
+
+
+def test_restore_team_already_running(team_service: TeamService) -> None:
+    """restore_team raises ValueError for already running team."""
+    process = team_service.create_team("test-team", user_id="anonymous")
+    with pytest.raises(ValueError, match="already running"):
+        team_service.restore_team(process.team_id)
+
+
+def test_get_events_success(team_service: TeamService) -> None:
+    """get_events returns events for an existing team."""
+    process = team_service.create_team("test-team", user_id="anonymous")
+    events = team_service.get_events(process.team_id)
+    assert isinstance(events, list)
+
+
+def test_get_events_not_found(team_service: TeamService) -> None:
+    """get_events raises ValueError for non-existent team."""
+    with pytest.raises(ValueError, match="not found"):
+        team_service.get_events(uuid.uuid4())
+
+
+def test_process_human_input_not_found_team(team_service: TeamService) -> None:
+    """process_human_input raises ValueError for non-existent team."""
+    with pytest.raises(ValueError, match="not found"):
+        team_service.process_human_input(uuid.uuid4(), "yes", "msg-id")
+
+
+def test_process_human_input_invalid_message(team_service: TeamService) -> None:
+    """process_human_input raises ValueError for non-existent message_id."""
+    process = team_service.create_team("test-team", user_id="anonymous")
+    with pytest.raises(ValueError, match="not found"):
+        team_service.process_human_input(process.team_id, "yes", "nonexistent")
+
+
+def test_create_team_caches_runtime(team_service: TeamService) -> None:
+    """create_team caches the TeamRuntime for subsequent action methods."""
+    process = team_service.create_team("test-team", user_id="anonymous")
+    assert process.team_id in team_service._runtimes
+
+
+def test_stop_team_removes_runtime_cache(team_service: TeamService) -> None:
+    """stop_team removes runtime from cache."""
+    process = team_service.create_team("test-team", user_id="anonymous")
+    team_service.stop_team(process.team_id)
+    assert process.team_id not in team_service._runtimes
+
+
+def test_restore_team_caches_runtime(team_service: TeamService) -> None:
+    """restore_team caches the new runtime."""
+    process = team_service.create_team("test-team", user_id="anonymous")
+    team_service.stop_team(process.team_id)
+    team_service.restore_team(process.team_id)
+    assert process.team_id in team_service._runtimes
+
+
+def test_delete_team_removes_runtime_cache(team_service: TeamService) -> None:
+    """delete_team removes runtime from cache."""
+    process = team_service.create_team("test-team", user_id="anonymous")
+    team_service.delete_team(process.team_id)
+    assert process.team_id not in team_service._runtimes
+
+
+def test_stop_team_deleted_raises(team_service: TeamService) -> None:
+    """stop_team raises ValueError for a deleted team."""
+    process = team_service.create_team("test-team", user_id="anonymous")
+    team_service.delete_team(process.team_id)
+    with pytest.raises(ValueError):
+        team_service.stop_team(process.team_id)
+
+
+def test_restore_team_deleted_raises(team_service: TeamService) -> None:
+    """restore_team raises ValueError for a deleted team."""
+    process = team_service.create_team("test-team", user_id="anonymous")
+    team_service.delete_team(process.team_id)
+    with pytest.raises(ValueError):
+        team_service.restore_team(process.team_id)


### PR DESCRIPTION
## Summary

- Add 5 team action REST endpoints: POST message, POST human-input, POST stop, POST restore, GET events
- Extend TeamService with runtime caching and action methods (send_message, process_human_input, stop_team, restore_team, get_events)
- Add 4 Pydantic request/response models: SendMessageRequest, HumanInputRequest, EventResponse, EventListResponse
- Code review fixes: deleted teams now return 404 (not 409), _raise_action_error uses NoReturn type

152 tests passing, 93.90% coverage, mypy strict clean, ruff clean.

Closes #8