### PR TITLE
Integration tests for WebSocket, events, and catalog

### DIFF
--- a/tests/integration/_helpers.py
+++ b/tests/integration/_helpers.py
@@ -1,0 +1,64 @@
+"""Shared helpers for integration tests — real app, real LLM."""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+from fastapi.testclient import TestClient
+
+CATALOG_ENTRY_ID = "test-team"
+POLL_INTERVAL_S = 1.0
+POLL_TIMEOUT_S = 60.0
+
+
+def create_team(client: TestClient) -> str:
+    """POST /teams and return the team_id."""
+    resp = client.post("/teams/", json={"catalog_entry_id": CATALOG_ENTRY_ID})
+    assert resp.status_code == 201
+    data = resp.json()
+    assert data["status"] == "running"
+    return data["team_id"]
+
+
+def wait_for_llm_response(
+    client: TestClient,
+    team_id: str,
+    timeout: float = POLL_TIMEOUT_S,
+) -> list[dict[str, object]]:
+    """Poll GET /teams/{team_id}/events until @Manager responds."""
+    deadline = time.monotonic() + timeout
+    events: list[dict[str, object]] = []
+    while time.monotonic() < deadline:
+        resp = client.get(f"/teams/{team_id}/events")
+        assert resp.status_code == 200
+        events = resp.json()["events"]
+        if has_llm_content(events):
+            return events
+        time.sleep(POLL_INTERVAL_S)
+    pytest.fail(
+        f"Timed out after {timeout}s waiting for LLM response "
+        f"(got {len(events)} events, none with LLM content)"
+    )
+
+
+def has_llm_content(events: list[dict[str, object]]) -> bool:
+    """Check if any event contains LLM-generated content from @Manager."""
+    for ev_wrapper in events:
+        ev = ev_wrapper["event"]
+        if not isinstance(ev, dict):
+            continue
+        msg = ev.get("message")
+        if not isinstance(msg, dict):
+            continue
+        content = msg.get("content")
+        sender = ev.get("sender")
+        if not isinstance(sender, dict):
+            continue
+        if (
+            isinstance(content, str)
+            and len(content) > 0
+            and sender.get("name") == "@Manager"
+        ):
+            return True
+    return False

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -153,9 +153,12 @@ def integration_team_service(
 def integration_app(
     integration_services: CommunityServices,
     integration_team_service: TeamService,
+    integration_settings: ServerSettings,
 ) -> FastAPI:
     """FastAPI app backed by real actors and real LLM."""
-    return create_app(integration_services, integration_team_service)
+    return create_app(
+        integration_services, integration_team_service, settings=integration_settings,
+    )
 
 
 @pytest.fixture()

--- a/tests/integration/test_catalog.py
+++ b/tests/integration/test_catalog.py
@@ -1,0 +1,49 @@
+"""Integration tests — catalog browsing endpoints with real wired app."""
+
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+
+pytestmark = pytest.mark.integration
+
+# ---------------------------------------------------------------------------
+# Tests (AC #3)
+# ---------------------------------------------------------------------------
+
+
+class TestCatalogIntegration:
+    """Integration tests for catalog browsing with real YAML catalog."""
+
+    def test_list_teams_returns_seeded_entry(
+        self, integration_client: TestClient,
+    ) -> None:
+        """AC #3: GET /catalog/teams returns at least the seeded test-team."""
+        resp = integration_client.get("/catalog/teams")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert "teams" in body
+        ids = [t["id"] for t in body["teams"]]
+        assert "test-team" in ids, f"Expected 'test-team' in catalog, got: {ids}"
+
+    def test_get_team_details(
+        self, integration_client: TestClient,
+    ) -> None:
+        """AC #3: GET /catalog/teams/test-team returns full details."""
+        resp = integration_client.get("/catalog/teams/test-team")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["id"] == "test-team"
+        assert body["name"] == "Integration Test Team"
+        assert body["entry_point"] == "human-proxy"
+        assert isinstance(body["members"], list)
+        assert len(body["members"]) == 2
+        assert isinstance(body["profiles"], list)
+
+    def test_get_nonexistent_team_returns_404(
+        self, integration_client: TestClient,
+    ) -> None:
+        """AC #3: GET /catalog/teams/nonexistent returns 404."""
+        resp = integration_client.get("/catalog/teams/nonexistent")
+        assert resp.status_code == 404
+        assert "not found" in resp.json()["detail"].lower()

--- a/tests/integration/test_events.py
+++ b/tests/integration/test_events.py
@@ -1,0 +1,166 @@
+"""Integration tests — event persistence via REST after team lifecycle operations."""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+from fastapi.testclient import TestClient
+
+pytestmark = pytest.mark.integration
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+CATALOG_ENTRY_ID = "test-team"
+POLL_INTERVAL_S = 1.0
+POLL_TIMEOUT_S = 60.0
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _create_team(client: TestClient) -> str:
+    """POST /teams and return the team_id."""
+    resp = client.post("/teams/", json={"catalog_entry_id": CATALOG_ENTRY_ID})
+    assert resp.status_code == 201
+    data = resp.json()
+    assert data["status"] == "running"
+    return data["team_id"]
+
+
+def _wait_for_llm_response(
+    client: TestClient,
+    team_id: str,
+    timeout: float = POLL_TIMEOUT_S,
+) -> list[dict[str, object]]:
+    """Poll GET /teams/{team_id}/events until @Manager responds."""
+    deadline = time.monotonic() + timeout
+    events: list[dict[str, object]] = []
+    while time.monotonic() < deadline:
+        resp = client.get(f"/teams/{team_id}/events")
+        assert resp.status_code == 200
+        events = resp.json()["events"]
+        if _has_llm_content(events):
+            return events
+        time.sleep(POLL_INTERVAL_S)
+    pytest.fail(
+        f"Timed out after {timeout}s waiting for LLM response "
+        f"(got {len(events)} events, none with LLM content)"
+    )
+
+
+def _has_llm_content(events: list[dict[str, object]]) -> bool:
+    """Check if any event contains LLM-generated content from @Manager."""
+    for ev_wrapper in events:
+        ev = ev_wrapper["event"]
+        if not isinstance(ev, dict):
+            continue
+        msg = ev.get("message")
+        if not isinstance(msg, dict):
+            continue
+        content = msg.get("content")
+        sender = ev.get("sender")
+        if not isinstance(sender, dict):
+            continue
+        if (
+            isinstance(content, str)
+            and len(content) > 0
+            and sender.get("name") == "@Manager"
+        ):
+            return True
+    return False
+
+
+# ---------------------------------------------------------------------------
+# Tests (AC #2)
+# ---------------------------------------------------------------------------
+
+
+class TestEventPersistence:
+    """Integration tests for event persistence after team lifecycle operations."""
+
+    def test_events_persisted_after_stop(
+        self, integration_client: TestClient,
+    ) -> None:
+        """AC #2: Create team, send message, wait for LLM, stop, verify events via REST."""
+        team_id = _create_team(integration_client)
+
+        # Send message and wait for LLM response
+        integration_client.post(
+            f"/teams/{team_id}/message",
+            json={"content": "Reply with exactly one word."},
+        )
+        events = _wait_for_llm_response(integration_client, team_id)
+        assert _has_llm_content(events)
+
+        # Stop the team
+        resp = integration_client.post(f"/teams/{team_id}/stop")
+        assert resp.status_code == 204
+
+        # Events should still be accessible via REST after stop
+        resp = integration_client.get(f"/teams/{team_id}/events")
+        assert resp.status_code == 200
+        stopped_events = resp.json()["events"]
+
+        # Verify SentMessage and ReceivedMessage are present
+        models = [
+            ev["event"].get("__model__", "")
+            for ev in stopped_events
+            if isinstance(ev.get("event"), dict)
+        ]
+        has_sent = any("SentMessage" in str(m) for m in models)
+        has_received = any("ReceivedMessage" in str(m) for m in models)
+        assert has_sent or has_received, (
+            f"Expected SentMessage or ReceivedMessage in persisted events, got: {models}"
+        )
+
+    def test_event_count_after_send_and_respond(
+        self, integration_client: TestClient,
+    ) -> None:
+        """AC #2: Verify event count >= 3 after a full send-and-respond cycle."""
+        team_id = _create_team(integration_client)
+
+        integration_client.post(
+            f"/teams/{team_id}/message",
+            json={"content": "What is 1 + 1? Answer with the number."},
+        )
+        events = _wait_for_llm_response(integration_client, team_id)
+        assert len(events) >= 3, (
+            f"Expected >= 3 events after send-and-respond cycle, got {len(events)}"
+        )
+
+    def test_events_survive_stop_restore_cycle(
+        self, integration_client: TestClient,
+    ) -> None:
+        """AC #2: Events from before stop are still accessible after restore."""
+        team_id = _create_team(integration_client)
+
+        # Send message and wait for LLM response
+        integration_client.post(
+            f"/teams/{team_id}/message",
+            json={"content": "Respond with one word."},
+        )
+        events_before = _wait_for_llm_response(integration_client, team_id)
+        count_before = len(events_before)
+        assert count_before >= 3
+
+        # Stop
+        resp = integration_client.post(f"/teams/{team_id}/stop")
+        assert resp.status_code == 204
+
+        # Restore
+        resp = integration_client.post(f"/teams/{team_id}/restore")
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "running"
+
+        # Events from before stop should still be accessible
+        resp = integration_client.get(f"/teams/{team_id}/events")
+        assert resp.status_code == 200
+        events_after = resp.json()["events"]
+        assert len(events_after) >= count_before, (
+            f"Events lost after stop/restore: had {count_before}, now {len(events_after)}"
+        )

--- a/tests/integration/test_events.py
+++ b/tests/integration/test_events.py
@@ -7,72 +7,9 @@ import time
 import pytest
 from fastapi.testclient import TestClient
 
+from ._helpers import create_team, has_llm_content, wait_for_llm_response
+
 pytestmark = pytest.mark.integration
-
-# ---------------------------------------------------------------------------
-# Constants
-# ---------------------------------------------------------------------------
-
-CATALOG_ENTRY_ID = "test-team"
-POLL_INTERVAL_S = 1.0
-POLL_TIMEOUT_S = 60.0
-
-
-# ---------------------------------------------------------------------------
-# Helpers
-# ---------------------------------------------------------------------------
-
-
-def _create_team(client: TestClient) -> str:
-    """POST /teams and return the team_id."""
-    resp = client.post("/teams/", json={"catalog_entry_id": CATALOG_ENTRY_ID})
-    assert resp.status_code == 201
-    data = resp.json()
-    assert data["status"] == "running"
-    return data["team_id"]
-
-
-def _wait_for_llm_response(
-    client: TestClient,
-    team_id: str,
-    timeout: float = POLL_TIMEOUT_S,
-) -> list[dict[str, object]]:
-    """Poll GET /teams/{team_id}/events until @Manager responds."""
-    deadline = time.monotonic() + timeout
-    events: list[dict[str, object]] = []
-    while time.monotonic() < deadline:
-        resp = client.get(f"/teams/{team_id}/events")
-        assert resp.status_code == 200
-        events = resp.json()["events"]
-        if _has_llm_content(events):
-            return events
-        time.sleep(POLL_INTERVAL_S)
-    pytest.fail(
-        f"Timed out after {timeout}s waiting for LLM response "
-        f"(got {len(events)} events, none with LLM content)"
-    )
-
-
-def _has_llm_content(events: list[dict[str, object]]) -> bool:
-    """Check if any event contains LLM-generated content from @Manager."""
-    for ev_wrapper in events:
-        ev = ev_wrapper["event"]
-        if not isinstance(ev, dict):
-            continue
-        msg = ev.get("message")
-        if not isinstance(msg, dict):
-            continue
-        content = msg.get("content")
-        sender = ev.get("sender")
-        if not isinstance(sender, dict):
-            continue
-        if (
-            isinstance(content, str)
-            and len(content) > 0
-            and sender.get("name") == "@Manager"
-        ):
-            return True
-    return False
 
 
 # ---------------------------------------------------------------------------
@@ -87,15 +24,15 @@ class TestEventPersistence:
         self, integration_client: TestClient,
     ) -> None:
         """AC #2: Create team, send message, wait for LLM, stop, verify events via REST."""
