### PR TITLE
Fix: restore CI workspace ref

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: b12consulting/akgentic-quick-start
+          ref: feat/98-akgentic-infra-dev  # required until workspace PR merges akgentic-infra
           submodules: recursive
           token: ${{ secrets.GH_PAT }}
 


### PR DESCRIPTION
## Summary

- Restores `ref: feat/98-akgentic-infra-dev` in CI checkout step
- This ref is required until the workspace master branch includes akgentic-infra as a workspace member
- The ref was accidentally removed in PR #17's code review fixes

Relates to #16