### PR TITLE
Angular V1 Adapter — WebSocket Wrapping & Response Models

### DIFF
--- a/src/akgentic/infra/server/routes/frontend_adapter/angular_v1/__init__.py
+++ b/src/akgentic/infra/server/routes/frontend_adapter/angular_v1/__init__.py
@@ -17,6 +17,7 @@ from akgentic.infra.server.routes.frontend_adapter.angular_v1.router import (
     process_router,
     states_router,
 )
+from akgentic.infra.server.routes.frontend_adapter.angular_v1.ws import wrap_event
 from akgentic.team.models import PersistedEvent
 
 __all__ = ["AngularV1Adapter"]
@@ -38,5 +39,5 @@ class AngularV1Adapter:
         app.include_router(states_router)
 
     def wrap_ws_event(self, event: PersistedEvent) -> WrappedWsEvent:
-        """Minimal passthrough — WebSocket wrapping is Story 3.2b scope."""
-        return WrappedWsEvent(payload=event.event.model_dump(mode="json"))
+        """Translate a V2 persisted event into a V1 WebSocket envelope."""
+        return wrap_event(event)

--- a/src/akgentic/infra/server/routes/frontend_adapter/angular_v1/_helpers.py
+++ b/src/akgentic/infra/server/routes/frontend_adapter/angular_v1/_helpers.py
@@ -1,0 +1,56 @@
+"""Shared helper functions for the Angular V1 frontend adapter.
+
+Used by both REST route translations (router.py) and WebSocket event
+wrapping (ws.py) to avoid duplicating message classification logic.
+"""
+
+from __future__ import annotations
+
+from akgentic.core.messages.message import Message, ResultMessage, UserMessage
+from akgentic.core.messages.orchestrator import SentMessage
+
+
+def extract_message_content(event: Message) -> str | None:
+    """Extract displayable content from a message event.
+
+    Args:
+        event: The message to extract content from.
+
+    Returns:
+        The displayable content string, or None if no content is available.
+    """
+    if hasattr(event, "content"):
+        return str(event.content)
+    if isinstance(event, SentMessage) and hasattr(event.message, "content"):
+        return str(event.message.content)
+    return None
+
+
+def classify_message_type(event: Message) -> str:
+    """Classify a message event as user/agent/system.
+
+    Args:
+        event: The message to classify.
+
+    Returns:
+        One of "user", "agent", or "system".
+    """
+    if isinstance(event, UserMessage):
+        return "user"
+    if isinstance(event, (ResultMessage, SentMessage)):
+        return "agent"
+    return "system"
+
+
+def get_sender_name(event: Message) -> str:
+    """Extract sender name from a message event.
+
+    Args:
+        event: The message to extract the sender from.
+
+    Returns:
+        The sender name string, or "system" if no sender.
+    """
+    if event.sender is not None:
+        return str(event.sender.name) if hasattr(event.sender, "name") else str(event.sender)
+    return "system"

--- a/src/akgentic/infra/server/routes/frontend_adapter/angular_v1/router.py
+++ b/src/akgentic/infra/server/routes/frontend_adapter/angular_v1/router.py
@@ -11,7 +11,6 @@ from typing import NoReturn, cast
 from fastapi import APIRouter, Depends, HTTPException, Request
 from pydantic import BaseModel, Field
 
-from akgentic.core.messages.message import Message
 from akgentic.core.messages.orchestrator import (
     StateChangedMessage,
 )
@@ -84,35 +83,20 @@ def _parse_uuid(id_str: str) -> uuid.UUID:
         raise HTTPException(status_code=422, detail=f"Invalid UUID: {id_str}") from None
 
 
-def _extract_message_content(event: Message) -> str | None:
-    """Extract displayable content from a message event."""
-    return extract_message_content(event)
-
-
-def _classify_message_type(event: Message) -> str:
-    """Classify a message event as user/agent/system."""
-    return classify_message_type(event)
-
-
-def _get_sender_name(event: Message) -> str:
-    """Extract sender name from a message event."""
-    return get_sender_name(event)
-
-
 def _events_to_v1_messages(events: list[PersistedEvent]) -> list[V1MessageEntry]:
     """Filter and transform persisted events to V1 message entries."""
     result: list[V1MessageEntry] = []
     for ev in events:
-        content = _extract_message_content(ev.event)
+        content = extract_message_content(ev.event)
         if content is None:
             continue
         result.append(
             V1MessageEntry(
                 id=str(ev.event.id),
-                sender=_get_sender_name(ev.event),
+                sender=get_sender_name(ev.event),
                 content=content,
                 timestamp=ev.timestamp.isoformat(),
-                type=_classify_message_type(ev.event),
+                type=classify_message_type(ev.event),
             )
         )
     return result
@@ -270,12 +254,12 @@ def get_llm_context(
         raise HTTPException(status_code=404, detail="Team not found") from None
     result: list[V1LlmContextEntry] = []
     for ev in events:
-        content = _extract_message_content(ev.event)
+        content = extract_message_content(ev.event)
         if content is None:
             continue
         result.append(
             V1LlmContextEntry(
-                role=_classify_message_type(ev.event),
+                role=classify_message_type(ev.event),
                 content=content,
                 timestamp=ev.timestamp.isoformat(),
             )
@@ -302,7 +286,7 @@ def get_states(
         if isinstance(ev.event, StateChangedMessage):
             result.append(
                 V1StateEntry(
-                    agent=_get_sender_name(ev.event),
+                    agent=get_sender_name(ev.event),
                     state=ev.event.state.model_dump(mode="json"),
                     timestamp=ev.timestamp.isoformat(),
                 )

--- a/src/akgentic/infra/server/routes/frontend_adapter/angular_v1/router.py
+++ b/src/akgentic/infra/server/routes/frontend_adapter/angular_v1/router.py
@@ -11,10 +11,14 @@ from typing import NoReturn, cast
 from fastapi import APIRouter, Depends, HTTPException, Request
 from pydantic import BaseModel, Field
 
-from akgentic.core.messages.message import Message, ResultMessage, UserMessage
+from akgentic.core.messages.message import Message
 from akgentic.core.messages.orchestrator import (
-    SentMessage,
     StateChangedMessage,
+)
+from akgentic.infra.server.routes.frontend_adapter.angular_v1._helpers import (
+    classify_message_type,
+    extract_message_content,
+    get_sender_name,
 )
 from akgentic.infra.server.routes.frontend_adapter.angular_v1.models import (
     V1LlmContextEntry,
@@ -82,27 +86,17 @@ def _parse_uuid(id_str: str) -> uuid.UUID:
 
 def _extract_message_content(event: Message) -> str | None:
     """Extract displayable content from a message event."""
-    if hasattr(event, "content"):
-        return str(event.content)
-    if isinstance(event, SentMessage) and hasattr(event.message, "content"):
-        return str(event.message.content)
-    return None
+    return extract_message_content(event)
 
 
 def _classify_message_type(event: Message) -> str:
     """Classify a message event as user/agent/system."""
-    if isinstance(event, UserMessage):
-        return "user"
-    if isinstance(event, (ResultMessage, SentMessage)):
-        return "agent"
-    return "system"
+    return classify_message_type(event)
 
 
 def _get_sender_name(event: Message) -> str:
     """Extract sender name from a message event."""
-    if event.sender is not None:
-        return str(event.sender.name) if hasattr(event.sender, "name") else str(event.sender)
-    return "system"
+    return get_sender_name(event)
 
 
 def _events_to_v1_messages(events: list[PersistedEvent]) -> list[V1MessageEntry]:

--- a/src/akgentic/infra/server/routes/frontend_adapter/angular_v1/ws.py
+++ b/src/akgentic/infra/server/routes/frontend_adapter/angular_v1/ws.py
@@ -69,8 +69,8 @@ def _build_message_envelope(event: Message, timestamp: str) -> dict[str, Any]:
 
     return {
         "type": "message",
-        "id": str(event.id),
-        "sender": get_sender_name(event),
+        "id": str(inner.id),
+        "sender": get_sender_name(inner),
         "content": content,
         "timestamp": timestamp,
         "message_type": message_type,

--- a/src/akgentic/infra/server/routes/frontend_adapter/angular_v1/ws.py
+++ b/src/akgentic/infra/server/routes/frontend_adapter/angular_v1/ws.py
@@ -1,0 +1,157 @@
+"""WebSocket event wrapping for the Angular V1 frontend adapter.
+
+Translates V2 ``PersistedEvent`` instances into V1 envelope format so
+the existing Angular V1 frontend's WebSocket handling works unchanged.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from akgentic.core.messages.message import Message, UserMessage
+from akgentic.core.messages.orchestrator import (
+    ErrorMessage,
+    EventMessage,
+    SentMessage,
+    StateChangedMessage,
+)
+from akgentic.infra.server.routes.frontend_adapter import WrappedWsEvent
+from akgentic.infra.server.routes.frontend_adapter.angular_v1._helpers import (
+    classify_message_type,
+    extract_message_content,
+    get_sender_name,
+)
+from akgentic.team.models import PersistedEvent
+
+
+def _classify_envelope_type(event: Message) -> str:
+    """Map a V2 message to its V1 envelope ``type`` discriminator.
+
+    Args:
+        event: The V2 message from a persisted event.
+
+    Returns:
+        One of ``"message"``, ``"state"``, or ``"tool_update"``.
+    """
+    if isinstance(event, StateChangedMessage):
+        return "state"
+    if isinstance(event, EventMessage):
+        return "tool_update"
+    return "message"
+
+
+def _build_message_envelope(event: Message, timestamp: str) -> dict[str, Any]:
+    """Build a V1 ``type: "message"`` envelope.
+
+    For ``SentMessage`` events the inner message is inspected to extract
+    content and classify the message type correctly.
+
+    Args:
+        event: The V2 message (or SentMessage wrapping one).
+        timestamp: ISO-formatted event timestamp.
+
+    Returns:
+        Dict with V1 message envelope fields.
+    """
+    inner = event.message if isinstance(event, SentMessage) else event
+
+    content = extract_message_content(event)
+    if content is None:
+        content = ""
+
+    if isinstance(event, ErrorMessage):
+        message_type = "system"
+        content = event.exception_value
+    elif isinstance(event, SentMessage):
+        message_type = _classify_inner_message_type(inner)
+    else:
+        message_type = classify_message_type(event)
+
+    return {
+        "type": "message",
+        "id": str(event.id),
+        "sender": get_sender_name(event),
+        "content": content,
+        "timestamp": timestamp,
+        "message_type": message_type,
+    }
+
+
+def _classify_inner_message_type(inner: Message) -> str:
+    """Classify the inner message of a ``SentMessage``.
+
+    Args:
+        inner: The inner message wrapped by SentMessage.
+
+    Returns:
+        One of ``"user"``, ``"agent"``, or ``"system"``.
+    """
+    if isinstance(inner, UserMessage):
+        return "user"
+    return classify_message_type(inner)
+
+
+def _build_state_envelope(event: StateChangedMessage, timestamp: str) -> dict[str, Any]:
+    """Build a V1 ``type: "state"`` envelope.
+
+    Args:
+        event: The state-changed message.
+        timestamp: ISO-formatted event timestamp.
+
+    Returns:
+        Dict with V1 state envelope fields.
+    """
+    return {
+        "type": "state",
+        "agent": get_sender_name(event),
+        "state": event.state.model_dump(mode="json"),
+        "timestamp": timestamp,
+    }
+
+
+def _build_tool_update_envelope(event: EventMessage, timestamp: str) -> dict[str, Any]:
+    """Build a V1 ``type: "tool_update"`` envelope.
+
+    Args:
+        event: The domain/tool event message.
+        timestamp: ISO-formatted event timestamp.
+
+    Returns:
+        Dict with V1 tool_update envelope fields.
+    """
+    if hasattr(event.event, "model_dump"):
+        serialized: Any = event.event.model_dump(mode="json")
+    elif isinstance(event.event, dict):
+        serialized = event.event
+    else:
+        serialized = str(event.event)
+    return {
+        "type": "tool_update",
+        "event": serialized,
+        "timestamp": timestamp,
+    }
+
+
+def wrap_event(event: PersistedEvent) -> WrappedWsEvent:
+    """Translate a V2 persisted event into a V1 WebSocket envelope.
+
+    This is the main entry point called by ``AngularV1Adapter.wrap_ws_event``.
+
+    Args:
+        event: The V2 persisted event to translate.
+
+    Returns:
+        A ``WrappedWsEvent`` containing the V1-formatted payload.
+    """
+    msg = event.event
+    timestamp = event.timestamp.isoformat()
+    envelope_type = _classify_envelope_type(msg)
+
+    if envelope_type == "state" and isinstance(msg, StateChangedMessage):
+        payload = _build_state_envelope(msg, timestamp)
+    elif envelope_type == "tool_update" and isinstance(msg, EventMessage):
+        payload = _build_tool_update_envelope(msg, timestamp)
+    else:
+        payload = _build_message_envelope(msg, timestamp)
+
+    return WrappedWsEvent(payload=payload)

--- a/tests/test_angular_v1_ws.py
+++ b/tests/test_angular_v1_ws.py
@@ -1,0 +1,393 @@
+"""Tests for Angular V1 adapter — WebSocket event wrapping (Story 3.2b)."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+from unittest.mock import MagicMock
+
+from akgentic.core.actor_address import ActorAddress
+from akgentic.core.agent_config import BaseConfig
+from akgentic.core.agent_state import BaseState
+from akgentic.core.messages.message import Message, ResultMessage, UserMessage
+from akgentic.core.messages.orchestrator import (
+    ErrorMessage,
+    EventMessage,
+    ProcessedMessage,
+    ReceivedMessage,
+    SentMessage,
+    StartMessage,
+    StateChangedMessage,
+    StopMessage,
+)
+from akgentic.team.models import PersistedEvent
+
+from akgentic.infra.server.routes.frontend_adapter import WrappedWsEvent
+from akgentic.infra.server.routes.frontend_adapter.angular_v1 import AngularV1Adapter
+from akgentic.infra.server.routes.frontend_adapter.angular_v1.ws import wrap_event
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+_NOW = datetime(2026, 3, 28, 12, 0, 0, tzinfo=UTC)
+_TEAM_ID = uuid.UUID("00000000-0000-0000-0000-000000000001")
+
+
+def _make_sender(name: str = "@Agent") -> MagicMock:
+    """Create a mock ActorAddress with a name attribute."""
+    sender = MagicMock(spec=ActorAddress)
+    sender.name = name
+    return sender
+
+
+def _make_persisted_event(
+    event: Message,
+    team_id: uuid.UUID = _TEAM_ID,
+    sequence: int = 1,
+) -> PersistedEvent:
+    """Create a PersistedEvent fixture."""
+    return PersistedEvent(
+        team_id=team_id,
+        sequence=sequence,
+        event=event,
+        timestamp=_NOW,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Task 4.2: UserMessage → type: "message", message_type: "user"
+# ---------------------------------------------------------------------------
+
+
+class TestWrapUserMessage:
+    """Test UserMessage event wrapping."""
+
+    def test_user_message_envelope_type(self) -> None:
+        """AC #1: UserMessage produces type: 'message' envelope."""
+        msg = UserMessage(content="hello world")
+        msg.sender = _make_sender("@Human")
+        event = _make_persisted_event(msg)
+        result = wrap_event(event)
+        assert result.payload["type"] == "message"
+
+    def test_user_message_fields(self) -> None:
+        """AC #1: UserMessage envelope has V1-compatible fields."""
+        msg = UserMessage(content="hello world")
+        msg.sender = _make_sender("@Human")
+        event = _make_persisted_event(msg)
+        result = wrap_event(event)
+        payload = result.payload
+        assert payload["message_type"] == "user"
+        assert payload["content"] == "hello world"
+        assert payload["sender"] == "@Human"
+        assert payload["timestamp"] == _NOW.isoformat()
+        assert "id" in payload
+
+
+# ---------------------------------------------------------------------------
+# Task 4.3: ResultMessage → type: "message", message_type: "agent"
+# ---------------------------------------------------------------------------
+
+
+class TestWrapResultMessage:
+    """Test ResultMessage event wrapping."""
+
+    def test_result_message_envelope_type(self) -> None:
+        """AC #2: ResultMessage produces type: 'message' envelope."""
+        msg = ResultMessage(content="AI response")
+        msg.sender = _make_sender("@Manager")
+        event = _make_persisted_event(msg)
+        result = wrap_event(event)
+        assert result.payload["type"] == "message"
+
+    def test_result_message_classified_as_agent(self) -> None:
+        """AC #2: ResultMessage message_type is 'agent'."""
+        msg = ResultMessage(content="AI response")
+        msg.sender = _make_sender("@Manager")
+        event = _make_persisted_event(msg)
+        result = wrap_event(event)
+        assert result.payload["message_type"] == "agent"
+        assert result.payload["content"] == "AI response"
+        assert result.payload["sender"] == "@Manager"
+
+
+# ---------------------------------------------------------------------------
+# Task 4.4: SentMessage wrapping UserMessage
+# ---------------------------------------------------------------------------
+
+
+class TestWrapSentMessageUser:
+    """Test SentMessage wrapping a UserMessage."""
+
+    def test_sent_user_message_extracts_inner_content(self) -> None:
+        """AC #1: SentMessage with inner UserMessage extracts content."""
+        inner = UserMessage(content="routed user msg")
+        recipient = _make_sender("@Worker")
+        sent = SentMessage(message=inner, recipient=recipient)
+        sent.sender = _make_sender("@Router")
+        event = _make_persisted_event(sent)
+        result = wrap_event(event)
+        assert result.payload["type"] == "message"
+        assert result.payload["content"] == "routed user msg"
+
+    def test_sent_user_message_type_is_user(self) -> None:
+        """SentMessage wrapping UserMessage has message_type: 'user'."""
+        inner = UserMessage(content="inner")
+        recipient = _make_sender("@Worker")
+        sent = SentMessage(message=inner, recipient=recipient)
+        sent.sender = _make_sender("@Router")
+        event = _make_persisted_event(sent)
+        result = wrap_event(event)
+        assert result.payload["message_type"] == "user"
+
+
+# ---------------------------------------------------------------------------
+# Task 4.5: SentMessage wrapping ResultMessage
+# ---------------------------------------------------------------------------
+
+
+class TestWrapSentMessageResult:
+    """Test SentMessage wrapping a ResultMessage."""
+
+    def test_sent_result_message_type_is_agent(self) -> None:
+        """AC #2: SentMessage wrapping ResultMessage has message_type: 'agent'."""
+        inner = ResultMessage(content="agent reply")
+        recipient = _make_sender("@User")
+        sent = SentMessage(message=inner, recipient=recipient)
+        sent.sender = _make_sender("@Agent")
+        event = _make_persisted_event(sent)
+        result = wrap_event(event)
+        assert result.payload["message_type"] == "agent"
+        assert result.payload["content"] == "agent reply"
+
+
+# ---------------------------------------------------------------------------
+# Task 4.6: StateChangedMessage → type: "state"
+# ---------------------------------------------------------------------------
+
+
+class TestWrapStateChanged:
+    """Test StateChangedMessage event wrapping."""
+
+    def test_state_envelope_type(self) -> None:
+        """AC #3: StateChangedMessage produces type: 'state' envelope."""
+        msg = StateChangedMessage(state=BaseState())
+        msg.sender = _make_sender("@Manager")
+        event = _make_persisted_event(msg)
+        result = wrap_event(event)
+        assert result.payload["type"] == "state"
+
+    def test_state_envelope_fields(self) -> None:
+        """AC #3: State envelope has V1-compatible fields."""
+        msg = StateChangedMessage(state=BaseState())
+        msg.sender = _make_sender("@Manager")
+        event = _make_persisted_event(msg)
+        result = wrap_event(event)
+        payload = result.payload
+        assert payload["agent"] == "@Manager"
+        assert isinstance(payload["state"], dict)
+        assert payload["timestamp"] == _NOW.isoformat()
+
+
+# ---------------------------------------------------------------------------
+# Task 4.7: EventMessage → type: "tool_update"
+# ---------------------------------------------------------------------------
+
+
+class TestWrapEventMessage:
+    """Test EventMessage event wrapping."""
+
+    def test_tool_update_envelope_type(self) -> None:
+        """AC #1: EventMessage produces type: 'tool_update' envelope."""
+        msg = EventMessage(event={"tool_name": "search", "result": "found"})
+        event = _make_persisted_event(msg)
+        result = wrap_event(event)
+        assert result.payload["type"] == "tool_update"
+
+    def test_tool_update_envelope_fields(self) -> None:
+        """EventMessage envelope has event and timestamp fields."""
+        msg = EventMessage(event={"tool_name": "search", "result": "found"})
+        event = _make_persisted_event(msg)
+        result = wrap_event(event)
+        payload = result.payload
+        assert payload["timestamp"] == _NOW.isoformat()
+        assert "event" in payload
+
+    def test_tool_update_with_pydantic_event(self) -> None:
+        """EventMessage with a Pydantic model event serializes via model_dump."""
+        state = BaseState()
+        msg = EventMessage(event=state)
+        event = _make_persisted_event(msg)
+        result = wrap_event(event)
+        assert isinstance(result.payload["event"], dict)
+
+    def test_tool_update_with_string_event(self) -> None:
+        """EventMessage with a plain string event falls back to str()."""
+        msg = EventMessage(event="simple event")
+        event = _make_persisted_event(msg)
+        result = wrap_event(event)
+        assert result.payload["event"] == "simple event"
+
+
+# ---------------------------------------------------------------------------
+# Task 4.8: Non-content events (ReceivedMessage, ProcessedMessage) — fallback
+# ---------------------------------------------------------------------------
+
+
+class TestWrapNonContentEvents:
+    """Test events without displayable content produce valid envelopes."""
+
+    def test_received_message_fallback(self) -> None:
+        """ReceivedMessage produces valid message envelope with empty content."""
+        msg = ReceivedMessage(message_id=uuid.uuid4())
+        event = _make_persisted_event(msg)
+        result = wrap_event(event)
+        assert result.payload["type"] == "message"
+        assert result.payload["message_type"] == "system"
+        assert "content" in result.payload
+
+    def test_processed_message_fallback(self) -> None:
+        """ProcessedMessage produces valid message envelope."""
+        msg = ProcessedMessage(message_id=uuid.uuid4())
+        event = _make_persisted_event(msg)
+        result = wrap_event(event)
+        assert result.payload["type"] == "message"
+        assert result.payload["message_type"] == "system"
+
+    def test_start_message_fallback(self) -> None:
+        """StartMessage produces valid message envelope with system type."""
+        msg = StartMessage(config=BaseConfig())
+        event = _make_persisted_event(msg)
+        result = wrap_event(event)
+        assert result.payload["type"] == "message"
+        assert result.payload["message_type"] == "system"
+
+    def test_stop_message_fallback(self) -> None:
+        """StopMessage produces valid message envelope with system type."""
+        msg = StopMessage()
+        event = _make_persisted_event(msg)
+        result = wrap_event(event)
+        assert result.payload["type"] == "message"
+        assert result.payload["message_type"] == "system"
+
+
+# ---------------------------------------------------------------------------
+# Task 4.9: ErrorMessage → type: "message", message_type: "system"
+# ---------------------------------------------------------------------------
+
+
+class TestWrapErrorMessage:
+    """Test ErrorMessage event wrapping."""
+
+    def test_error_message_type(self) -> None:
+        """ErrorMessage produces type: 'message' envelope."""
+        msg = ErrorMessage(
+            exception_type="ValueError",
+            exception_value="something went wrong",
+        )
+        event = _make_persisted_event(msg)
+        result = wrap_event(event)
+        assert result.payload["type"] == "message"
+
+    def test_error_message_classified_as_system(self) -> None:
+        """ErrorMessage message_type is 'system'."""
+        msg = ErrorMessage(
+            exception_type="ValueError",
+            exception_value="something went wrong",
+        )
+        event = _make_persisted_event(msg)
+        result = wrap_event(event)
+        assert result.payload["message_type"] == "system"
+        assert result.payload["content"] == "something went wrong"
+
+
+# ---------------------------------------------------------------------------
+# Task 4.10: AngularV1Adapter.wrap_ws_event() integration
+# ---------------------------------------------------------------------------
+
+
+class TestAdapterWrapWsEvent:
+    """Test AngularV1Adapter.wrap_ws_event() delegates to ws.wrap_event()."""
+
+    def test_adapter_returns_wrapped_event(self) -> None:
+        """wrap_ws_event returns WrappedWsEvent instance."""
+        adapter = AngularV1Adapter()
+        msg = UserMessage(content="test")
+        event = _make_persisted_event(msg)
+        result = adapter.wrap_ws_event(event)
+        assert isinstance(result, WrappedWsEvent)
+
+    def test_adapter_produces_v1_envelope(self) -> None:
+        """wrap_ws_event produces V1 envelope, not raw passthrough."""
+        adapter = AngularV1Adapter()
+        msg = UserMessage(content="test content")
+        event = _make_persisted_event(msg)
+        result = adapter.wrap_ws_event(event)
+        assert result.payload["type"] == "message"
+        assert result.payload["content"] == "test content"
+        assert result.payload["message_type"] == "user"
+
+    def test_adapter_state_event(self) -> None:
+        """wrap_ws_event produces state envelope for StateChangedMessage."""
+        adapter = AngularV1Adapter()
+        msg = StateChangedMessage(state=BaseState())
+        msg.sender = _make_sender("@Agent")
+        event = _make_persisted_event(msg)
+        result = adapter.wrap_ws_event(event)
+        assert result.payload["type"] == "state"
+        assert result.payload["agent"] == "@Agent"
+
+
+# ---------------------------------------------------------------------------
+# Task 4.11: JSON serialization
+# ---------------------------------------------------------------------------
+
+
+class TestWrappedEventSerialization:
+    """Test that wrapped payloads are JSON-serializable."""
+
+    def test_user_message_json_serializable(self) -> None:
+        """WrappedWsEvent from UserMessage serializes to valid JSON."""
+        msg = UserMessage(content="hello")
+        event = _make_persisted_event(msg)
+        result = wrap_event(event)
+        json_str = result.model_dump_json()
+        assert '"type":"message"' in json_str
+        assert '"content":"hello"' in json_str
+
+    def test_state_message_json_serializable(self) -> None:
+        """WrappedWsEvent from StateChangedMessage serializes to valid JSON."""
+        msg = StateChangedMessage(state=BaseState())
+        msg.sender = _make_sender("@Bot")
+        event = _make_persisted_event(msg)
+        result = wrap_event(event)
+        json_str = result.model_dump_json()
+        assert '"type":"state"' in json_str
+
+    def test_error_message_json_serializable(self) -> None:
+        """WrappedWsEvent from ErrorMessage serializes to valid JSON."""
+        msg = ErrorMessage(
+            exception_type="RuntimeError",
+            exception_value="oops",
+        )
+        event = _make_persisted_event(msg)
+        result = wrap_event(event)
+        json_str = result.model_dump_json()
+        assert '"type":"message"' in json_str
+        assert '"oops"' in json_str
+
+    def test_tool_update_json_serializable(self) -> None:
+        """WrappedWsEvent from EventMessage serializes to valid JSON."""
+        msg = EventMessage(event={"tool": "search"})
+        event = _make_persisted_event(msg)
+        result = wrap_event(event)
+        json_str = result.model_dump_json()
+        assert '"type":"tool_update"' in json_str
+
+    def test_no_sender_defaults_to_system(self) -> None:
+        """Event with no sender uses 'system' as sender name."""
+        msg = UserMessage(content="orphan")
+        event = _make_persisted_event(msg)
+        result = wrap_event(event)
+        assert result.payload["sender"] == "system"

--- a/tests/test_angular_v1_ws.py
+++ b/tests/test_angular_v1_ws.py
@@ -123,6 +123,7 @@ class TestWrapSentMessageUser:
     def test_sent_user_message_extracts_inner_content(self) -> None:
         """AC #1: SentMessage with inner UserMessage extracts content."""
         inner = UserMessage(content="routed user msg")
+        inner.sender = _make_sender("@Human")
         recipient = _make_sender("@Worker")
         sent = SentMessage(message=inner, recipient=recipient)
         sent.sender = _make_sender("@Router")
@@ -130,6 +131,8 @@ class TestWrapSentMessageUser:
         result = wrap_event(event)
         assert result.payload["type"] == "message"
         assert result.payload["content"] == "routed user msg"
+        assert result.payload["sender"] == "@Human"
+        assert result.payload["id"] == str(inner.id)
 
     def test_sent_user_message_type_is_user(self) -> None:
         """SentMessage wrapping UserMessage has message_type: 'user'."""
@@ -153,13 +156,16 @@ class TestWrapSentMessageResult:
     def test_sent_result_message_type_is_agent(self) -> None:
         """AC #2: SentMessage wrapping ResultMessage has message_type: 'agent'."""
         inner = ResultMessage(content="agent reply")
+        inner.sender = _make_sender("@Agent")
         recipient = _make_sender("@User")
         sent = SentMessage(message=inner, recipient=recipient)
-        sent.sender = _make_sender("@Agent")
+        sent.sender = _make_sender("@Router")
         event = _make_persisted_event(sent)
         result = wrap_event(event)
         assert result.payload["message_type"] == "agent"
         assert result.payload["content"] == "agent reply"
+        assert result.payload["sender"] == "@Agent"
+        assert result.payload["id"] == str(inner.id)
 
 
 # ---------------------------------------------------------------------------
@@ -270,6 +276,29 @@ class TestWrapNonContentEvents:
         result = wrap_event(event)
         assert result.payload["type"] == "message"
         assert result.payload["message_type"] == "system"
+
+
+# ---------------------------------------------------------------------------
+# Review fix: SentMessage wrapping non-content message
+# ---------------------------------------------------------------------------
+
+
+class TestWrapSentMessageNonContent:
+    """Test SentMessage wrapping a message without displayable content."""
+
+    def test_sent_start_message_produces_valid_envelope(self) -> None:
+        """SentMessage wrapping StartMessage produces valid envelope with empty content."""
+        inner = StartMessage(config=BaseConfig())
+        inner.sender = _make_sender("@Orchestrator")
+        recipient = _make_sender("@Worker")
+        sent = SentMessage(message=inner, recipient=recipient)
+        sent.sender = _make_sender("@Router")
+        event = _make_persisted_event(sent)
+        result = wrap_event(event)
+        assert result.payload["type"] == "message"
+        assert result.payload["message_type"] == "system"
+        assert result.payload["sender"] == "@Orchestrator"
+        assert result.payload["content"] == ""
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Implement V1 WebSocket event wrapping in `angular_v1/ws.py` — translates V2 `PersistedEvent` instances into V1 envelope format (`message`, `state`, `tool_update`)
- Extract shared helpers (`extract_message_content`, `classify_message_type`, `get_sender_name`) into `_helpers.py` to avoid logic duplication between REST and WebSocket code paths
- Replace passthrough stub in `AngularV1Adapter.wrap_ws_event()` with real wrapping via `ws.wrap_event()`

### Code review fixes
- Fix SentMessage sender/id extraction to use inner message instead of outer wrapper
- Remove thin wrapper indirection in `router.py` — callers use `_helpers` directly
- Add sender/id assertions to SentMessage tests and test for non-content inner messages

## Quality gates
- 281 tests pass (28 new), 94.72% coverage
- mypy strict: clean
- ruff: clean

Closes #27