-        team_id = _create_team(integration_client)
+        team_id = create_team(integration_client)
 
         # Send message and wait for LLM response
         integration_client.post(
             f"/teams/{team_id}/message",
             json={"content": "Reply with exactly one word."},
         )
-        events = _wait_for_llm_response(integration_client, team_id)
-        assert _has_llm_content(events)
+        events = wait_for_llm_response(integration_client, team_id)
+        assert has_llm_content(events)
 
         # Stop the team
         resp = integration_client.post(f"/teams/{team_id}/stop")
@@ -122,29 +59,33 @@ class TestEventPersistence:
         self, integration_client: TestClient,
     ) -> None:
         """AC #2: Verify event count >= 3 after a full send-and-respond cycle."""
-        team_id = _create_team(integration_client)
+        team_id = create_team(integration_client)
 
         integration_client.post(
             f"/teams/{team_id}/message",
             json={"content": "What is 1 + 1? Answer with the number."},
         )
-        events = _wait_for_llm_response(integration_client, team_id)
+        events = wait_for_llm_response(integration_client, team_id)
         assert len(events) >= 3, (
             f"Expected >= 3 events after send-and-respond cycle, got {len(events)}"
         )
+
+        # Stop team before fixture teardown to avoid LLM-in-flight hang
+        integration_client.post(f"/teams/{team_id}/stop")
+        time.sleep(0.5)
 
     def test_events_survive_stop_restore_cycle(
         self, integration_client: TestClient,
     ) -> None:
         """AC #2: Events from before stop are still accessible after restore."""
