### PR TITLE
fix: align CI with ADR-003 standardization

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
           --cov=akgentic.infra
           --cov-report=term-missing
           --cov-report=json:coverage.json
-          --cov-fail-under=90
+          --cov-fail-under=80
 
       # Coverage badge is updated only on master push.
       # NOTE: Replace REPLACE_WITH_GIST_ID with the actual Gist ID after the
@@ -57,12 +57,12 @@ jobs:
       - name: Update coverage badge
         if: github.ref_name == 'master' && github.event_name == 'push'
         run: |
-          COVERAGE=$(python -c "import json; print(int(float(json.load(open('coverage.json'))['totals']['percent_covered_display'])))")
+          COVERAGE=$(python -c "import json; print(int(json.load(open('coverage.json'))['totals']['percent_covered_display']))")
           if [ "$COVERAGE" -ge 90 ]; then COLOR="brightgreen"
           elif [ "$COVERAGE" -ge 80 ]; then COLOR="green"
           elif [ "$COVERAGE" -ge 70 ]; then COLOR="yellow"
           else COLOR="red"; fi
           echo "{\"schemaVersion\":1,\"label\":\"coverage\",\"message\":\"${COVERAGE}%\",\"color\":\"${COLOR}\"}" > badge.json
-          gh gist edit REPLACE_WITH_GIST_ID -f coverage.json badge.json
+          gh gist edit d0b84268aa19a7460fe186dbf23e500d -f coverage.json badge.json
         env:
           GH_TOKEN: ${{ secrets.GH_PAT }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,4 +77,4 @@ addopts = "-m 'not integration' --cov=akgentic.infra --cov-branch"
 filterwarnings = ["ignore:No logs or spans:UserWarning"]
 
 [tool.coverage.report]
-fail_under = 90
+fail_under = 80


### PR DESCRIPTION
## Summary

- Coverage threshold aligned to ADR-003 standard (90 → 80) in both `ci.yml` and `pyproject.toml`
- Replaced placeholder gist ID with real gist `d0b84268aa19a7460fe186dbf23e500d` for coverage badge
- Aligned coverage JSON extraction with canonical template (akgentic-catalog)
- `pre-commit run --all-files` step deferred — no `.pre-commit-config.yaml` exists in workspace (ADR-002 scope)

**Note:** CI will pass once `akgentic-quick-start` root `pyproject.toml` includes `akgentic-infra` as a workspace member (already on `feat/98-akgentic-infra-dev`).

Closes #14