### PR TITLE
CI Pipeline & Coverage Badge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,17 +52,17 @@ jobs:
           --cov-fail-under=90
 
       # Coverage badge is updated only on master push.
-      # NOTE: Replace <GIST_ID> with the actual Gist ID after the repo owner
-      # creates the Gist manually.
+      # NOTE: Replace REPLACE_WITH_GIST_ID with the actual Gist ID after the
+      # repo owner creates the Gist manually.
       - name: Update coverage badge
         if: github.ref_name == 'master' && github.event_name == 'push'
         run: |
-          COVERAGE=$(python -c "import json; print(int(json.load(open('coverage.json'))['totals']['percent_covered_display']))")
+          COVERAGE=$(python -c "import json; print(int(float(json.load(open('coverage.json'))['totals']['percent_covered_display'])))")
           if [ "$COVERAGE" -ge 90 ]; then COLOR="brightgreen"
           elif [ "$COVERAGE" -ge 80 ]; then COLOR="green"
           elif [ "$COVERAGE" -ge 70 ]; then COLOR="yellow"
           else COLOR="red"; fi
           echo "{\"schemaVersion\":1,\"label\":\"coverage\",\"message\":\"${COVERAGE}%\",\"color\":\"${COLOR}\"}" > badge.json
-          gh gist edit <GIST_ID> -f coverage.json badge.json
+          gh gist edit REPLACE_WITH_GIST_ID -f coverage.json badge.json
         env:
           GH_TOKEN: ${{ secrets.GH_PAT }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,68 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+    branches: [master]
+  workflow_dispatch:
+
+env:
+  NO_COLOR: "1"
+
+jobs:
+  quality:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout workspace
+        uses: actions/checkout@v4
+        with:
+          repository: b12consulting/akgentic-quick-start
+          submodules: recursive
+          token: ${{ secrets.GH_PAT }}
+
+      - name: Override akgentic-infra submodule with current branch
+        working-directory: packages/akgentic-infra
+        run: |
+          git fetch origin ${{ github.head_ref || github.ref_name }}
+          git checkout FETCH_HEAD
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+        with:
+          version: "latest"
+
+      - name: Set up Python 3.12
+        run: uv python install 3.12
+
+      - name: Install dependencies
+        run: uv sync --all-packages --all-extras
+
+      - name: Type checking
+        run: uv run mypy packages/akgentic-infra/src/
+
+      - name: Linting
+        run: uv run ruff check packages/akgentic-infra/src/
+
+      - name: Run tests with coverage
+        run: >
+          uv run pytest packages/akgentic-infra/tests/
+          --cov=akgentic.infra
+          --cov-report=term-missing
+          --cov-report=json:coverage.json
+          --cov-fail-under=90
+
+      # Coverage badge is updated only on master push.
+      # NOTE: Replace <GIST_ID> with the actual Gist ID after the repo owner
+      # creates the Gist manually.
+      - name: Update coverage badge
+        if: github.ref_name == 'master' && github.event_name == 'push'
+        run: |
+          COVERAGE=$(python -c "import json; print(int(json.load(open('coverage.json'))['totals']['percent_covered_display']))")
+          if [ "$COVERAGE" -ge 90 ]; then COLOR="brightgreen"
+          elif [ "$COVERAGE" -ge 80 ]; then COLOR="green"
+          elif [ "$COVERAGE" -ge 70 ]; then COLOR="yellow"
+          else COLOR="red"; fi
+          echo "{\"schemaVersion\":1,\"label\":\"coverage\",\"message\":\"${COVERAGE}%\",\"color\":\"${COLOR}\"}" > badge.json
+          gh gist edit <GIST_ID> -f coverage.json badge.json
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT }}

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![Coverage](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/b12consulting/<GIST_ID>/raw/coverage.json)
+![Coverage](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/b12consulting/REPLACE_WITH_GIST_ID/raw/coverage.json)
 
 # Akgentic <Module>: [One-line description]
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+![Coverage](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/b12consulting/<GIST_ID>/raw/coverage.json)
+
 # Akgentic <Module>: [One-line description]
 
 **Status:** [Alpha/Beta/Production] - [Phase or version]


### PR DESCRIPTION
## Summary

- Add GitHub Actions CI pipeline (`.github/workflows/ci.yml`) following ADR-03 canonical template
- Pipeline runs mypy strict, ruff check, pytest with 90% coverage threshold on every PR
- Coverage badge step updates a GitHub Gist on master push with color-coded shields.io badge
- README updated with coverage badge placeholder

## Review Fixes Applied

- Used `int(float())` instead of `int()` for coverage parsing to handle decimal strings safely
- Replaced `<GIST_ID>` angle-bracket placeholders with `REPLACE_WITH_GIST_ID` to avoid shell redirection

Closes #12