-        team_id = _create_team(integration_client)
+        team_id = create_team(integration_client)
 
         # Send message and wait for LLM response
         integration_client.post(
             f"/teams/{team_id}/message",
             json={"content": "Respond with one word."},
         )
-        events_before = _wait_for_llm_response(integration_client, team_id)
+        events_before = wait_for_llm_response(integration_client, team_id)
         count_before = len(events_before)
         assert count_before >= 3
 
@@ -164,3 +105,7 @@ class TestEventPersistence:
         assert len(events_after) >= count_before, (
             f"Events lost after stop/restore: had {count_before}, now {len(events_after)}"
         )
+
+        # Stop team before fixture teardown to avoid LLM-in-flight hang
+        integration_client.post(f"/teams/{team_id}/stop")
+        time.sleep(0.5)

--- a/tests/integration/test_websocket.py
+++ b/tests/integration/test_websocket.py
@@ -7,72 +7,9 @@ import time
 import pytest
 from fastapi.testclient import TestClient
 
+from ._helpers import create_team, has_llm_content, wait_for_llm_response
+
 pytestmark = pytest.mark.integration
-
-# ---------------------------------------------------------------------------
-# Constants
-# ---------------------------------------------------------------------------
-
-CATALOG_ENTRY_ID = "test-team"
-POLL_INTERVAL_S = 1.0
-POLL_TIMEOUT_S = 60.0
-
-
-# ---------------------------------------------------------------------------
-# Helpers
-# ---------------------------------------------------------------------------
-
-
-def _create_team(client: TestClient) -> str:
-    """POST /teams and return the team_id."""
-    resp = client.post("/teams/", json={"catalog_entry_id": CATALOG_ENTRY_ID})
-    assert resp.status_code == 201
-    data = resp.json()
-    assert data["status"] == "running"
-    return data["team_id"]
-
-
-def _wait_for_llm_response(
-    client: TestClient,
-    team_id: str,
-    timeout: float = POLL_TIMEOUT_S,
-) -> list[dict[str, object]]:
-    """Poll GET /teams/{team_id}/events until @Manager responds."""
-    deadline = time.monotonic() + timeout
-    events: list[dict[str, object]] = []
-    while time.monotonic() < deadline:
-        resp = client.get(f"/teams/{team_id}/events")
-        assert resp.status_code == 200
-        events = resp.json()["events"]
-        if _has_llm_content(events):
-            return events
-        time.sleep(POLL_INTERVAL_S)
-    pytest.fail(
-        f"Timed out after {timeout}s waiting for LLM response "
-        f"(got {len(events)} events, none with LLM content)"
-    )
-
-
-def _has_llm_content(events: list[dict[str, object]]) -> bool:
-    """Check if any event contains LLM-generated content from @Manager."""
-    for ev_wrapper in events:
-        ev = ev_wrapper["event"]
-        if not isinstance(ev, dict):
-            continue
-        msg = ev.get("message")
-        if not isinstance(msg, dict):
-            continue
-        content = msg.get("content")
-        sender = ev.get("sender")
-        if not isinstance(sender, dict):
-            continue
-        if (
-            isinstance(content, str)
-            and len(content) > 0
-            and sender.get("name") == "@Manager"
-        ):
-            return True
-    return False
 
 
 # ---------------------------------------------------------------------------
