### PR TITLE
Integration tests — team lifecycle

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ dev = [
     "httpx>=0.27.0",
     "mypy>=1.8.0",
     "ruff>=0.1.0",
+    "python-dotenv>=1.0.0",
 ]
 
 [build-system]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 from collections.abc import Generator
 from pathlib import Path
 
@@ -72,6 +73,13 @@ def _seed_catalog(catalog_root: Path) -> None:
     # Empty dirs for templates and tools (no entries needed for this team)
     (catalog_root / "templates").mkdir(parents=True, exist_ok=True)
     (catalog_root / "tools").mkdir(parents=True, exist_ok=True)
+
+
+@pytest.fixture(autouse=True)
+def _ensure_openai_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Set a dummy OPENAI_API_KEY so BaseAgent actors can initialise in unit tests."""
+    if not os.environ.get("OPENAI_API_KEY"):
+        monkeypatch.setenv("OPENAI_API_KEY", "test-dummy-key")
 
 
 @pytest.fixture()

--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -1,0 +1,1 @@
+"""Integration tests for akgentic-infra — real FastAPI app, real actors, real LLM."""

--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -1,1 +1,3 @@
 """Integration tests for akgentic-infra — real FastAPI app, real actors, real LLM."""
+
+from __future__ import annotations

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,0 +1,164 @@
+"""Integration test fixtures — real app, real actors, real LLM (no mocks)."""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Generator
+from pathlib import Path
+
+import pytest
+import yaml
+from dotenv import load_dotenv
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from akgentic.infra.server.app import create_app
+from akgentic.infra.server.deps import CommunityServices
+from akgentic.infra.server.services.team_service import TeamService
+from akgentic.infra.server.settings import ServerSettings
+from akgentic.infra.wiring import wire_community
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_PROJECT_ROOT = Path(__file__).resolve().parents[4]
+
+
+def _write_yaml(path: Path, data: dict[str, object]) -> None:
+    """Write a single YAML entry file."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(yaml.dump(data, default_flow_style=False))
+
+
+def _seed_integration_catalog(catalog_root: Path) -> None:
+    """Seed YAML catalog with an LLM-capable agent for integration testing.
+
+    Uses gpt-4o-mini for fast, cheap LLM calls.
+    """
+    _write_yaml(
+        catalog_root / "agents" / "human-proxy.yaml",
+        {
+            "id": "human-proxy",
+            "tool_ids": [],
+            "card": {
+                "role": "Human",
+                "description": "Human user interface",
+                "skills": [],
+                "agent_class": "akgentic.agent.HumanProxy",
+                "config": {"name": "@Human", "role": "Human"},
+                "routes_to": ["@Manager"],
+            },
+        },
+    )
+    _write_yaml(
+        catalog_root / "agents" / "manager.yaml",
+        {
+            "id": "manager",
+            "tool_ids": [],
+            "card": {
+                "role": "Manager",
+                "description": "Integration test manager agent",
+                "skills": ["coordination"],
+                "agent_class": "akgentic.agent.BaseAgent",
+                "config": {
+                    "name": "@Manager",
+                    "role": "Manager",
+                    "prompt": {
+                        "template": (
+                            "You are a helpful assistant. "
+                            "Reply concisely in one or two sentences."
+                        ),
+                    },
+                    "model_cfg": {
+                        "provider": "openai",
+                        "model": "gpt-4o-mini",
+                        "temperature": 0.0,
+                    },
+                    "usage_limits": {
+                        "request_limit": 5,
+                        "total_tokens_limit": 10000,
+                    },
+                },
+                "routes_to": [],
+            },
+        },
+    )
+    _write_yaml(
+        catalog_root / "teams" / "test-team.yaml",
+        {
+            "id": "test-team",
+            "name": "Integration Test Team",
+            "entry_point": "human-proxy",
+            "message_types": ["akgentic.agent.AgentMessage"],
+            "members": [
+                {"agent_id": "human-proxy"},
+                {"agent_id": "manager"},
+            ],
+            "profiles": [],
+        },
+    )
+    (catalog_root / "templates").mkdir(parents=True, exist_ok=True)
+    (catalog_root / "tools").mkdir(parents=True, exist_ok=True)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="session", autouse=True)
+def openai_api_key() -> str:
+    """Ensure OPENAI_API_KEY is available; fail fast if not."""
+    load_dotenv(_PROJECT_ROOT / ".env")
+    key = os.environ.get("OPENAI_API_KEY")
+    if not key:
+        pytest.fail("OPENAI_API_KEY not set — required for integration tests")
+    return key
+
+
+@pytest.fixture()
+def integration_settings(tmp_path: Path) -> ServerSettings:
+    """ServerSettings backed by tmp_path with a seeded integration catalog."""
+    settings = ServerSettings(workspaces_root=tmp_path / "workspaces")
+    _seed_integration_catalog(settings.workspaces_root / "catalog")
+    return settings
+
+
+@pytest.fixture()
+def integration_services(
+    integration_settings: ServerSettings,
+) -> Generator[CommunityServices, None, None]:
+    """Wired community services with real actor system — shuts down on teardown."""
+    services = wire_community(integration_settings)
+    yield services
+    services.actor_system.shutdown()
+
+
+@pytest.fixture()
+def integration_team_service(
+    integration_services: CommunityServices,
+) -> TeamService:
+    """TeamService wired to integration services."""
+    return TeamService(
+        services=integration_services,
+        team_catalog=integration_services.team_catalog,
+        agent_catalog=integration_services.agent_catalog,
+        tool_catalog=integration_services.tool_catalog,
+        template_catalog=integration_services.template_catalog,
+    )
+
+
+@pytest.fixture()
+def integration_app(
+    integration_services: CommunityServices,
+    integration_team_service: TeamService,
+) -> FastAPI:
+    """FastAPI app backed by real actors and real LLM."""
+    return create_app(integration_services, integration_team_service)
+
+
+@pytest.fixture()
+def integration_client(integration_app: FastAPI) -> TestClient:
+    """Sync HTTP test client hitting a real FastAPI app."""
+    return TestClient(integration_app)

