### PR TITLE
Catalog & Workspace Endpoints

### DIFF
--- a/src/akgentic/infra/__init__.py
+++ b/src/akgentic/infra/__init__.py
@@ -26,6 +26,9 @@ from akgentic.infra.protocols import (
 from akgentic.infra.server.app import create_app
 from akgentic.infra.server.deps import CommunityServices, TierServices
 from akgentic.infra.server.models import (
+    CatalogTeamListResponse,
+    CatalogTeamMember,
+    CatalogTeamResponse,
     CreateTeamRequest,
     EventListResponse,
     EventResponse,
@@ -33,6 +36,9 @@ from akgentic.infra.server.models import (
     SendMessageRequest,
     TeamListResponse,
     TeamResponse,
+    WorkspaceFileEntry,
+    WorkspaceFileUploadResponse,
+    WorkspaceTreeResponse,
 )
 from akgentic.infra.server.services.team_service import TeamService
 from akgentic.infra.server.settings import ServerSettings
@@ -59,6 +65,9 @@ __all__ = [
     "TelemetrySubscriber",
     "WebSocketEventSubscriber",
     # Server
+    "CatalogTeamListResponse",
+    "CatalogTeamMember",
+    "CatalogTeamResponse",
     "CommunityServices",
     "CreateTeamRequest",
     "EventListResponse",
@@ -70,6 +79,9 @@ __all__ = [
     "TeamResponse",
     "TeamService",
     "TierServices",
+    "WorkspaceFileEntry",
+    "WorkspaceFileUploadResponse",
+    "WorkspaceTreeResponse",
     "create_app",
     # Wiring
     "wire_community",

--- a/src/akgentic/infra/server/app.py
+++ b/src/akgentic/infra/server/app.py
@@ -6,15 +6,19 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
 from akgentic.infra.server.deps import CommunityServices
+from akgentic.infra.server.routes.catalog import router as catalog_router
 from akgentic.infra.server.routes.teams import router as teams_router
+from akgentic.infra.server.routes.workspace import router as workspace_router
 from akgentic.infra.server.routes.ws import ConnectionManager
 from akgentic.infra.server.routes.ws import router as ws_router
 from akgentic.infra.server.services.team_service import TeamService
+from akgentic.infra.server.settings import ServerSettings
 
 
 def create_app(
     services: CommunityServices,
     team_service: TeamService,
+    settings: ServerSettings | None = None,
     cors_origins: list[str] | None = None,
 ) -> FastAPI:
     """Create and configure the FastAPI application.
@@ -42,9 +46,12 @@ def create_app(
 
     app.state.services = services
     app.state.team_service = team_service
+    app.state.settings = settings or ServerSettings()
     app.state.connection_manager = ConnectionManager()
 
     app.include_router(teams_router)
+    app.include_router(catalog_router)
+    app.include_router(workspace_router)
     app.include_router(ws_router)
 
     return app

--- a/src/akgentic/infra/server/models.py
+++ b/src/akgentic/infra/server/models.py
@@ -61,3 +61,58 @@ class EventListResponse(BaseModel):
     """Response body for GET /teams/{team_id}/events."""
 
     events: list[EventResponse] = Field(description="List of persisted events")
+
+
+# --- Catalog response models ---
+
+
+class CatalogTeamMember(BaseModel):
+    """Simplified view of a team member in a catalog template."""
+
+    agent_id: str = Field(description="Agent identifier")
+    children: list[CatalogTeamMember] = Field(
+        default_factory=list, description="Nested child members"
+    )
+
+
+class CatalogTeamResponse(BaseModel):
+    """Serialized team template from the catalog."""
+
+    id: str = Field(description="Template identifier")
+    name: str = Field(description="Human-readable template name")
+    description: str = Field(description="Template description")
+    entry_point: str = Field(description="Entry-point agent identifier")
+    members: list[CatalogTeamMember] = Field(description="Team member hierarchy")
+    profiles: list[str] = Field(description="Available runtime profiles")
+
+
+class CatalogTeamListResponse(BaseModel):
+    """Response body for GET /catalog/teams."""
+
+    teams: list[CatalogTeamResponse] = Field(description="List of team templates")
+
+
+# --- Workspace response models ---
+
+
+class WorkspaceFileEntry(BaseModel):
+    """Single entry in a workspace file tree listing."""
+
+    name: str = Field(description="File or directory name")
+    is_dir: bool = Field(description="True if entry is a directory")
+    size: int = Field(description="File size in bytes (0 for directories)")
+
+
+class WorkspaceTreeResponse(BaseModel):
+    """Response body for GET /workspace/{team_id}/tree."""
+
+    team_id: str = Field(description="Team identifier")
+    path: str = Field(description="Listed directory path")
+    entries: list[WorkspaceFileEntry] = Field(description="Directory entries")
+
+
+class WorkspaceFileUploadResponse(BaseModel):
+    """Response body for POST /workspace/{team_id}/file."""
+
+    path: str = Field(description="Destination file path")
+    size: int = Field(description="File size in bytes")

--- a/src/akgentic/infra/server/routes/catalog.py
+++ b/src/akgentic/infra/server/routes/catalog.py
@@ -1,0 +1,55 @@
+"""Catalog browsing endpoints — read-only access to team templates."""
+
+from __future__ import annotations
+
+from typing import cast
+
+from fastapi import APIRouter, HTTPException, Request
+
+from akgentic.catalog.models.team import TeamEntry, TeamMemberSpec
+from akgentic.infra.server.deps import CommunityServices
+from akgentic.infra.server.models import (
+    CatalogTeamListResponse,
+    CatalogTeamMember,
+    CatalogTeamResponse,
+)
+
+router = APIRouter(prefix="/catalog", tags=["catalog"])
+
+
+def _member_to_response(spec: TeamMemberSpec) -> CatalogTeamMember:
+    """Recursively convert a TeamMemberSpec tree to CatalogTeamMember."""
+    return CatalogTeamMember(
+        agent_id=spec.agent_id,
+        children=[_member_to_response(child) for child in spec.members],
+    )
+
+
+def _entry_to_response(entry: TeamEntry) -> CatalogTeamResponse:
+    """Convert a TeamEntry to CatalogTeamResponse."""
+    return CatalogTeamResponse(
+        id=entry.id,
+        name=entry.name,
+        description=entry.description,
+        entry_point=entry.entry_point,
+        members=[_member_to_response(m) for m in entry.members],
+        profiles=entry.profiles,
+    )
+
+
+@router.get("/teams", response_model=CatalogTeamListResponse)
+def list_team_templates(request: Request) -> CatalogTeamListResponse:
+    """List all available team templates from the catalog."""
+    services = cast(CommunityServices, request.app.state.services)
+    entries = services.team_catalog.list()
+    return CatalogTeamListResponse(teams=[_entry_to_response(e) for e in entries])
+
+
+@router.get("/teams/{name}", response_model=CatalogTeamResponse)
+def get_team_template(name: str, request: Request) -> CatalogTeamResponse:
+    """Get a specific team template by name."""
+    services = cast(CommunityServices, request.app.state.services)
+    entry = services.team_catalog.get(name)
+    if entry is None:
+        raise HTTPException(status_code=404, detail=f"Team template '{name}' not found")
+    return _entry_to_response(entry)

--- a/src/akgentic/infra/server/routes/workspace.py
+++ b/src/akgentic/infra/server/routes/workspace.py
@@ -1,0 +1,110 @@
+"""Workspace file access endpoints — tree listing, file read, file upload."""
+
+from __future__ import annotations
+
+import uuid
+from typing import Annotated, cast
+
+from fastapi import APIRouter, HTTPException, Request, Response, UploadFile
+from fastapi.params import File, Form
+
+from akgentic.infra.server.models import (
+    WorkspaceFileEntry,
+    WorkspaceFileUploadResponse,
+    WorkspaceTreeResponse,
+)
+from akgentic.infra.server.services.team_service import TeamService
+from akgentic.infra.server.settings import ServerSettings
+from akgentic.tool.workspace import Filesystem
+
+router = APIRouter(prefix="/workspace", tags=["workspace"])
+
+_MAX_FILE_SIZE = 10_485_760  # 10 MB
+
+
+def _get_workspace(team_id: uuid.UUID, settings: ServerSettings) -> Filesystem:
+    """Instantiate a Filesystem scoped to a team's workspace directory."""
+    return Filesystem(base_path=str(settings.workspaces_root), workspace_name=str(team_id))
+
+
+def _validate_team(team_id: uuid.UUID, request: Request) -> None:
+    """Raise 404 if the team does not exist."""
+    service = cast(TeamService, request.app.state.team_service)
+    if service.get_team(team_id) is None:
+        raise HTTPException(status_code=404, detail="Team not found")
+
+
+@router.get("/{team_id}/tree", response_model=WorkspaceTreeResponse)
+def list_workspace_tree(
+    team_id: uuid.UUID,
+    request: Request,
+    path: str = "",
+) -> WorkspaceTreeResponse:
+    """List files in a team's workspace directory."""
+    _validate_team(team_id, request)
+    settings = cast(ServerSettings, request.app.state.settings)
+    ws = _get_workspace(team_id, settings)
+    try:
+        entries = ws.list(path)
+    except PermissionError:
+        raise HTTPException(status_code=403, detail="Path access denied") from None
+    return WorkspaceTreeResponse(
+        team_id=str(team_id),
+        path=path,
+        entries=[
+            WorkspaceFileEntry(name=e.name, is_dir=e.is_dir, size=e.size) for e in entries
+        ],
+    )
+
+
+@router.get("/{team_id}/file")
+def read_workspace_file(
+    team_id: uuid.UUID,
+    request: Request,
+    path: str = "",
+) -> Response:
+    """Read a file from a team's workspace."""
+    _validate_team(team_id, request)
+    settings = cast(ServerSettings, request.app.state.settings)
+    ws = _get_workspace(team_id, settings)
+    try:
+        validated = ws._validate_path(path)  # noqa: SLF001
+    except PermissionError:
+        raise HTTPException(status_code=403, detail="Path access denied") from None
+    if not validated.is_file():
+        raise HTTPException(status_code=404, detail="File not found")
+    if validated.stat().st_size > _MAX_FILE_SIZE:
+        raise HTTPException(status_code=413, detail="File exceeds 10 MB size limit")
+    try:
+        data = ws.read(path)
+    except FileNotFoundError:
+        raise HTTPException(status_code=404, detail="File not found") from None
+    except PermissionError:
+        raise HTTPException(status_code=403, detail="Path access denied") from None
+    filename = validated.name
+    return Response(
+        content=data,
+        media_type="application/octet-stream",
+        headers={"Content-Disposition": f'attachment; filename="{filename}"'},
+    )
+
+
+@router.post("/{team_id}/file", status_code=201, response_model=WorkspaceFileUploadResponse)
+async def upload_workspace_file(
+    team_id: uuid.UUID,
+    request: Request,
+    path: Annotated[str, Form()],
+    file: Annotated[UploadFile, File()],
+) -> WorkspaceFileUploadResponse:
+    """Upload a file to a team's workspace."""
+    _validate_team(team_id, request)
+    settings = cast(ServerSettings, request.app.state.settings)
+    ws = _get_workspace(team_id, settings)
+    data = await file.read()
+    if len(data) > _MAX_FILE_SIZE:
+        raise HTTPException(status_code=413, detail="File exceeds 10 MB size limit")
+    try:
+        ws.write(path, data)
+    except PermissionError:
+        raise HTTPException(status_code=403, detail="Path access denied") from None
+    return WorkspaceFileUploadResponse(path=path, size=len(data))

--- a/src/akgentic/infra/server/routes/workspace.py
+++ b/src/akgentic/infra/server/routes/workspace.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import uuid
+from pathlib import PurePosixPath
 from typing import Annotated, cast
 
 from fastapi import APIRouter, HTTPException, Request, Response, UploadFile
@@ -61,27 +62,21 @@ def list_workspace_tree(
 def read_workspace_file(
     team_id: uuid.UUID,
     request: Request,
-    path: str = "",
+    path: str,
 ) -> Response:
     """Read a file from a team's workspace."""
     _validate_team(team_id, request)
     settings = cast(ServerSettings, request.app.state.settings)
     ws = _get_workspace(team_id, settings)
     try:
-        validated = ws._validate_path(path)  # noqa: SLF001
-    except PermissionError:
-        raise HTTPException(status_code=403, detail="Path access denied") from None
-    if not validated.is_file():
-        raise HTTPException(status_code=404, detail="File not found")
-    if validated.stat().st_size > _MAX_FILE_SIZE:
-        raise HTTPException(status_code=413, detail="File exceeds 10 MB size limit")
-    try:
         data = ws.read(path)
     except FileNotFoundError:
         raise HTTPException(status_code=404, detail="File not found") from None
     except PermissionError:
         raise HTTPException(status_code=403, detail="Path access denied") from None
-    filename = validated.name
+    if len(data) > _MAX_FILE_SIZE:
+        raise HTTPException(status_code=413, detail="File exceeds 10 MB size limit")
+    filename = PurePosixPath(path).name
     return Response(
         content=data,
         media_type="application/octet-stream",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -119,9 +119,13 @@ def team_service(community_services: CommunityServices) -> TeamService:
 
 
 @pytest.fixture()
-def app(community_services: CommunityServices, team_service: TeamService) -> FastAPI:
+def app(
+    community_services: CommunityServices,
+    team_service: TeamService,
+    seeded_settings: ServerSettings,
+) -> FastAPI:
     """FastAPI app with wired services."""
-    return create_app(community_services, team_service)
+    return create_app(community_services, team_service, settings=seeded_settings)
 
 
 @pytest.fixture()

--- a/tests/test_catalog_routes.py
+++ b/tests/test_catalog_routes.py
@@ -1,0 +1,55 @@
+"""Tests for catalog browsing endpoints (GET /catalog/teams, GET /catalog/teams/{name})."""
+
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+
+def test_list_team_templates(client: TestClient) -> None:
+    """GET /catalog/teams returns seeded team templates."""
+    resp = client.get("/catalog/teams")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert "teams" in body
+    assert len(body["teams"]) >= 1
+    ids = [t["id"] for t in body["teams"]]
+    assert "test-team" in ids
+
+
+def test_get_team_template(client: TestClient) -> None:
+    """GET /catalog/teams/{name} returns specific team details."""
+    resp = client.get("/catalog/teams/test-team")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["id"] == "test-team"
+    assert body["name"] == "Test Team"
+    assert body["entry_point"] == "human-proxy"
+    assert isinstance(body["members"], list)
+    assert len(body["members"]) == 2
+
+
+def test_get_team_template_members_have_expected_fields(client: TestClient) -> None:
+    """GET /catalog/teams/{name} members contain agent_id and children fields."""
+    resp = client.get("/catalog/teams/test-team")
+    assert resp.status_code == 200
+    body = resp.json()
+    for member in body["members"]:
+        assert "agent_id" in member
+        assert "children" in member
+        assert isinstance(member["children"], list)
+
+
+def test_get_team_template_not_found(client: TestClient) -> None:
+    """GET /catalog/teams/{name} returns 404 for non-existent template."""
+    resp = client.get("/catalog/teams/nonexistent-template")
+    assert resp.status_code == 404
+    assert "not found" in resp.json()["detail"].lower()
+
+
+def test_list_team_templates_response_shape(client: TestClient) -> None:
+    """GET /catalog/teams response has all expected fields per CatalogTeamResponse."""
+    resp = client.get("/catalog/teams")
+    assert resp.status_code == 200
+    team = resp.json()["teams"][0]
+    expected_fields = {"id", "name", "description", "entry_point", "members", "profiles"}
+    assert expected_fields.issubset(set(team.keys()))

--- a/tests/test_workspace_routes.py
+++ b/tests/test_workspace_routes.py
@@ -121,6 +121,19 @@ def test_workspace_file_upload_team_not_found(client: TestClient) -> None:
     assert resp.status_code == 404
 
 
+def test_workspace_file_upload_size_limit(
+    client: TestClient, team_with_workspace: uuid.UUID
+) -> None:
+    """POST /workspace/{team_id}/file returns 413 for uploads exceeding 10 MB."""
+    big_data = b"\x00" * (10_485_760 + 1)
+    resp = client.post(
+        f"/workspace/{team_with_workspace}/file",
+        data={"path": "huge-upload.bin"},
+        files={"file": ("huge-upload.bin", big_data, "application/octet-stream")},
+    )
+    assert resp.status_code == 413
+
+
 def test_workspace_file_upload_traversal_attack(
     client: TestClient, team_with_workspace: uuid.UUID
 ) -> None:

--- a/tests/test_workspace_routes.py
+++ b/tests/test_workspace_routes.py
@@ -1,0 +1,133 @@
+"""Tests for workspace file access endpoints."""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from fastapi.testclient import TestClient
+
+from akgentic.infra.server.settings import ServerSettings
+
+
+@pytest.fixture()
+def team_with_workspace(client: TestClient, seeded_settings: ServerSettings) -> uuid.UUID:
+    """Create a team via REST and seed workspace files."""
+    resp = client.post("/teams/", json={"catalog_entry_id": "test-team"})
+    assert resp.status_code == 201
+    team_id = uuid.UUID(resp.json()["team_id"])
+    ws_root = seeded_settings.workspaces_root / str(team_id)
+    ws_root.mkdir(parents=True, exist_ok=True)
+    (ws_root / "output.txt").write_text("hello world")
+    (ws_root / "subdir").mkdir()
+    (ws_root / "subdir" / "data.json").write_text('{"key": "value"}')
+    return team_id
+
+
+# --- Tree listing tests ---
+
+
+def test_workspace_tree(client: TestClient, team_with_workspace: uuid.UUID) -> None:
+    """GET /workspace/{team_id}/tree returns file listing."""
+    resp = client.get(f"/workspace/{team_with_workspace}/tree")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["team_id"] == str(team_with_workspace)
+    names = [e["name"] for e in body["entries"]]
+    assert "output.txt" in names
+    assert "subdir" in names
+
+
+def test_workspace_tree_not_found(client: TestClient) -> None:
+    """GET /workspace/{team_id}/tree returns 404 for non-existent team."""
+    fake_id = uuid.uuid4()
+    resp = client.get(f"/workspace/{fake_id}/tree")
+    assert resp.status_code == 404
+
+
+# --- File read tests ---
+
+
+def test_workspace_file_read(client: TestClient, team_with_workspace: uuid.UUID) -> None:
+    """GET /workspace/{team_id}/file returns file content."""
+    resp = client.get(f"/workspace/{team_with_workspace}/file", params={"path": "output.txt"})
+    assert resp.status_code == 200
+    assert resp.content == b"hello world"
+    assert "Content-Disposition" in resp.headers
+
+
+def test_workspace_file_not_found(client: TestClient, team_with_workspace: uuid.UUID) -> None:
+    """GET /workspace/{team_id}/file returns 404 for non-existent file."""
+    resp = client.get(
+        f"/workspace/{team_with_workspace}/file", params={"path": "does-not-exist.txt"}
+    )
+    assert resp.status_code == 404
+
+
+def test_workspace_file_size_limit(
+    client: TestClient,
+    team_with_workspace: uuid.UUID,
+    seeded_settings: ServerSettings,
+) -> None:
+    """GET /workspace/{team_id}/file returns 413 for files exceeding 10 MB."""
+    ws_root = seeded_settings.workspaces_root / str(team_with_workspace)
+    big_file = ws_root / "huge.bin"
+    big_file.write_bytes(b"\x00" * (10_485_760 + 1))
+    resp = client.get(f"/workspace/{team_with_workspace}/file", params={"path": "huge.bin"})
+    assert resp.status_code == 413
+
+
+def test_workspace_file_traversal_attack(
+    client: TestClient, team_with_workspace: uuid.UUID
+) -> None:
+    """GET /workspace/{team_id}/file rejects path traversal attempts with 403."""
+    resp = client.get(
+        f"/workspace/{team_with_workspace}/file", params={"path": "../../etc/passwd"}
+    )
+    assert resp.status_code == 403
+
+
+# --- File upload tests ---
+
+
+def test_workspace_file_upload(client: TestClient, team_with_workspace: uuid.UUID) -> None:
+    """POST /workspace/{team_id}/file uploads and stores file."""
+    resp = client.post(
+        f"/workspace/{team_with_workspace}/file",
+        data={"path": "uploaded.txt"},
+        files={"file": ("uploaded.txt", b"upload content", "text/plain")},
+    )
+    assert resp.status_code == 201
+    body = resp.json()
+    assert body["path"] == "uploaded.txt"
+    assert body["size"] == len(b"upload content")
+
+    # Verify file can be read back
+    read_resp = client.get(
+        f"/workspace/{team_with_workspace}/file", params={"path": "uploaded.txt"}
+    )
+    assert read_resp.status_code == 200
+    assert read_resp.content == b"upload content"
+
+
+def test_workspace_file_upload_team_not_found(client: TestClient) -> None:
+    """POST /workspace/{team_id}/file returns 404 for non-existent team."""
+    fake_id = uuid.uuid4()
+    resp = client.post(
+        f"/workspace/{fake_id}/file",
+        data={"path": "test.txt"},
+        files={"file": ("test.txt", b"data", "text/plain")},
+    )
+    assert resp.status_code == 404
+
+
+def test_workspace_file_upload_traversal_attack(
+    client: TestClient, team_with_workspace: uuid.UUID
+) -> None:
+    """POST /workspace/{team_id}/file rejects path traversal with 403."""
+    resp = client.post(
+        f"/workspace/{team_with_workspace}/file",
+        data={"path": "../../../etc/evil"},
+        files={"file": ("evil.txt", b"malicious", "text/plain")},
+    )
+    assert resp.status_code == 403


### PR DESCRIPTION
## Summary

- Read-only catalog browsing endpoints (`GET /catalog/teams`, `GET /catalog/teams/{name}`) backed by `CommunityServices.team_catalog`
- Workspace file access endpoints (`GET /workspace/{team_id}/tree`, `GET /workspace/{team_id}/file`, `POST /workspace/{team_id}/file`) with 10 MB size limits and directory traversal protection
- 6 new Pydantic response models in `server/models.py`
- 15 new tests (5 catalog + 10 workspace) — 186 total, 92.71% coverage

Closes #19