### PR TITLE
Frontend Adapter Plugin System

### DIFF
--- a/src/akgentic/infra/server/app.py
+++ b/src/akgentic/infra/server/app.py
@@ -7,6 +7,7 @@ from fastapi.middleware.cors import CORSMiddleware
 
 from akgentic.infra.server.deps import CommunityServices
 from akgentic.infra.server.routes.catalog import router as catalog_router
+from akgentic.infra.server.routes.frontend_adapter import load_frontend_adapter
 from akgentic.infra.server.routes.teams import router as teams_router
 from akgentic.infra.server.routes.workspace import router as workspace_router
 from akgentic.infra.server.routes.ws import ConnectionManager
@@ -53,5 +54,10 @@ def create_app(
     app.include_router(catalog_router)
     app.include_router(workspace_router)
     app.include_router(ws_router)
+
+    if app.state.settings.frontend_adapter:
+        adapter = load_frontend_adapter(app.state.settings.frontend_adapter)
+        adapter.register_routes(app)
+        app.state.frontend_adapter = adapter
 
     return app

--- a/src/akgentic/infra/server/routes/frontend_adapter/__init__.py
+++ b/src/akgentic/infra/server/routes/frontend_adapter/__init__.py
@@ -1,0 +1,81 @@
+"""Frontend adapter plugin system for the akgentic-infra server.
+
+Defines the ``FrontendAdapter`` protocol and a dynamic loader utility that
+resolves adapter classes by fully-qualified dotted name (FQDN) at server
+start-up.  This allows external packages to supply their own route
+translations and WebSocket event wrappers without modifying server code.
+"""
+
+from __future__ import annotations
+
+import importlib
+from typing import Any, Protocol, runtime_checkable
+
+from fastapi import FastAPI
+
+from akgentic.team.models import PersistedEvent
+
+__all__ = ["FrontendAdapter", "load_frontend_adapter"]
+
+
+@runtime_checkable
+class FrontendAdapter(Protocol):
+    """Protocol for frontend compatibility adapters.
+
+    Implementations translate V2 API routes and WebSocket events into
+    formats expected by a specific frontend client (e.g. Angular V1).
+    """
+
+    def register_routes(self, app: FastAPI) -> None:
+        """Mount adapter-specific HTTP routes onto the FastAPI application.
+
+        Args:
+            app: The FastAPI application instance to add routes to.
+        """
+        ...
+
+    def wrap_ws_event(self, event: PersistedEvent) -> dict[str, Any]:
+        """Translate a persisted event into a frontend-specific JSON payload.
+
+        Args:
+            event: The V2 persisted event to translate.
+
+        Returns:
+            A dictionary representing the event in the frontend's expected format.
+        """
+        ...
+
+
+def load_frontend_adapter(fqdn: str) -> FrontendAdapter:
+    """Dynamically load a frontend adapter class by fully-qualified dotted name.
+
+    Args:
+        fqdn: Fully-qualified class name, e.g. ``"acme_corp.compat.AcmeAdapter"``.
+
+    Returns:
+        An instance of the adapter class that satisfies the ``FrontendAdapter``
+        protocol.
+
+    Raises:
+        ImportError: If the module or class cannot be found.
+        TypeError: If the resolved class does not implement ``FrontendAdapter``.
+    """
+    module_path, _, class_name = fqdn.rpartition(".")
+    if not module_path:
+        raise ImportError(f"Cannot load frontend adapter '{fqdn}': invalid FQDN (no module path)")
+
+    try:
+        module = importlib.import_module(module_path)
+    except ModuleNotFoundError as exc:
+        raise ImportError(f"Cannot load frontend adapter '{fqdn}': {exc}") from exc
+
+    try:
+        cls = getattr(module, class_name)
+    except AttributeError as exc:
+        raise ImportError(f"Cannot load frontend adapter '{fqdn}': {exc}") from exc
+
+    instance = cls()
+    if not isinstance(instance, FrontendAdapter):
+        raise TypeError(f"Class '{fqdn}' does not implement FrontendAdapter protocol")
+
+    return instance

--- a/src/akgentic/infra/server/routes/frontend_adapter/__init__.py
+++ b/src/akgentic/infra/server/routes/frontend_adapter/__init__.py
@@ -88,7 +88,12 @@ def load_frontend_adapter(fqdn: str) -> FrontendAdapter:
     except AttributeError as exc:
         raise ImportError(f"Cannot load frontend adapter '{fqdn}': {exc}") from exc
 
-    instance = cls()
+    try:
+        instance = cls()
+    except TypeError as exc:
+        raise TypeError(
+            f"Cannot instantiate frontend adapter '{fqdn}': {exc}"
+        ) from exc
     if not isinstance(instance, FrontendAdapter):
         raise TypeError(f"Class '{fqdn}' does not implement FrontendAdapter protocol")
 

--- a/src/akgentic/infra/server/routes/frontend_adapter/__init__.py
+++ b/src/akgentic/infra/server/routes/frontend_adapter/__init__.py
@@ -12,10 +12,24 @@ import importlib
 from typing import Any, Protocol, runtime_checkable
 
 from fastapi import FastAPI
+from pydantic import BaseModel, Field
 
 from akgentic.team.models import PersistedEvent
 
-__all__ = ["FrontendAdapter", "load_frontend_adapter"]
+__all__ = ["FrontendAdapter", "WrappedWsEvent", "load_frontend_adapter"]
+
+
+class WrappedWsEvent(BaseModel):
+    """WebSocket event wrapped by a frontend adapter for client delivery.
+
+    Encapsulates the adapter-transformed payload so that the return type
+    crossing the adapter → WebSocket boundary is a proper Pydantic model
+    rather than a raw dict.
+    """
+
+    payload: dict[str, Any] = Field(
+        description="Adapter-transformed event data in the frontend's expected format",
+    )
 
 
 @runtime_checkable
@@ -34,14 +48,14 @@ class FrontendAdapter(Protocol):
         """
         ...
 
-    def wrap_ws_event(self, event: PersistedEvent) -> dict[str, Any]:
-        """Translate a persisted event into a frontend-specific JSON payload.
+    def wrap_ws_event(self, event: PersistedEvent) -> WrappedWsEvent:
+        """Translate a persisted event into a frontend-specific payload.
 
         Args:
             event: The V2 persisted event to translate.
 
         Returns:
-            A dictionary representing the event in the frontend's expected format.
+            A WrappedWsEvent containing the event in the frontend's expected format.
         """
         ...
 

--- a/src/akgentic/infra/server/routes/ws.py
+++ b/src/akgentic/infra/server/routes/ws.py
@@ -153,7 +153,12 @@ async def _send_loop(
             break
 
         if adapter is not None and team_id is not None:
-            msg_data = json.loads(item)
+            try:
+                msg_data = json.loads(item)
+            except json.JSONDecodeError:
+                logger.warning("Malformed JSON in event queue, sending raw text")
+                await websocket.send_text(item)
+                continue
             event = PersistedEvent.model_validate({
                 "team_id": str(team_id),
                 "sequence": seq,

--- a/src/akgentic/infra/server/routes/ws.py
+++ b/src/akgentic/infra/server/routes/ws.py
@@ -162,7 +162,7 @@ async def _send_loop(
             })
             seq += 1
             wrapped = adapter.wrap_ws_event(event)
-            await websocket.send_text(json.dumps(wrapped))
+            await websocket.send_text(wrapped.model_dump_json())
         else:
             await websocket.send_text(item)
 

--- a/src/akgentic/infra/server/routes/ws.py
+++ b/src/akgentic/infra/server/routes/ws.py
@@ -3,9 +3,11 @@
 from __future__ import annotations
 
 import asyncio
+import json
 import logging
 import queue
 import uuid
+from datetime import UTC, datetime
 from queue import Empty
 from typing import cast
 
@@ -14,8 +16,9 @@ from starlette.websockets import WebSocketState
 
 from akgentic.core.orchestrator import Orchestrator
 from akgentic.infra.adapters.websocket_subscriber import WebSocketEventSubscriber
+from akgentic.infra.server.routes.frontend_adapter import FrontendAdapter
 from akgentic.infra.server.services.team_service import TeamService
-from akgentic.team.models import TeamStatus
+from akgentic.team.models import PersistedEvent, TeamStatus
 
 logger = logging.getLogger(__name__)
 
@@ -91,10 +94,12 @@ async def websocket_events(websocket: WebSocket, team_id: uuid.UUID) -> None:
 
     await websocket.accept()
 
+    adapter: FrontendAdapter | None = getattr(websocket.app.state, "frontend_adapter", None)
+
     if process.status == TeamStatus.RUNNING:
-        await _run_streaming_loop(websocket, service, team_id, conn_mgr)
+        await _run_streaming_loop(websocket, service, team_id, conn_mgr, adapter)
     else:
-        await _run_idle_loop(websocket, team_id, conn_mgr, service)
+        await _run_idle_loop(websocket, team_id, conn_mgr, service, adapter)
 
 
 async def _run_streaming_loop(
@@ -102,6 +107,7 @@ async def _run_streaming_loop(
     service: TeamService,
     team_id: uuid.UUID,
     conn_mgr: ConnectionManager,
+    adapter: FrontendAdapter | None = None,
 ) -> None:
     """Subscribe to orchestrator events and forward them over WebSocket."""
     runtime = service.get_runtime(team_id)
@@ -114,7 +120,7 @@ async def _run_streaming_loop(
     orch_proxy.subscribe(subscriber)
 
     try:
-        await _send_loop(websocket, subscriber)
+        await _send_loop(websocket, subscriber, team_id, adapter)
     except WebSocketDisconnect:
         pass
     finally:
@@ -127,10 +133,13 @@ async def _run_streaming_loop(
 async def _send_loop(
     websocket: WebSocket,
     subscriber: WebSocketEventSubscriber,
+    team_id: uuid.UUID | None = None,
+    adapter: FrontendAdapter | None = None,
 ) -> None:
     """Read from subscriber queue and send over WebSocket."""
     loop = asyncio.get_running_loop()
     q = subscriber.get_queue()
+    seq = 0
     while True:
         try:
             item: str | None = await loop.run_in_executor(None, _queue_get, q)
@@ -143,7 +152,19 @@ async def _send_loop(
             await websocket.close(code=1000)
             break
 
-        await websocket.send_text(item)
+        if adapter is not None and team_id is not None:
+            msg_data = json.loads(item)
+            event = PersistedEvent.model_validate({
+                "team_id": str(team_id),
+                "sequence": seq,
+                "event": msg_data,
+                "timestamp": datetime.now(tz=UTC).isoformat(),
+            })
+            seq += 1
+            wrapped = adapter.wrap_ws_event(event)
+            await websocket.send_text(json.dumps(wrapped))
+        else:
+            await websocket.send_text(item)
 
 
 async def _run_idle_loop(
@@ -151,6 +172,7 @@ async def _run_idle_loop(
     team_id: uuid.UUID,
     conn_mgr: ConnectionManager,
     service: TeamService,
+    adapter: FrontendAdapter | None = None,
 ) -> None:
     """Wait for team restore or client disconnect."""
     conn_mgr.add_waiting(team_id, websocket)
@@ -161,7 +183,7 @@ async def _run_idle_loop(
             except TimeoutError:
                 sub = conn_mgr.get_subscriber(websocket)
                 if sub is not None:
-                    await _send_loop(websocket, sub)
+                    await _send_loop(websocket, sub, team_id, adapter)
                     return
             except WebSocketDisconnect:
                 return

--- a/tests/test_frontend_adapter.py
+++ b/tests/test_frontend_adapter.py
@@ -132,6 +132,28 @@ class TestLoadFrontendAdapter:
             ):
                 load_frontend_adapter("fake_adapter_module._NotAnAdapter")
 
+    def test_load_adapter_with_constructor_args_raises_type_error(self) -> None:
+        """Adapter requiring constructor args raises clear TypeError."""
+        mod = _make_stub_module()
+
+        class _NeedsArgs:
+            def __init__(self, required: str) -> None:
+                pass
+
+            def register_routes(self, app: FastAPI) -> None:
+                pass
+
+            def wrap_ws_event(self, event: PersistedEvent) -> WrappedWsEvent:
+                return WrappedWsEvent(payload={})
+
+        mod._NeedsArgs = _NeedsArgs  # type: ignore[attr-defined]
+        with patch(
+            "akgentic.infra.server.routes.frontend_adapter.importlib.import_module",
+            return_value=mod,
+        ):
+            with pytest.raises(TypeError, match="Cannot instantiate frontend adapter"):
+                load_frontend_adapter("fake_adapter_module._NeedsArgs")
+
     def test_load_invalid_fqdn_no_module_path(self) -> None:
         """AC #4: FQDN without module path raises ImportError."""
         with pytest.raises(ImportError, match="invalid FQDN"):
@@ -283,8 +305,8 @@ class TestWebSocketAdapterIntegration:
     @pytest.fixture()
     def client_with_adapter(
         self,
-        community_services: MagicMock,
-        team_service: MagicMock,
+        community_services: object,
+        team_service: object,
         seeded_settings: ServerSettings,
     ) -> TestClient:
         """TestClient with a stub adapter set on app.state."""

--- a/tests/test_frontend_adapter.py
+++ b/tests/test_frontend_adapter.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import types
-from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -13,6 +12,7 @@ from fastapi.testclient import TestClient
 
 from akgentic.infra.server.routes.frontend_adapter import (
     FrontendAdapter,
+    WrappedWsEvent,
     load_frontend_adapter,
 )
 from akgentic.infra.server.settings import ServerSettings
@@ -33,8 +33,8 @@ class _StubAdapter:
         self.registered = True
         self.routes_app = app
 
-    def wrap_ws_event(self, event: PersistedEvent) -> dict[str, Any]:
-        return {"wrapped": True, "sequence": event.sequence}
+    def wrap_ws_event(self, event: PersistedEvent) -> WrappedWsEvent:
+        return WrappedWsEvent(payload={"wrapped": True, "sequence": event.sequence})
 
 
 class _NotAnAdapter:
@@ -277,7 +277,8 @@ class TestWebSocketAdapterIntegration:
             _trigger_subscriber_event(client_with_adapter, team_id)
             data = ws.receive_json(mode="text")
             assert isinstance(data, dict)
-            assert data.get("wrapped") is True
+            assert "payload" in data
+            assert data["payload"].get("wrapped") is True
 
     @pytest.fixture()
     def client_with_adapter(

--- a/tests/test_frontend_adapter.py
+++ b/tests/test_frontend_adapter.py
@@ -1,0 +1,302 @@
+"""Tests for the frontend adapter plugin system (Story 3.1)."""
+
+from __future__ import annotations
+
+import types
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+from akgentic.team.models import PersistedEvent
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from akgentic.infra.server.routes.frontend_adapter import (
+    FrontendAdapter,
+    load_frontend_adapter,
+)
+from akgentic.infra.server.settings import ServerSettings
+
+# ---------------------------------------------------------------------------
+# Stub adapter for testing
+# ---------------------------------------------------------------------------
+
+
+class _StubAdapter:
+    """Test adapter that satisfies the FrontendAdapter protocol."""
+
+    def __init__(self) -> None:
+        self.registered: bool = False
+        self.routes_app: FastAPI | None = None
+
+    def register_routes(self, app: FastAPI) -> None:
+        self.registered = True
+        self.routes_app = app
+
+    def wrap_ws_event(self, event: PersistedEvent) -> dict[str, Any]:
+        return {"wrapped": True, "sequence": event.sequence}
+
+
+class _NotAnAdapter:
+    """Class that does NOT implement the FrontendAdapter protocol."""
+
+    def some_other_method(self) -> None:
+        pass
+
+
+def _make_stub_module() -> types.ModuleType:
+    """Create a fake module containing the stub adapter classes."""
+    mod = types.ModuleType("fake_adapter_module")
+    mod._StubAdapter = _StubAdapter  # type: ignore[attr-defined]
+    mod._NotAnAdapter = _NotAnAdapter  # type: ignore[attr-defined]
+    return mod
+
+
+# ---------------------------------------------------------------------------
+# Task 1: FrontendAdapter protocol tests (AC #1, #6)
+# ---------------------------------------------------------------------------
+
+
+class TestFrontendAdapterProtocol:
+    """Verify the FrontendAdapter protocol definition."""
+
+    def test_protocol_has_register_routes(self) -> None:
+        """AC #1: FrontendAdapter has register_routes method."""
+        assert hasattr(FrontendAdapter, "register_routes")
+
+    def test_protocol_has_wrap_ws_event(self) -> None:
+        """AC #1: FrontendAdapter has wrap_ws_event method."""
+        assert hasattr(FrontendAdapter, "wrap_ws_event")
+
+    def test_stub_satisfies_protocol(self) -> None:
+        """AC #1: A valid implementation is recognized as FrontendAdapter."""
+        adapter = _StubAdapter()
+        assert isinstance(adapter, FrontendAdapter)
+
+    def test_non_adapter_does_not_satisfy_protocol(self) -> None:
+        """AC #1: A class missing methods is not a FrontendAdapter."""
+        obj = _NotAnAdapter()
+        assert not isinstance(obj, FrontendAdapter)
+
+    def test_protocol_is_importable_from_module(self) -> None:
+        """AC #6: FrontendAdapter is importable from the module."""
+        from akgentic.infra.server.routes.frontend_adapter import (
+            FrontendAdapter as FrontendAdapterImported,
+        )
+
+        assert FrontendAdapterImported is FrontendAdapter
+
+
+# ---------------------------------------------------------------------------
+# Task 2: load_frontend_adapter tests (AC #3, #4, #5)
+# ---------------------------------------------------------------------------
+
+
+class TestLoadFrontendAdapter:
+    """Verify the adapter loader utility."""
+
+    def test_load_valid_fqdn(self) -> None:
+        """AC #3: Valid FQDN loads and returns adapter instance."""
+        mod = _make_stub_module()
+        with patch(
+            "akgentic.infra.server.routes.frontend_adapter.importlib.import_module",
+            return_value=mod,
+        ):
+            adapter = load_frontend_adapter("fake_adapter_module._StubAdapter")
+        assert isinstance(adapter, FrontendAdapter)
+
+    def test_load_nonexistent_module_raises_import_error(self) -> None:
+        """AC #4: Non-existent module raises ImportError with clear message."""
+        with pytest.raises(ImportError, match="Cannot load frontend adapter"):
+            load_frontend_adapter("nonexistent.module.Adapter")
+
+    def test_load_nonexistent_class_raises_import_error(self) -> None:
+        """AC #4: Non-existent class in valid module raises ImportError."""
+        mod = _make_stub_module()
+        with patch(
+            "akgentic.infra.server.routes.frontend_adapter.importlib.import_module",
+            return_value=mod,
+        ):
+            with pytest.raises(ImportError, match="Cannot load frontend adapter"):
+                load_frontend_adapter("fake_adapter_module.NonExistentClass")
+
+    def test_load_non_adapter_class_raises_type_error(self) -> None:
+        """AC #5: Class not implementing protocol raises TypeError."""
+        mod = _make_stub_module()
+        with patch(
+            "akgentic.infra.server.routes.frontend_adapter.importlib.import_module",
+            return_value=mod,
+        ):
+            with pytest.raises(
+                TypeError, match="does not implement FrontendAdapter protocol",
+            ):
+                load_frontend_adapter("fake_adapter_module._NotAnAdapter")
+
+    def test_load_invalid_fqdn_no_module_path(self) -> None:
+        """AC #4: FQDN without module path raises ImportError."""
+        with pytest.raises(ImportError, match="invalid FQDN"):
+            load_frontend_adapter("JustAClassName")
+
+    def test_loader_is_importable_from_module(self) -> None:
+        """AC #6: load_frontend_adapter is importable from the module."""
+        from akgentic.infra.server.routes.frontend_adapter import (
+            load_frontend_adapter as loader,
+        )
+
+        assert loader is load_frontend_adapter
+
+
+# ---------------------------------------------------------------------------
+# Task 3: create_app() integration tests (AC #2, #3)
+# ---------------------------------------------------------------------------
+
+
+class TestCreateAppAdapterIntegration:
+    """Verify adapter loading in create_app()."""
+
+    def test_no_adapter_when_frontend_adapter_is_none(
+        self,
+        community_services: MagicMock,
+        team_service: MagicMock,
+    ) -> None:
+        """AC #2: frontend_adapter=None means no adapter loaded."""
+        settings = ServerSettings(frontend_adapter=None)
+        app = self._create_app(community_services, team_service, settings)
+        assert not hasattr(app.state, "frontend_adapter")
+
+    def test_no_adapter_when_frontend_adapter_is_empty(
+        self,
+        community_services: MagicMock,
+        team_service: MagicMock,
+    ) -> None:
+        """AC #2: frontend_adapter="" means no adapter loaded."""
+        settings = ServerSettings(frontend_adapter="")
+        app = self._create_app(community_services, team_service, settings)
+        assert not hasattr(app.state, "frontend_adapter")
+
+    def test_adapter_loaded_with_valid_fqdn(
+        self,
+        community_services: MagicMock,
+        team_service: MagicMock,
+    ) -> None:
+        """AC #3: Valid FQDN loads adapter and calls register_routes."""
+        settings = ServerSettings(
+            frontend_adapter="fake_adapter_module._StubAdapter",
+        )
+        stub = _StubAdapter()
+        with patch(
+            "akgentic.infra.server.app.load_frontend_adapter",
+            return_value=stub,
+        ):
+            app = self._create_app(community_services, team_service, settings)
+
+        assert app.state.frontend_adapter is stub
+        assert stub.registered
+        assert stub.routes_app is app
+
+    def test_invalid_fqdn_raises_error(
+        self,
+        community_services: MagicMock,
+        team_service: MagicMock,
+    ) -> None:
+        """AC #3: Invalid FQDN raises clear error during app creation."""
+        settings = ServerSettings(
+            frontend_adapter="nonexistent.module.BadAdapter",
+        )
+        with pytest.raises(ImportError):
+            self._create_app(community_services, team_service, settings)
+
+    def test_v2_routes_always_mounted(
+        self,
+        community_services: MagicMock,
+        team_service: MagicMock,
+    ) -> None:
+        """AC #3: V2 routes are mounted regardless of adapter config."""
+        settings = ServerSettings(
+            frontend_adapter="fake_adapter_module._StubAdapter",
+        )
+        with patch(
+            "akgentic.infra.server.app.load_frontend_adapter",
+            return_value=_StubAdapter(),
+        ):
+            app = self._create_app(community_services, team_service, settings)
+
+        route_paths = {r.path for r in app.routes if hasattr(r, "path")}
+        assert "/teams/" in route_paths or any("/teams" in p for p in route_paths)
+
+    @staticmethod
+    def _create_app(
+        services: MagicMock,
+        team_service: MagicMock,
+        settings: ServerSettings,
+    ) -> FastAPI:
+        from akgentic.infra.server.app import create_app
+
+        return create_app(services, team_service, settings=settings)
+
+    @pytest.fixture()
+    def community_services(self) -> MagicMock:
+        return MagicMock()
+
+    @pytest.fixture()
+    def team_service(self) -> MagicMock:
+        return MagicMock()
+
+
+# ---------------------------------------------------------------------------
+# Task 4: WebSocket adapter integration tests (AC #1)
+# ---------------------------------------------------------------------------
+
+
+class TestWebSocketAdapterIntegration:
+    """Verify WebSocket route behavior with and without adapter."""
+
+    def test_ws_sends_v2_format_without_adapter(self, client: TestClient) -> None:
+        """AC #1: No adapter — events sent in V2 format (existing behavior)."""
+        resp = client.post("/teams/", json={"catalog_entry_id": "test-team"})
+        assert resp.status_code == 201
+        team_id = resp.json()["team_id"]
+
+        with client.websocket_connect(f"/ws/{team_id}") as ws:
+            _trigger_subscriber_event(client, team_id)
+            data = ws.receive_json(mode="text")
+            assert isinstance(data, dict)
+            assert "__model__" in data
+
+    def test_ws_calls_wrap_ws_event_when_adapter_present(
+        self, client_with_adapter: TestClient,
+    ) -> None:
+        """AC #1: Adapter present — wrap_ws_event is called."""
+        resp = client_with_adapter.post(
+            "/teams/", json={"catalog_entry_id": "test-team"},
+        )
+        assert resp.status_code == 201
+        team_id = resp.json()["team_id"]
+
+        with client_with_adapter.websocket_connect(f"/ws/{team_id}") as ws:
+            _trigger_subscriber_event(client_with_adapter, team_id)
+            data = ws.receive_json(mode="text")
+            assert isinstance(data, dict)
+            assert data.get("wrapped") is True
+
+    @pytest.fixture()
+    def client_with_adapter(
+        self,
+        community_services: MagicMock,
+        team_service: MagicMock,
+        seeded_settings: ServerSettings,
+    ) -> TestClient:
+        """TestClient with a stub adapter set on app.state."""
+        from akgentic.infra.server.app import create_app
+
+        app = create_app(community_services, team_service, settings=seeded_settings)
+        app.state.frontend_adapter = _StubAdapter()
+        return TestClient(app)
+
+
+def _trigger_subscriber_event(client: TestClient, team_id: str) -> None:
+    """Send a message to the team to trigger an orchestrator event."""
+    import time
+
+    time.sleep(0.3)
+    client.post(f"/teams/{team_id}/message", json={"content": "hello"})


### PR DESCRIPTION
## Summary

Implements a pluggable frontend adapter system (Story 3.1) that allows different frontend implementations to connect to the V2 backend without modifying server code.

- Defines `FrontendAdapter` as a `@runtime_checkable Protocol` with `register_routes` and `wrap_ws_event` methods
- Implements `load_frontend_adapter(fqdn)` using `importlib` with clear error handling for invalid FQDNs, missing modules, protocol mismatches, and constructor failures
- Integrates adapter loading into `create_app()` — V2 routes always mount first, adapter routes are additive
- Integrates `wrap_ws_event` into WebSocket `_send_loop` with graceful JSON error handling
- Introduces `WrappedWsEvent` Pydantic model for type-safe adapter→WebSocket boundary

### Code Review Fixes Applied
- Added `json.JSONDecodeError` handling in WebSocket adapter path to prevent connection drops on malformed messages
- Wrapped adapter class instantiation in try/except for clear errors on constructor failures
- Fixed misleading type annotations in test fixture
- Added test for adapter constructor failure case

**Tests:** 205 pass (19 new), 92.77% coverage, mypy strict clean, ruff clean

Closes #23