@@ -87,7 +24,7 @@ class TestWebSocketIntegration:
         self, integration_client: TestClient,
     ) -> None:
         """AC #1: Create team, open WS, send message, verify events delivered via WS."""
-        team_id = _create_team(integration_client)
+        team_id = create_team(integration_client)
 
         with integration_client.websocket_connect(f"/ws/{team_id}") as ws:
             # Send a message to trigger events through the actor system
@@ -100,6 +37,10 @@ class TestWebSocketIntegration:
             data = ws.receive_json(mode="text")
             assert isinstance(data, dict)
             assert "__model__" in data
+            model = str(data.get("__model__", ""))
+            assert "SentMessage" in model or "ReceivedMessage" in model, (
+                f"Expected SentMessage or ReceivedMessage, got: {model}"
+            )
 
         # Stop team before fixture teardown to avoid LLM-in-flight hang
         integration_client.post(f"/teams/{team_id}/stop")
@@ -109,15 +50,15 @@ class TestWebSocketIntegration:
         self, integration_client: TestClient,
     ) -> None:
         """AC #1: Send message via HTTP, verify LLM response arrives, open WS for new events."""
-        team_id = _create_team(integration_client)
+        team_id = create_team(integration_client)
 
         # Send message and wait for LLM response via REST polling
         integration_client.post(
             f"/teams/{team_id}/message",
             json={"content": "Reply with exactly one word."},
         )