--- a/tests/integration/test_team_lifecycle.py
+++ b/tests/integration/test_team_lifecycle.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import time
-from typing import Any
 
 import pytest
 from fastapi.testclient import TestClient
@@ -23,10 +22,10 @@ def _wait_for_llm_response(
     client: TestClient,
     team_id: str,
     timeout: float = POLL_TIMEOUT_S,
-) -> list[dict[str, Any]]:
+) -> list[dict[str, object]]:
     """Poll events until an LLM-generated response from @Manager appears."""
     deadline = time.monotonic() + timeout
-    events: list[dict[str, Any]] = []
+    events: list[dict[str, object]] = []
     while time.monotonic() < deadline:
         resp = client.get(f"/teams/{team_id}/events")
         assert resp.status_code == 200
@@ -40,21 +39,26 @@ def _wait_for_llm_response(
     )
 
 
-def _has_llm_content(events: list[dict[str, Any]]) -> bool:
+def _has_llm_content(events: list[dict[str, object]]) -> bool:
     """Check if any event contains LLM-generated content from @Manager."""
     for ev_wrapper in events:
         ev = ev_wrapper["event"]
+        if not isinstance(ev, dict):
+            continue
         # SentMessage wraps a message with content
         msg = ev.get("message")
-        if isinstance(msg, dict):
-            content = msg.get("content")
-            sender = ev.get("sender", {})
-            if (
-                isinstance(content, str)
-                and len(content) > 0
-                and sender.get("name") == "@Manager"
-            ):
-                return True
+        if not isinstance(msg, dict):
+            continue
+        content = msg.get("content")
+        sender = ev.get("sender")
+        if not isinstance(sender, dict):
+            continue
+        if (
+            isinstance(content, str)
+            and len(content) > 0
+            and sender.get("name") == "@Manager"
+        ):
+            return True
     return False
 
 

