### PR TITLE
Channel protocols and registry infrastructure

### DIFF
--- a/src/akgentic/infra/__init__.py
+++ b/src/akgentic/infra/__init__.py
@@ -5,11 +5,14 @@ from __future__ import annotations
 from pkgutil import extend_path
 
 from akgentic.infra.adapters import (
+    ChannelConfig,
+    ChannelParserRegistry,
     LocalPlacement,
     LocalServiceRegistry,
     NoAuth,
     TelemetrySubscriber,
     WebSocketEventSubscriber,
+    YamlChannelRegistry,
 )
 from akgentic.infra.protocols import (
     AuthStrategy,
@@ -59,11 +62,14 @@ __all__ = [
     "PlacementStrategy",
     "RecoveryPolicy",
     # Adapters
+    "ChannelConfig",
+    "ChannelParserRegistry",
     "LocalPlacement",
     "LocalServiceRegistry",
     "NoAuth",
     "TelemetrySubscriber",
     "WebSocketEventSubscriber",
+    "YamlChannelRegistry",
     # Server
     "CatalogTeamListResponse",
     "CatalogTeamMember",

--- a/src/akgentic/infra/adapters/__init__.py
+++ b/src/akgentic/infra/adapters/__init__.py
@@ -2,16 +2,24 @@
 
 from __future__ import annotations
 
+from akgentic.infra.adapters.channel_parser_registry import (
+    ChannelConfig,
+    ChannelParserRegistry,
+)
 from akgentic.infra.adapters.local_placement import LocalPlacement
 from akgentic.infra.adapters.local_service_registry import LocalServiceRegistry
 from akgentic.infra.adapters.no_auth import NoAuth
 from akgentic.infra.adapters.telemetry_subscriber import TelemetrySubscriber
 from akgentic.infra.adapters.websocket_subscriber import WebSocketEventSubscriber
+from akgentic.infra.adapters.yaml_channel_registry import YamlChannelRegistry
 
 __all__ = [
+    "ChannelConfig",
+    "ChannelParserRegistry",
     "LocalPlacement",
     "LocalServiceRegistry",
     "NoAuth",
     "TelemetrySubscriber",
     "WebSocketEventSubscriber",
+    "YamlChannelRegistry",
 ]

--- a/src/akgentic/infra/adapters/channel_parser_registry.py
+++ b/src/akgentic/infra/adapters/channel_parser_registry.py
@@ -1,0 +1,89 @@
+"""Channel parser registry — resolves and holds channel parsers/adapters from config."""
+
+from __future__ import annotations
+
+import importlib
+from typing import TYPE_CHECKING
+
+from pydantic import BaseModel, Field
+
+if TYPE_CHECKING:
+    from akgentic.infra.protocols.channels import (
+        ChannelParser,
+        InteractionChannelAdapter,
+    )
+
+
+class ChannelConfig(BaseModel):
+    """Configuration for a single interaction channel."""
+
+    parser_fqcn: str = Field(description="Fully-qualified class name of the ChannelParser")
+    adapter_fqcn: str = Field(
+        description="Fully-qualified class name of the InteractionChannelAdapter"
+    )
+
+
+def import_class(fqcn: str) -> type:
+    """Dynamically import a class by its fully-qualified dotted name.
+
+    Args:
+        fqcn: Fully-qualified class name, e.g. "acme.parsers.WhatsAppParser".
+
+    Returns:
+        The resolved class object.
+
+    Raises:
+        ImportError: If the module or class cannot be found.
+    """
+    module_path, _, class_name = fqcn.rpartition(".")
+    if not module_path:
+        msg = f"Invalid FQCN '{fqcn}': no module path"
+        raise ImportError(msg)
+    try:
+        module = importlib.import_module(module_path)
+    except ModuleNotFoundError as exc:
+        msg = f"Module '{module_path}' not found for FQCN '{fqcn}'"
+        raise ImportError(msg) from exc
+    try:
+        cls: type = getattr(module, class_name)
+        return cls
+    except AttributeError as exc:
+        msg = f"Class '{class_name}' not found in module '{module_path}'"
+        raise ImportError(msg) from exc
+
+
+class ChannelParserRegistry:
+    """Resolves FQCNs from channel configuration and holds parsers/adapters.
+
+    Parsers are indexed by ``channel_name``; adapters are collected into a list
+    for use by ``InteractionChannelDispatcher`` (story 4.2).
+    """
+
+    def __init__(self, channels_config: dict[str, ChannelConfig]) -> None:
+        self._parsers: dict[str, ChannelParser] = {}
+        self._adapters: list[InteractionChannelAdapter] = []
+        self._load(channels_config)
+
+    def _load(self, channels_config: dict[str, ChannelConfig]) -> None:
+        """Resolve FQCNs and instantiate parsers and adapters."""
+        for _channel_key, cfg in channels_config.items():
+            parser_cls = import_class(cfg.parser_fqcn)
+            adapter_cls = import_class(cfg.adapter_fqcn)
+
+            parser: ChannelParser = parser_cls()
+            adapter: InteractionChannelAdapter = adapter_cls()
+
+            self._parsers[parser.channel_name] = parser
+            self._adapters.append(adapter)
+
+    def get_parser(self, channel_name: str) -> ChannelParser | None:
+        """Return the parser for the given channel name, or None."""
+        return self._parsers.get(channel_name)
+
+    def get_adapters(self) -> list[InteractionChannelAdapter]:
+        """Return all resolved adapters."""
+        return list(self._adapters)
+
+    def channel_names(self) -> list[str]:
+        """Return all registered channel names."""
+        return list(self._parsers.keys())

--- a/src/akgentic/infra/adapters/channel_parser_registry.py
+++ b/src/akgentic/infra/adapters/channel_parser_registry.py
@@ -3,15 +3,13 @@
 from __future__ import annotations
 
 import importlib
-from typing import TYPE_CHECKING
 
 from pydantic import BaseModel, Field
 
-if TYPE_CHECKING:
-    from akgentic.infra.protocols.channels import (
-        ChannelParser,
-        InteractionChannelAdapter,
-    )
+from akgentic.infra.protocols.channels import (
+    ChannelParser,
+    InteractionChannelAdapter,
+)
 
 
 class ChannelConfig(BaseModel):
@@ -70,8 +68,20 @@ class ChannelParserRegistry:
             parser_cls = import_class(cfg.parser_fqcn)
             adapter_cls = import_class(cfg.adapter_fqcn)
 
-            parser: ChannelParser = parser_cls()
-            adapter: InteractionChannelAdapter = adapter_cls()
+            parser = parser_cls()
+            if not isinstance(parser, ChannelParser):
+                msg = (
+                    f"Class '{cfg.parser_fqcn}' does not satisfy ChannelParser protocol"
+                )
+                raise TypeError(msg)
+
+            adapter = adapter_cls()
+            if not isinstance(adapter, InteractionChannelAdapter):
+                msg = (
+                    f"Class '{cfg.adapter_fqcn}' does not satisfy "
+                    f"InteractionChannelAdapter protocol"
+                )
+                raise TypeError(msg)
 
             self._parsers[parser.channel_name] = parser
             self._adapters.append(adapter)

--- a/src/akgentic/infra/adapters/yaml_channel_registry.py
+++ b/src/akgentic/infra/adapters/yaml_channel_registry.py
@@ -1,0 +1,73 @@
+"""YAML-backed channel registry — maps channel users to teams via a YAML file."""
+
+from __future__ import annotations
+
+import uuid
+from pathlib import Path
+
+import yaml
+
+
+class YamlChannelRegistry:
+    """Persists channel-user-to-team mappings in a YAML file.
+
+    File format:
+        channel_name:
+          channel_user_id: "team_uuid_string"
+
+    Satisfies the ``ChannelRegistry`` protocol.
+    """
+
+    def __init__(self, registry_path: Path) -> None:
+        self._path = registry_path
+
+    def _load(self) -> dict[str, dict[str, str]]:
+        """Load registry data from YAML, returning empty dict if file missing."""
+        if not self._path.exists():
+            return {}
+        text = self._path.read_text(encoding="utf-8")
+        data = yaml.safe_load(text)
+        if data is None:
+            return {}
+        return dict(data)
+
+    def _save(self, data: dict[str, dict[str, str]]) -> None:
+        """Write registry data to YAML."""
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        self._path.write_text(
+            yaml.safe_dump(data, default_flow_style=False), encoding="utf-8"
+        )
+
+    async def register(
+        self, channel: str, channel_user_id: str, team_id: uuid.UUID
+    ) -> None:
+        """Add a channel-user → team mapping."""
+        data = self._load()
+        if channel not in data:
+            data[channel] = {}
+        data[channel][channel_user_id] = str(team_id)
+        self._save(data)
+
+    async def find_team(
+        self, channel: str, channel_user_id: str
+    ) -> uuid.UUID | None:
+        """Look up the team for a channel user, or return None."""
+        data = self._load()
+        channel_data = data.get(channel)
+        if channel_data is None:
+            return None
+        team_str = channel_data.get(channel_user_id)
+        if team_str is None:
+            return None
+        return uuid.UUID(team_str)
+
+    async def deregister(self, channel: str, channel_user_id: str) -> None:
+        """Remove a channel-user mapping if it exists."""
+        data = self._load()
+        channel_data = data.get(channel)
+        if channel_data is None:
+            return
+        channel_data.pop(channel_user_id, None)
+        if not channel_data:
+            del data[channel]
+        self._save(data)

--- a/src/akgentic/infra/protocols/channels.py
+++ b/src/akgentic/infra/protocols/channels.py
@@ -3,9 +3,12 @@
 from __future__ import annotations
 
 import uuid
-from typing import Protocol
+from typing import TYPE_CHECKING, Protocol, runtime_checkable
 
 from pydantic import BaseModel, Field
+
+if TYPE_CHECKING:
+    from akgentic.core.messages import SentMessage
 
 # Recursive JSON-safe type for webhook payloads — replaces dict[str, Any].
 JsonValue = str | int | float | bool | None | list["JsonValue"] | dict[str, "JsonValue"]
@@ -14,14 +17,13 @@ JsonValue = str | int | float | bool | None | list["JsonValue"] | dict[str, "Jso
 class ChannelMessage(BaseModel):
     """Normalized message from an external interaction channel."""
 
-    channel_id: str = Field(description="Channel identifier (e.g. whatsapp, slack)")
-    sender_id: str = Field(description="Channel-specific sender identifier")
     content: str = Field(description="Message content")
-    metadata: dict[str, str] = Field(
-        default_factory=dict, description="Channel-specific metadata"
-    )
+    channel_user_id: str = Field(description="Channel-specific user identifier")
+    team_id: uuid.UUID | None = Field(default=None, description="Associated team ID")
+    message_id: str | None = Field(default=None, description="Channel-specific message ID")
 
 
+@runtime_checkable
 class InteractionChannelAdapter(Protocol):
     """Delivers outbound messages to humans via an external channel.
 
@@ -29,61 +31,139 @@ class InteractionChannelAdapter(Protocol):
     Called synchronously within the actor thread (see threading model note in architecture).
     """
 
-    def send(self, channel_id: str, message: str) -> None:
-        """Send a message to a human via the external channel.
+    def matches(self, msg: SentMessage) -> bool:
+        """Check if this adapter handles the given message.
 
         Args:
-            channel_id: Channel-specific recipient identifier
-            message: Message content to deliver
+            msg: The outbound message to check.
+
+        Returns:
+            True if this adapter should deliver the message.
+        """
+        ...
+
+    def deliver(self, msg: SentMessage) -> None:
+        """Deliver an outbound message via this channel.
+
+        Args:
+            msg: The message to deliver.
+        """
+        ...
+
+    def on_stop(self, team_id: uuid.UUID) -> None:
+        """Clean up resources when a team stops.
+
+        Args:
+            team_id: The team being stopped.
         """
         ...
 
 
+@runtime_checkable
 class InteractionChannelIngestion(Protocol):
     """Routes inbound human replies from external channels to the correct team's UserProxy."""
 
-    def route_inbound(self, channel_id: str, content: str) -> None:
-        """Route an inbound message from an external channel to the appropriate team.
+    async def route_reply(
+        self,
+        team_id: uuid.UUID,
+        content: str,
+        original_message_id: str | None = None,
+    ) -> None:
+        """Route an inbound reply to an existing team.
 
         Args:
-            channel_id: Channel-specific sender identifier
-            content: Message content from the human
+            team_id: Target team ID.
+            content: Message content from the human.
+            original_message_id: Optional ID of the message being replied to.
+        """
+        ...
+
+    async def initiate_team(
+        self,
+        content: str,
+        channel_user_id: str,
+        catalog_entry_id: str,
+    ) -> uuid.UUID:
+        """Create a new team and send the initial message.
+
+        Args:
+            content: Initial message content.
+            channel_user_id: Channel-specific user identifier.
+            catalog_entry_id: Catalog entry to use for team creation.
+
+        Returns:
+            The newly created team's ID.
         """
         ...
 
 
+@runtime_checkable
 class ChannelParser(Protocol):
     """Parses channel-specific webhook payloads into a common ChannelMessage.
 
     Runs in FastAPI async context — uses async signatures.
     """
 
+    @property
+    def channel_name(self) -> str:
+        """The channel name this parser handles (e.g. 'whatsapp', 'slack')."""
+        ...
+
+    @property
+    def default_catalog_entry(self) -> str:
+        """Default catalog entry ID to use when initiating a new team."""
+        ...
+
     async def parse(self, payload: dict[str, JsonValue]) -> ChannelMessage:
         """Parse a raw webhook payload into a structured channel message.
 
         Args:
-            payload: Raw webhook payload from the external channel
+            payload: Raw webhook payload from the external channel.
 
         Returns:
-            Parsed ChannelMessage with normalized fields
+            Parsed ChannelMessage with normalized fields.
         """
         ...
 
 
+@runtime_checkable
 class ChannelRegistry(Protocol):
     """Maps external channel users to active teams.
 
     Runs in FastAPI async context — uses async signatures.
     """
 
-    async def find_team(self, channel_id: str, sender_id: str) -> uuid.UUID | None:
+    async def register(
+        self, channel: str, channel_user_id: str, team_id: uuid.UUID
+    ) -> None:
+        """Register a mapping from a channel user to a team.
+
+        Args:
+            channel: Channel name (e.g., "whatsapp", "slack").
+            channel_user_id: Channel-specific user identifier.
+            team_id: The team ID to associate.
+        """
+        ...
+
+    async def find_team(
+        self, channel: str, channel_user_id: str
+    ) -> uuid.UUID | None:
         """Find the team associated with a channel user.
 
         Args:
-            channel_id: Channel identifier (e.g., "whatsapp", "slack")
-            sender_id: Channel-specific sender identifier
+            channel: Channel name (e.g., "whatsapp", "slack").
+            channel_user_id: Channel-specific user identifier.
 
         Returns:
-            Team ID if a mapping exists, None otherwise
+            Team ID if a mapping exists, None otherwise.
+        """
+        ...
+
+    async def deregister(self, channel: str, channel_user_id: str) -> None:
+        """Remove the mapping for a channel user.
+
+        Args:
+            channel: Channel name (e.g., "whatsapp", "slack").
+            channel_user_id: Channel-specific user identifier.
         """
         ...

--- a/tests/test_channel_parser_registry.py
+++ b/tests/test_channel_parser_registry.py
@@ -199,6 +199,42 @@ def test_registry_invalid_adapter_fqcn() -> None:
         ChannelParserRegistry(config)
 
 
+class _NotAParser:
+    """Deliberately does NOT satisfy ChannelParser protocol."""
+
+    pass
+
+
+class _NotAnAdapter:
+    """Deliberately does NOT satisfy InteractionChannelAdapter protocol."""
+
+    pass
+
+
+def test_registry_rejects_non_parser_protocol() -> None:
+    """ChannelParserRegistry raises TypeError when class doesn't satisfy ChannelParser."""
+    config = {
+        "bad": ChannelConfig(
+            parser_fqcn="tests.test_channel_parser_registry._NotAParser",
+            adapter_fqcn="tests.test_channel_parser_registry.StubWhatsAppAdapter",
+        ),
+    }
+    with pytest.raises(TypeError, match="ChannelParser"):
+        ChannelParserRegistry(config)
+
+
+def test_registry_rejects_non_adapter_protocol() -> None:
+    """ChannelParserRegistry raises TypeError for non-InteractionChannelAdapter."""
+    config = {
+        "bad": ChannelConfig(
+            parser_fqcn="tests.test_channel_parser_registry.StubWhatsAppParser",
+            adapter_fqcn="tests.test_channel_parser_registry._NotAnAdapter",
+        ),
+    }
+    with pytest.raises(TypeError, match="InteractionChannelAdapter"):
+        ChannelParserRegistry(config)
+
+
 def test_channel_config_is_pydantic_model() -> None:
     """ChannelConfig is a Pydantic model with correct fields."""
     from pydantic import BaseModel

--- a/tests/test_channel_parser_registry.py
+++ b/tests/test_channel_parser_registry.py
@@ -1,0 +1,209 @@
+"""Tests for ChannelParserRegistry — FQCN-based channel parser/adapter resolution."""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+from akgentic.infra.adapters.channel_parser_registry import (
+    ChannelConfig,
+    ChannelParserRegistry,
+    import_class,
+)
+from akgentic.infra.protocols.channels import ChannelMessage, JsonValue
+
+# --- Stub implementations for testing ---
+
+
+class StubWhatsAppParser:
+    """Test stub satisfying ChannelParser protocol."""
+
+    @property
+    def channel_name(self) -> str:
+        return "whatsapp"
+
+    @property
+    def default_catalog_entry(self) -> str:
+        return "default-whatsapp-team"
+
+    async def parse(self, payload: dict[str, JsonValue]) -> ChannelMessage:
+        return ChannelMessage(
+            content=str(payload.get("text", "")),
+            channel_user_id=str(payload.get("from", "")),
+        )
+
+
+class StubWhatsAppAdapter:
+    """Test stub satisfying InteractionChannelAdapter protocol."""
+
+    def matches(self, msg: object) -> bool:
+        return False
+
+    def deliver(self, msg: object) -> None:
+        pass
+
+    def on_stop(self, team_id: uuid.UUID) -> None:
+        pass
+
+
+class StubSlackParser:
+    """Test stub for a second channel parser."""
+
+    @property
+    def channel_name(self) -> str:
+        return "slack"
+
+    @property
+    def default_catalog_entry(self) -> str:
+        return "default-slack-team"
+
+    async def parse(self, payload: dict[str, JsonValue]) -> ChannelMessage:
+        return ChannelMessage(
+            content=str(payload.get("text", "")),
+            channel_user_id=str(payload.get("user", "")),
+        )
+
+
+class StubSlackAdapter:
+    """Test stub for a second channel adapter."""
+
+    def matches(self, msg: object) -> bool:
+        return False
+
+    def deliver(self, msg: object) -> None:
+        pass
+
+    def on_stop(self, team_id: uuid.UUID) -> None:
+        pass
+
+
+# --- import_class tests ---
+
+
+def test_import_class_resolves_known_class() -> None:
+    """import_class() resolves a known class from its FQCN."""
+    cls = import_class("akgentic.infra.protocols.channels.ChannelMessage")
+    assert cls is ChannelMessage
+
+
+def test_import_class_invalid_fqcn_no_dot() -> None:
+    """import_class() raises ImportError for FQCN without a module path."""
+    with pytest.raises(ImportError, match="Invalid FQCN"):
+        import_class("NoDots")
+
+
+def test_import_class_module_not_found() -> None:
+    """import_class() raises ImportError for non-existent module."""
+    with pytest.raises(ImportError, match="not found"):
+        import_class("nonexistent.module.SomeClass")
+
+
+def test_import_class_class_not_found() -> None:
+    """import_class() raises ImportError for missing class in valid module."""
+    with pytest.raises(ImportError, match="not found"):
+        import_class("akgentic.infra.protocols.channels.NonExistentClass")
+
+
+# --- ChannelParserRegistry tests ---
+
+
+def _make_config() -> dict[str, ChannelConfig]:
+    """Build a channels config pointing to test stubs in this module."""
+    this_module = "tests.test_channel_parser_registry"
+    return {
+        "whatsapp": ChannelConfig(
+            parser_fqcn=f"{this_module}.StubWhatsAppParser",
+            adapter_fqcn=f"{this_module}.StubWhatsAppAdapter",
+        ),
+        "slack": ChannelConfig(
+            parser_fqcn=f"{this_module}.StubSlackParser",
+            adapter_fqcn=f"{this_module}.StubSlackAdapter",
+        ),
+    }
+
+
+def test_registry_loads_parsers_and_adapters() -> None:
+    """ChannelParserRegistry resolves parsers and adapters from config."""
+    registry = ChannelParserRegistry(_make_config())
+    assert len(registry.channel_names()) == 2
+    assert len(registry.get_adapters()) == 2
+
+
+def test_get_parser_returns_correct_parser() -> None:
+    """get_parser() returns the parser indexed by channel_name."""
+    registry = ChannelParserRegistry(_make_config())
+    parser = registry.get_parser("whatsapp")
+    assert parser is not None
+    assert parser.channel_name == "whatsapp"
+
+
+def test_get_parser_returns_none_for_unknown() -> None:
+    """get_parser() returns None for an unregistered channel name."""
+    registry = ChannelParserRegistry(_make_config())
+    assert registry.get_parser("telegram") is None
+
+
+def test_get_adapters_returns_all_adapters() -> None:
+    """get_adapters() returns all resolved adapter instances."""
+    registry = ChannelParserRegistry(_make_config())
+    adapters = registry.get_adapters()
+    assert len(adapters) == 2
+    # Verify they are distinct instances
+    assert adapters[0] is not adapters[1]
+
+
+def test_get_adapters_returns_copy() -> None:
+    """get_adapters() returns a copy, not the internal list."""
+    registry = ChannelParserRegistry(_make_config())
+    adapters = registry.get_adapters()
+    adapters.clear()
+    assert len(registry.get_adapters()) == 2
+
+
+def test_channel_names_returns_all_names() -> None:
+    """channel_names() returns all registered channel names."""
+    registry = ChannelParserRegistry(_make_config())
+    names = registry.channel_names()
+    assert sorted(names) == ["slack", "whatsapp"]
+
+
+def test_registry_with_empty_config() -> None:
+    """ChannelParserRegistry with empty config has no parsers or adapters."""
+    registry = ChannelParserRegistry({})
+    assert registry.channel_names() == []
+    assert registry.get_adapters() == []
+
+
+def test_registry_invalid_parser_fqcn() -> None:
+    """ChannelParserRegistry raises ImportError for invalid parser FQCN."""
+    config = {
+        "bad": ChannelConfig(
+            parser_fqcn="nonexistent.module.BadParser",
+            adapter_fqcn="tests.test_channel_parser_registry.StubWhatsAppAdapter",
+        ),
+    }
+    with pytest.raises(ImportError):
+        ChannelParserRegistry(config)
+
+
+def test_registry_invalid_adapter_fqcn() -> None:
+    """ChannelParserRegistry raises ImportError for invalid adapter FQCN."""
+    config = {
+        "bad": ChannelConfig(
+            parser_fqcn="tests.test_channel_parser_registry.StubWhatsAppParser",
+            adapter_fqcn="nonexistent.module.BadAdapter",
+        ),
+    }
+    with pytest.raises(ImportError):
+        ChannelParserRegistry(config)
+
+
+def test_channel_config_is_pydantic_model() -> None:
+    """ChannelConfig is a Pydantic model with correct fields."""
+    from pydantic import BaseModel
+
+    assert issubclass(ChannelConfig, BaseModel)
+    fields = ChannelConfig.model_fields
+    assert "parser_fqcn" in fields
+    assert "adapter_fqcn" in fields

--- a/tests/test_protocols.py
+++ b/tests/test_protocols.py
@@ -73,6 +73,9 @@ def test_health_monitor_has_check_health() -> None:
     assert len(sig.parameters) == 1
 
 
+# --- InteractionChannelAdapter ---
+
+
 def test_interaction_channel_adapter_is_protocol() -> None:
     """InteractionChannelAdapter uses typing.Protocol base."""
     from akgentic.infra.protocols import InteractionChannelAdapter
@@ -80,14 +83,75 @@ def test_interaction_channel_adapter_is_protocol() -> None:
     assert Protocol in inspect.getmro(InteractionChannelAdapter)
 
 
-def test_interaction_channel_adapter_has_send() -> None:
-    """InteractionChannelAdapter defines send with channel_id and message parameters."""
+def test_interaction_channel_adapter_has_matches() -> None:
+    """InteractionChannelAdapter defines matches with msg parameter."""
     from akgentic.infra.protocols import InteractionChannelAdapter
 
-    assert hasattr(InteractionChannelAdapter, "send")
-    sig = inspect.signature(InteractionChannelAdapter.send)
-    assert "channel_id" in sig.parameters
-    assert "message" in sig.parameters
+    assert hasattr(InteractionChannelAdapter, "matches")
+    sig = inspect.signature(InteractionChannelAdapter.matches)
+    assert "msg" in sig.parameters
+
+
+def test_interaction_channel_adapter_has_deliver() -> None:
+    """InteractionChannelAdapter defines deliver with msg parameter."""
+    from akgentic.infra.protocols import InteractionChannelAdapter
+
+    assert hasattr(InteractionChannelAdapter, "deliver")
+    sig = inspect.signature(InteractionChannelAdapter.deliver)
+    assert "msg" in sig.parameters
+
+
+def test_interaction_channel_adapter_has_on_stop() -> None:
+    """InteractionChannelAdapter defines on_stop with team_id parameter."""
+    from akgentic.infra.protocols import InteractionChannelAdapter
+
+    assert hasattr(InteractionChannelAdapter, "on_stop")
+    sig = inspect.signature(InteractionChannelAdapter.on_stop)
+    assert "team_id" in sig.parameters
+
+
+def test_interaction_channel_adapter_matches_returns_bool() -> None:
+    """InteractionChannelAdapter.matches has bool return annotation."""
+    from akgentic.infra.protocols import InteractionChannelAdapter
+
+    sig = inspect.signature(InteractionChannelAdapter.matches)
+    assert sig.return_annotation is bool or sig.return_annotation == "bool"
+
+
+def test_interaction_channel_adapter_deliver_returns_none() -> None:
+    """InteractionChannelAdapter.deliver has None return annotation."""
+    from akgentic.infra.protocols import InteractionChannelAdapter
+
+    sig = inspect.signature(InteractionChannelAdapter.deliver)
+    assert sig.return_annotation is None or sig.return_annotation == "None"
+
+
+def test_interaction_channel_adapter_on_stop_returns_none() -> None:
+    """InteractionChannelAdapter.on_stop returns None."""
+    from akgentic.infra.protocols import InteractionChannelAdapter
+
+    hints = get_type_hints(InteractionChannelAdapter.on_stop)
+    assert hints["return"] is type(None)
+
+
+def test_interaction_channel_adapter_structural_subtyping() -> None:
+    """A concrete class satisfying InteractionChannelAdapter is recognized."""
+    from akgentic.infra.protocols import InteractionChannelAdapter
+
+    class FakeAdapter:
+        def matches(self, msg: object) -> bool:
+            return True
+
+        def deliver(self, msg: object) -> None:
+            pass
+
+        def on_stop(self, team_id: uuid.UUID) -> None:
+            pass
+
+    assert isinstance(FakeAdapter(), InteractionChannelAdapter)
+
+
+# --- InteractionChannelIngestion ---
 
 
 def test_interaction_channel_ingestion_is_protocol() -> None:
@@ -97,14 +161,71 @@ def test_interaction_channel_ingestion_is_protocol() -> None:
     assert Protocol in inspect.getmro(InteractionChannelIngestion)
 
 
-def test_interaction_channel_ingestion_has_route_inbound() -> None:
-    """InteractionChannelIngestion defines route_inbound with channel_id and content."""
+def test_interaction_channel_ingestion_has_route_reply() -> None:
+    """InteractionChannelIngestion defines async route_reply."""
     from akgentic.infra.protocols import InteractionChannelIngestion
 
-    assert hasattr(InteractionChannelIngestion, "route_inbound")
-    sig = inspect.signature(InteractionChannelIngestion.route_inbound)
-    assert "channel_id" in sig.parameters
+    assert hasattr(InteractionChannelIngestion, "route_reply")
+    sig = inspect.signature(InteractionChannelIngestion.route_reply)
+    assert "team_id" in sig.parameters
     assert "content" in sig.parameters
+    assert "original_message_id" in sig.parameters
+    assert inspect.iscoroutinefunction(InteractionChannelIngestion.route_reply)
+
+
+def test_interaction_channel_ingestion_has_initiate_team() -> None:
+    """InteractionChannelIngestion defines async initiate_team."""
+    from akgentic.infra.protocols import InteractionChannelIngestion
+
+    assert hasattr(InteractionChannelIngestion, "initiate_team")
+    sig = inspect.signature(InteractionChannelIngestion.initiate_team)
+    assert "content" in sig.parameters
+    assert "channel_user_id" in sig.parameters
+    assert "catalog_entry_id" in sig.parameters
+    assert inspect.iscoroutinefunction(InteractionChannelIngestion.initiate_team)
+
+
+def test_interaction_channel_ingestion_route_reply_returns_none() -> None:
+    """InteractionChannelIngestion.route_reply returns None."""
+    from akgentic.infra.protocols import InteractionChannelIngestion
+
+    hints = get_type_hints(InteractionChannelIngestion.route_reply)
+    assert hints["return"] is type(None)
+
+
+def test_interaction_channel_ingestion_initiate_team_returns_uuid() -> None:
+    """InteractionChannelIngestion.initiate_team returns UUID."""
+    from akgentic.infra.protocols import InteractionChannelIngestion
+
+    hints = get_type_hints(InteractionChannelIngestion.initiate_team)
+    assert hints["return"] is uuid.UUID
+
+
+def test_interaction_channel_ingestion_structural_subtyping() -> None:
+    """A concrete class satisfying InteractionChannelIngestion is recognized."""
+    from akgentic.infra.protocols import InteractionChannelIngestion
+
+    class FakeIngestion:
+        async def route_reply(
+            self,
+            team_id: uuid.UUID,
+            content: str,
+            original_message_id: str | None = None,
+        ) -> None:
+            pass
+
+        async def initiate_team(
+            self,
+            content: str,
+            channel_user_id: str,
+            catalog_entry_id: str,
+        ) -> uuid.UUID:
+            return uuid.uuid4()
+
+    assert isinstance(FakeIngestion(), InteractionChannelIngestion)
+
+
+# --- ChannelParser ---
 
 
 def test_channel_parser_is_protocol() -> None:
@@ -124,6 +245,31 @@ def test_channel_parser_has_parse() -> None:
     assert inspect.iscoroutinefunction(ChannelParser.parse)
 
 
+def test_channel_parser_has_channel_name_property() -> None:
+    """ChannelParser defines channel_name property."""
+    from akgentic.infra.protocols import ChannelParser
+
+    assert hasattr(ChannelParser, "channel_name")
+
+
+def test_channel_parser_has_default_catalog_entry_property() -> None:
+    """ChannelParser defines default_catalog_entry property."""
+    from akgentic.infra.protocols import ChannelParser
+
+    assert hasattr(ChannelParser, "default_catalog_entry")
+
+
+def test_channel_parser_return_type() -> None:
+    """ChannelParser.parse returns ChannelMessage."""
+    from akgentic.infra.protocols import ChannelMessage, ChannelParser
+
+    hints = get_type_hints(ChannelParser.parse)
+    assert hints["return"] is ChannelMessage
+
+
+# --- ChannelRegistry ---
+
+
 def test_channel_registry_is_protocol() -> None:
     """ChannelRegistry uses typing.Protocol base."""
     from akgentic.infra.protocols import ChannelRegistry
@@ -131,15 +277,137 @@ def test_channel_registry_is_protocol() -> None:
     assert Protocol in inspect.getmro(ChannelRegistry)
 
 
+def test_channel_registry_has_register() -> None:
+    """ChannelRegistry defines async register with channel, channel_user_id, team_id."""
+    from akgentic.infra.protocols import ChannelRegistry
+
+    assert hasattr(ChannelRegistry, "register")
+    sig = inspect.signature(ChannelRegistry.register)
+    assert "channel" in sig.parameters
+    assert "channel_user_id" in sig.parameters
+    assert "team_id" in sig.parameters
+    assert inspect.iscoroutinefunction(ChannelRegistry.register)
+
+
 def test_channel_registry_has_find_team() -> None:
-    """ChannelRegistry defines async find_team with channel_id and sender_id."""
+    """ChannelRegistry defines async find_team with channel and channel_user_id."""
     from akgentic.infra.protocols import ChannelRegistry
 
     assert hasattr(ChannelRegistry, "find_team")
     sig = inspect.signature(ChannelRegistry.find_team)
-    assert "channel_id" in sig.parameters
-    assert "sender_id" in sig.parameters
+    assert "channel" in sig.parameters
+    assert "channel_user_id" in sig.parameters
     assert inspect.iscoroutinefunction(ChannelRegistry.find_team)
+
+
+def test_channel_registry_has_deregister() -> None:
+    """ChannelRegistry defines async deregister with channel and channel_user_id."""
+    from akgentic.infra.protocols import ChannelRegistry
+
+    assert hasattr(ChannelRegistry, "deregister")
+    sig = inspect.signature(ChannelRegistry.deregister)
+    assert "channel" in sig.parameters
+    assert "channel_user_id" in sig.parameters
+    assert inspect.iscoroutinefunction(ChannelRegistry.deregister)
+
+
+def test_channel_registry_find_team_return_type() -> None:
+    """ChannelRegistry.find_team returns uuid.UUID | None."""
+    from akgentic.infra.protocols import ChannelRegistry
+
+    hints = get_type_hints(ChannelRegistry.find_team)
+    assert hints["return"] == uuid.UUID | None
+
+
+def test_channel_registry_register_returns_none() -> None:
+    """ChannelRegistry.register returns None."""
+    from akgentic.infra.protocols import ChannelRegistry
+
+    hints = get_type_hints(ChannelRegistry.register)
+    assert hints["return"] is type(None)
+
+
+def test_channel_registry_deregister_returns_none() -> None:
+    """ChannelRegistry.deregister returns None."""
+    from akgentic.infra.protocols import ChannelRegistry
+
+    hints = get_type_hints(ChannelRegistry.deregister)
+    assert hints["return"] is type(None)
+
+
+def test_channel_registry_structural_subtyping() -> None:
+    """A concrete class satisfying ChannelRegistry is recognized."""
+    from akgentic.infra.protocols import ChannelRegistry
+
+    class FakeRegistry:
+        async def register(
+            self, channel: str, channel_user_id: str, team_id: uuid.UUID
+        ) -> None:
+            pass
+
+        async def find_team(
+            self, channel: str, channel_user_id: str
+        ) -> uuid.UUID | None:
+            return None
+
+        async def deregister(self, channel: str, channel_user_id: str) -> None:
+            pass
+
+    assert isinstance(FakeRegistry(), ChannelRegistry)
+
+
+# --- ChannelMessage ---
+
+
+def test_channel_message_is_pydantic_model() -> None:
+    """ChannelMessage is a Pydantic BaseModel with correct fields."""
+    from pydantic import BaseModel
+
+    from akgentic.infra.protocols import ChannelMessage
+
+    assert issubclass(ChannelMessage, BaseModel)
+    fields = ChannelMessage.model_fields
+    assert "content" in fields
+    assert "channel_user_id" in fields
+    assert "team_id" in fields
+    assert "message_id" in fields
+
+
+def test_channel_message_field_descriptions() -> None:
+    """ChannelMessage fields have descriptions."""
+    from akgentic.infra.protocols import ChannelMessage
+
+    for name, field_info in ChannelMessage.model_fields.items():
+        assert field_info.description is not None, f"Field {name} missing description"
+
+
+def test_channel_message_optional_defaults() -> None:
+    """ChannelMessage team_id and message_id default to None."""
+    from akgentic.infra.protocols import ChannelMessage
+
+    msg = ChannelMessage(content="hello", channel_user_id="u1")
+    assert msg.team_id is None
+    assert msg.message_id is None
+
+
+def test_channel_message_with_all_fields() -> None:
+    """ChannelMessage can be created with all fields."""
+    from akgentic.infra.protocols import ChannelMessage
+
+    tid = uuid.uuid4()
+    msg = ChannelMessage(
+        content="hello",
+        channel_user_id="u1",
+        team_id=tid,
+        message_id="msg-123",
+    )
+    assert msg.content == "hello"
+    assert msg.channel_user_id == "u1"
+    assert msg.team_id == tid
+    assert msg.message_id == "msg-123"
+
+
+# --- Non-channel protocols (unchanged) ---
 
 
 def test_placement_strategy_return_type() -> None:
@@ -172,65 +440,3 @@ def test_health_monitor_return_type() -> None:
 
     hints = get_type_hints(HealthMonitor.check_health)
     assert hints["return"] == list[uuid.UUID]
-
-
-def test_interaction_channel_adapter_return_type() -> None:
-    """InteractionChannelAdapter.send returns None."""
-    from akgentic.infra.protocols import InteractionChannelAdapter
-
-    hints = get_type_hints(InteractionChannelAdapter.send)
-    assert hints["return"] is type(None)
-
-
-def test_interaction_channel_ingestion_return_type() -> None:
-    """InteractionChannelIngestion.route_inbound returns None."""
-    from akgentic.infra.protocols import InteractionChannelIngestion
-
-    hints = get_type_hints(InteractionChannelIngestion.route_inbound)
-    assert hints["return"] is type(None)
-
-
-def test_channel_parser_return_type() -> None:
-    """ChannelParser.parse returns ChannelMessage."""
-    from akgentic.infra.protocols import ChannelMessage, ChannelParser
-
-    hints = get_type_hints(ChannelParser.parse)
-    assert hints["return"] is ChannelMessage
-
-
-def test_channel_registry_return_type() -> None:
-    """ChannelRegistry.find_team returns uuid.UUID | None."""
-    from akgentic.infra.protocols import ChannelRegistry
-
-    hints = get_type_hints(ChannelRegistry.find_team)
-    assert hints["return"] == uuid.UUID | None
-
-
-def test_channel_message_is_pydantic_model() -> None:
-    """ChannelMessage is a Pydantic BaseModel with correct fields."""
-    from pydantic import BaseModel
-
-    from akgentic.infra.protocols import ChannelMessage
-
-    assert issubclass(ChannelMessage, BaseModel)
-    fields = ChannelMessage.model_fields
-    assert "channel_id" in fields
-    assert "sender_id" in fields
-    assert "content" in fields
-    assert "metadata" in fields
-
-
-def test_channel_message_field_descriptions() -> None:
-    """ChannelMessage fields have descriptions."""
-    from akgentic.infra.protocols import ChannelMessage
-
-    for name, field_info in ChannelMessage.model_fields.items():
-        assert field_info.description is not None, f"Field {name} missing description"
-
-
-def test_channel_message_metadata_defaults_empty() -> None:
-    """ChannelMessage metadata defaults to empty dict."""
-    from akgentic.infra.protocols import ChannelMessage
-
-    msg = ChannelMessage(channel_id="slack", sender_id="u1", content="hello")
-    assert msg.metadata == {}

--- a/tests/test_protocols.py
+++ b/tests/test_protocols.py
@@ -267,6 +267,25 @@ def test_channel_parser_return_type() -> None:
     assert hints["return"] is ChannelMessage
 
 
+def test_channel_parser_structural_subtyping() -> None:
+    """A concrete class satisfying ChannelParser is recognized."""
+    from akgentic.infra.protocols import ChannelMessage, ChannelParser
+
+    class FakeParser:
+        @property
+        def channel_name(self) -> str:
+            return "fake"
+
+        @property
+        def default_catalog_entry(self) -> str:
+            return "default-fake"
+
+        async def parse(self, payload: dict[str, object]) -> ChannelMessage:
+            return ChannelMessage(content="", channel_user_id="")
+
+    assert isinstance(FakeParser(), ChannelParser)
+
+
 # --- ChannelRegistry ---
 
 

--- a/tests/test_yaml_channel_registry.py
+++ b/tests/test_yaml_channel_registry.py
@@ -1,0 +1,160 @@
+"""Tests for YamlChannelRegistry — YAML-backed channel-user-to-team mapping."""
+
+from __future__ import annotations
+
+import uuid
+from pathlib import Path
+
+import pytest
+import yaml
+
+from akgentic.infra.adapters.yaml_channel_registry import YamlChannelRegistry
+from akgentic.infra.protocols import ChannelRegistry
+
+
+@pytest.fixture()
+def registry_path(tmp_path: Path) -> Path:
+    """Return a temporary path for the registry YAML file."""
+    return tmp_path / "channel_registry.yaml"
+
+
+@pytest.fixture()
+def registry(registry_path: Path) -> YamlChannelRegistry:
+    """Return a fresh YamlChannelRegistry instance."""
+    return YamlChannelRegistry(registry_path)
+
+
+async def test_satisfies_channel_registry_protocol() -> None:
+    """YamlChannelRegistry satisfies the ChannelRegistry protocol."""
+    assert isinstance(YamlChannelRegistry(Path("/tmp/fake.yaml")), ChannelRegistry)
+
+
+async def test_register_creates_mapping(
+    registry: YamlChannelRegistry, registry_path: Path
+) -> None:
+    """register() persists a channel-user → team mapping to YAML."""
+    team_id = uuid.uuid4()
+    await registry.register("whatsapp", "+1234567890", team_id)
+
+    data = yaml.safe_load(registry_path.read_text())  # noqa: ASYNC240
+    assert data["whatsapp"]["+1234567890"] == str(team_id)
+
+
+async def test_find_team_returns_uuid(registry: YamlChannelRegistry) -> None:
+    """find_team() returns the UUID for a registered channel user."""
+    team_id = uuid.uuid4()
+    await registry.register("slack", "U12345", team_id)
+
+    result = await registry.find_team("slack", "U12345")
+    assert result == team_id
+
+
+async def test_find_team_returns_none_for_unknown_channel(
+    registry: YamlChannelRegistry,
+) -> None:
+    """find_team() returns None for an unregistered channel."""
+    result = await registry.find_team("whatsapp", "+9999999999")
+    assert result is None
+
+
+async def test_find_team_returns_none_for_unknown_user(
+    registry: YamlChannelRegistry,
+) -> None:
+    """find_team() returns None when channel exists but user doesn't."""
+    await registry.register("slack", "U11111", uuid.uuid4())
+
+    result = await registry.find_team("slack", "U99999")
+    assert result is None
+
+
+async def test_deregister_removes_mapping(registry: YamlChannelRegistry) -> None:
+    """deregister() removes the mapping for a channel user."""
+    team_id = uuid.uuid4()
+    await registry.register("whatsapp", "+1234567890", team_id)
+    await registry.deregister("whatsapp", "+1234567890")
+
+    result = await registry.find_team("whatsapp", "+1234567890")
+    assert result is None
+
+
+async def test_deregister_unknown_channel_is_noop(
+    registry: YamlChannelRegistry,
+) -> None:
+    """deregister() on an unknown channel does not raise."""
+    await registry.deregister("nonexistent", "nobody")
+
+
+async def test_deregister_unknown_user_is_noop(
+    registry: YamlChannelRegistry,
+) -> None:
+    """deregister() for unknown user in existing channel does not raise."""
+    await registry.register("slack", "U11111", uuid.uuid4())
+    await registry.deregister("slack", "U99999")
+
+
+async def test_missing_file_treated_as_empty(registry_path: Path) -> None:
+    """A non-existent YAML file is treated as an empty registry."""
+    reg = YamlChannelRegistry(registry_path)
+    result = await reg.find_team("whatsapp", "+1234567890")
+    assert result is None
+
+
+async def test_empty_file_treated_as_empty(registry_path: Path) -> None:
+    """An empty YAML file is treated as an empty registry."""
+    registry_path.write_text("")  # noqa: ASYNC240
+    reg = YamlChannelRegistry(registry_path)
+    result = await reg.find_team("whatsapp", "+1234567890")
+    assert result is None
+
+
+async def test_multiple_channels(registry: YamlChannelRegistry) -> None:
+    """Multiple channels with different users are tracked independently."""
+    t1 = uuid.uuid4()
+    t2 = uuid.uuid4()
+    await registry.register("whatsapp", "+111", t1)
+    await registry.register("slack", "U222", t2)
+
+    assert await registry.find_team("whatsapp", "+111") == t1
+    assert await registry.find_team("slack", "U222") == t2
+
+
+async def test_multiple_users_same_channel(registry: YamlChannelRegistry) -> None:
+    """Multiple users in the same channel each get their own mapping."""
+    t1 = uuid.uuid4()
+    t2 = uuid.uuid4()
+    await registry.register("slack", "U111", t1)
+    await registry.register("slack", "U222", t2)
+
+    assert await registry.find_team("slack", "U111") == t1
+    assert await registry.find_team("slack", "U222") == t2
+
+
+async def test_uuid_serialization_roundtrip(registry: YamlChannelRegistry) -> None:
+    """UUID is serialized to string and deserialized back correctly."""
+    team_id = uuid.UUID("550e8400-e29b-41d4-a716-446655440000")
+    await registry.register("whatsapp", "+1234567890", team_id)
+
+    result = await registry.find_team("whatsapp", "+1234567890")
+    assert result == team_id
+    assert isinstance(result, uuid.UUID)
+
+
+async def test_deregister_removes_empty_channel_section(
+    registry: YamlChannelRegistry, registry_path: Path
+) -> None:
+    """Deregistering the last user in a channel removes the channel section."""
+    await registry.register("whatsapp", "+111", uuid.uuid4())
+    await registry.deregister("whatsapp", "+111")
+
+    data = yaml.safe_load(registry_path.read_text())  # noqa: ASYNC240
+    assert data is None or "whatsapp" not in (data or {})
+
+
+async def test_register_overwrites_existing(registry: YamlChannelRegistry) -> None:
+    """Re-registering the same user updates the team ID."""
+    t1 = uuid.uuid4()
+    t2 = uuid.uuid4()
+    await registry.register("slack", "U111", t1)
+    await registry.register("slack", "U111", t2)
+
+    assert await registry.find_team("slack", "U111") == t2


### PR DESCRIPTION
## Summary

- Updated all 5 channel protocols in `protocols/channels.py` to match architecture spec (InteractionChannelAdapter, ChannelParser, InteractionChannelIngestion, ChannelRegistry, ChannelMessage)
- Added `@runtime_checkable` to all channel protocols for structural subtyping
- Created `YamlChannelRegistry` (Community tier) with YAML-backed channel-user-to-team mapping
- Created `ChannelParserRegistry` with FQCN resolution via `import_class()`, parser indexing by channel name, adapter list for dispatcher
- Created `ChannelConfig` Pydantic model for channel configuration
- Added runtime protocol validation in `ChannelParserRegistry` matching the `load_frontend_adapter()` pattern
- Full test suite: 329 passed, 95.27% coverage, mypy clean, ruff clean

Closes #31