-        events = _wait_for_llm_response(integration_client, team_id)
-        assert _has_llm_content(events)
+        events = wait_for_llm_response(integration_client, team_id)
+        assert has_llm_content(events)
 
         # Now open WS and send another message — verify WS delivers events
         with integration_client.websocket_connect(f"/ws/{team_id}") as ws:
@@ -144,7 +85,7 @@ class TestWebSocketIntegration:
         self, integration_client: TestClient,
     ) -> None:
         """AC #1: Connect WS to stopped team, restore, verify events flow after restore."""
-        team_id = _create_team(integration_client)
+        team_id = create_team(integration_client)
 
         # Stop the team
         resp = integration_client.post(f"/teams/{team_id}/stop")

--- a/tests/integration/test_websocket.py
+++ b/tests/integration/test_websocket.py
@@ -1,0 +1,170 @@
+"""Integration tests — WebSocket event streaming with real actors and real LLM."""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+from fastapi.testclient import TestClient
+
+pytestmark = pytest.mark.integration
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+CATALOG_ENTRY_ID = "test-team"
+POLL_INTERVAL_S = 1.0
+POLL_TIMEOUT_S = 60.0
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _create_team(client: TestClient) -> str:
+    """POST /teams and return the team_id."""
+    resp = client.post("/teams/", json={"catalog_entry_id": CATALOG_ENTRY_ID})
+    assert resp.status_code == 201
+    data = resp.json()
+    assert data["status"] == "running"
+    return data["team_id"]
+
+
+def _wait_for_llm_response(
+    client: TestClient,
+    team_id: str,
+    timeout: float = POLL_TIMEOUT_S,
+) -> list[dict[str, object]]:
+    """Poll GET /teams/{team_id}/events until @Manager responds."""
+    deadline = time.monotonic() + timeout
+    events: list[dict[str, object]] = []
+    while time.monotonic() < deadline:
+        resp = client.get(f"/teams/{team_id}/events")
+        assert resp.status_code == 200
+        events = resp.json()["events"]
+        if _has_llm_content(events):
+            return events
+        time.sleep(POLL_INTERVAL_S)
+    pytest.fail(
+        f"Timed out after {timeout}s waiting for LLM response "
+        f"(got {len(events)} events, none with LLM content)"
+    )
+
+
+def _has_llm_content(events: list[dict[str, object]]) -> bool:
+    """Check if any event contains LLM-generated content from @Manager."""
+    for ev_wrapper in events:
+        ev = ev_wrapper["event"]
+        if not isinstance(ev, dict):
+            continue
+        msg = ev.get("message")
+        if not isinstance(msg, dict):
+            continue
+        content = msg.get("content")
+        sender = ev.get("sender")
+        if not isinstance(sender, dict):
+            continue
+        if (
+            isinstance(content, str)
+            and len(content) > 0
+            and sender.get("name") == "@Manager"
+        ):
+            return True
+    return False
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestWebSocketIntegration:
+    """Integration tests for WebSocket event streaming (AC #1)."""
+
+    def test_ws_create_team_send_message_receive_events(
+        self, integration_client: TestClient,
+    ) -> None:
+        """AC #1: Create team, open WS, send message, verify events delivered via WS."""
+        team_id = _create_team(integration_client)
+
+        with integration_client.websocket_connect(f"/ws/{team_id}") as ws:
+            # Send a message to trigger events through the actor system
+            time.sleep(0.3)
+            integration_client.post(
+                f"/teams/{team_id}/message",
+                json={"content": "Say hello"},
+            )
+
+            data = ws.receive_json(mode="text")
+            assert isinstance(data, dict)
+            assert "__model__" in data
+
+        # Stop team before fixture teardown to avoid LLM-in-flight hang
+        integration_client.post(f"/teams/{team_id}/stop")
+        time.sleep(0.5)
+
+    def test_ws_full_round_trip_with_llm(
+        self, integration_client: TestClient,
+    ) -> None:
+        """AC #1: Send message via HTTP, verify LLM response arrives, open WS for new events."""
+        team_id = _create_team(integration_client)
+
+        # Send message and wait for LLM response via REST polling
+        integration_client.post(
+            f"/teams/{team_id}/message",
+            json={"content": "Reply with exactly one word."},
+        )
+        events = _wait_for_llm_response(integration_client, team_id)
+        assert _has_llm_content(events)
+
+        # Now open WS and send another message — verify WS delivers events
+        with integration_client.websocket_connect(f"/ws/{team_id}") as ws:
+            time.sleep(0.3)
+            integration_client.post(
+                f"/teams/{team_id}/message",
+                json={"content": "Say yes."},
+            )
+            data = ws.receive_json(mode="text")
+            assert isinstance(data, dict)
+            assert "__model__" in data
+
+            # Verify at least one event has SentMessage or ReceivedMessage
+            model = str(data.get("__model__", ""))
+            assert "SentMessage" in model or "ReceivedMessage" in model, (
+                f"Expected SentMessage or ReceivedMessage, got: {model}"
+            )
+
+        # Stop team before fixture teardown to avoid LLM-in-flight hang
+        integration_client.post(f"/teams/{team_id}/stop")
+        time.sleep(0.5)
+
+    def test_ws_restore_receives_events(
+        self, integration_client: TestClient,
+    ) -> None:
+        """AC #1: Connect WS to stopped team, restore, verify events flow after restore."""
+        team_id = _create_team(integration_client)
+
+        # Stop the team
+        resp = integration_client.post(f"/teams/{team_id}/stop")
+        assert resp.status_code == 204
+
+        with integration_client.websocket_connect(f"/ws/{team_id}") as ws:
+            # Restore the team — idle WS should start receiving events
+            integration_client.post(f"/teams/{team_id}/restore")
+            time.sleep(0.5)
+
+            # Send a message to generate events
+            integration_client.post(
+                f"/teams/{team_id}/message",
+                json={"content": "hello after restore"},
+            )
+
+            data = ws.receive_json(mode="text")
+            assert isinstance(data, dict)
+            assert "__model__" in data
+
+        # Stop team before fixture teardown to avoid LLM-in-flight hang
+        integration_client.post(f"/teams/{team_id}/stop")
+        time.sleep(0.5)


### PR DESCRIPTION
## Summary

- Add 9 integration tests covering WebSocket event streaming (AC #1), event persistence via REST (AC #2), and catalog browsing (AC #3)
- Fix `integration_app` fixture to pass `integration_settings` to `create_app()` (required for workspace routes from Story 2.2)
- Code review fixes: missing team stop calls to prevent teardown hangs, shared test helpers extracted to `_helpers.py`

Closes #21