--- a/tests/integration/test_team_lifecycle.py
+++ b/tests/integration/test_team_lifecycle.py
@@ -1,0 +1,180 @@
+"""Integration tests — full team lifecycle with real LLM."""
+
+from __future__ import annotations
+
+import time
+from typing import Any
+
+import pytest
+from fastapi.testclient import TestClient
+
+pytestmark = pytest.mark.integration
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+CATALOG_ENTRY_ID = "test-team"
+POLL_INTERVAL_S = 1.0
+POLL_TIMEOUT_S = 60.0
+
+
+def _wait_for_llm_response(
+    client: TestClient,
+    team_id: str,
+    timeout: float = POLL_TIMEOUT_S,
+) -> list[dict[str, Any]]:
+    """Poll events until an LLM-generated response from @Manager appears."""
+    deadline = time.monotonic() + timeout
+    events: list[dict[str, Any]] = []
+    while time.monotonic() < deadline:
+        resp = client.get(f"/teams/{team_id}/events")
+        assert resp.status_code == 200
+        events = resp.json()["events"]
+        if _has_llm_content(events):
+            return events
+        time.sleep(POLL_INTERVAL_S)
+    pytest.fail(
+        f"Timed out after {timeout}s waiting for LLM response "
+        f"(got {len(events)} events, none with LLM content)"
+    )
+
+
+def _has_llm_content(events: list[dict[str, Any]]) -> bool:
+    """Check if any event contains LLM-generated content from @Manager."""
+    for ev_wrapper in events:
+        ev = ev_wrapper["event"]
+        # SentMessage wraps a message with content
+        msg = ev.get("message")
+        if isinstance(msg, dict):
+            content = msg.get("content")
+            sender = ev.get("sender", {})
+            if (
+                isinstance(content, str)
+                and len(content) > 0
+                and sender.get("name") == "@Manager"
+            ):
+                return True
+    return False
+
+
+def _create_team(client: TestClient) -> str:
+    """POST /teams and return the team_id."""
+    resp = client.post("/teams/", json={"catalog_entry_id": CATALOG_ENTRY_ID})
+    assert resp.status_code == 201
+    data = resp.json()
+    assert data["status"] == "running"
+    return data["team_id"]
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestTeamLifecycle:
+    """Integration tests exercising the full team lifecycle via HTTP."""
+
+    def test_create_team_send_message_receive_response(
+        self, integration_client: TestClient,
+    ) -> None:
+        """AC #1, #2: Create a team and verify it is running."""
+        team_id = _create_team(integration_client)
+
+        resp = integration_client.get(f"/teams/{team_id}")
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "running"
+
+    def test_send_message_and_receive_llm_response(
+        self, integration_client: TestClient,
+    ) -> None:
+        """AC #5 (partial): Send a message and verify LLM responds."""
+        team_id = _create_team(integration_client)
+
+        resp = integration_client.post(
+            f"/teams/{team_id}/message",
+            json={"content": "Say hello in exactly three words."},
+        )
+        assert resp.status_code == 204
+
+        events = _wait_for_llm_response(integration_client, team_id)
+        assert _has_llm_content(events)
+
+    def test_stop_and_restore_team(
+        self, integration_client: TestClient,
+    ) -> None:
+        """AC #5 (partial): Stop and restore a team."""
+        team_id = _create_team(integration_client)
+
+        # Stop
+        resp = integration_client.post(f"/teams/{team_id}/stop")
+        assert resp.status_code == 204
+
+        resp = integration_client.get(f"/teams/{team_id}")
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "stopped"
+
+        # Restore
+        resp = integration_client.post(f"/teams/{team_id}/restore")
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "running"
+
+    def test_events_persisted_after_stop(
+        self, integration_client: TestClient,
+    ) -> None:
+        """AC #5 (partial): Events persist after stop."""
+        team_id = _create_team(integration_client)
+
+        # Send a message and wait for LLM to respond
+        integration_client.post(
+            f"/teams/{team_id}/message",
+            json={"content": "Respond with one word."},
+        )
+        _wait_for_llm_response(integration_client, team_id)
+
+        # Stop the team
+        resp = integration_client.post(f"/teams/{team_id}/stop")
+        assert resp.status_code == 204
+
+        # Events should still be accessible after stop
+        resp = integration_client.get(f"/teams/{team_id}/events")
+        assert resp.status_code == 200
+        events = resp.json()["events"]
+        assert len(events) >= 3
+
+    def test_full_lifecycle_round_trip(
+        self, integration_client: TestClient,
+    ) -> None:
+        """AC #5: Full round-trip — create, message, LLM, stop, restore."""
+        # 1. Create
+        team_id = _create_team(integration_client)
+
+        # 2. Send message
+        resp = integration_client.post(
+            f"/teams/{team_id}/message",
+            json={"content": "What is 2 + 2? Answer with the number."},
+        )
+        assert resp.status_code == 204
+
+        # 3. Wait for LLM response
+        events = _wait_for_llm_response(integration_client, team_id)
+        assert _has_llm_content(events)
+
+        # 4. Stop
+        resp = integration_client.post(f"/teams/{team_id}/stop")
+        assert resp.status_code == 204
+
+        resp = integration_client.get(f"/teams/{team_id}")
+        assert resp.json()["status"] == "stopped"
+
+        # 5. Restore
+        resp = integration_client.post(f"/teams/{team_id}/restore")
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "running"
+
+        # 6. Verify events persisted through stop/restore cycle
+        resp = integration_client.get(f"/teams/{team_id}/events")
+        assert resp.status_code == 200
+        final_events = resp.json()["events"]
+        assert len(final_events) >= 3
+        assert _has_llm_content(final_events)


### PR DESCRIPTION
## Summary

- Add end-to-end integration tests for the full team lifecycle (create → message → LLM → stop → restore → events)
- Integration tests use real FastAPI app, real actor system, and real OpenAI LLM (gpt-4o-mini)
- Tests excluded from default `pytest` runs via `@pytest.mark.integration` marker; run explicitly with `-m integration`
- Add `python-dotenv` dev dependency for `.env` loading
- Add `_ensure_openai_key` autouse fixture to prevent BaseAgent init failures in unit tests

Closes #10