### PR TITLE
Outbound Dispatch — InteractionChannelDispatcher & TelemetrySubscriber

### DIFF
--- a/src/akgentic/infra/__init__.py
+++ b/src/akgentic/infra/__init__.py
@@ -7,6 +7,7 @@ from pkgutil import extend_path
 from akgentic.infra.adapters import (
     ChannelConfig,
     ChannelParserRegistry,
+    InteractionChannelDispatcher,
     LocalPlacement,
     LocalServiceRegistry,
     NoAuth,
@@ -64,6 +65,7 @@ __all__ = [
     # Adapters
     "ChannelConfig",
     "ChannelParserRegistry",
+    "InteractionChannelDispatcher",
     "LocalPlacement",
     "LocalServiceRegistry",
     "NoAuth",

--- a/src/akgentic/infra/adapters/__init__.py
+++ b/src/akgentic/infra/adapters/__init__.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from akgentic.infra.adapters.channel_dispatcher import InteractionChannelDispatcher
 from akgentic.infra.adapters.channel_parser_registry import (
     ChannelConfig,
     ChannelParserRegistry,
@@ -16,6 +17,7 @@ from akgentic.infra.adapters.yaml_channel_registry import YamlChannelRegistry
 __all__ = [
     "ChannelConfig",
     "ChannelParserRegistry",
+    "InteractionChannelDispatcher",
     "LocalPlacement",
     "LocalServiceRegistry",
     "NoAuth",

--- a/src/akgentic/infra/adapters/channel_dispatcher.py
+++ b/src/akgentic/infra/adapters/channel_dispatcher.py
@@ -27,7 +27,7 @@ class InteractionChannelDispatcher:
     def __init__(
         self, adapters: list[InteractionChannelAdapter], team_id: uuid.UUID
     ) -> None:
-        self._adapters = adapters
+        self._adapters = list(adapters)
         self._team_id = team_id
         self._restoring = False
 

--- a/src/akgentic/infra/adapters/channel_dispatcher.py
+++ b/src/akgentic/infra/adapters/channel_dispatcher.py
@@ -1,0 +1,59 @@
+"""InteractionChannelDispatcher — per-team outbound message dispatcher."""
+
+from __future__ import annotations
+
+import uuid
+from typing import TYPE_CHECKING
+
+from akgentic.core.messages import SentMessage
+
+if TYPE_CHECKING:
+    from akgentic.core.messages import Message
+    from akgentic.infra.protocols.channels import InteractionChannelAdapter
+
+
+class InteractionChannelDispatcher:
+    """Routes outbound SentMessage events to the first matching channel adapter.
+
+    Satisfies the EventSubscriber protocol from akgentic.core.orchestrator
+    via structural subtyping. Each team gets its own dispatcher instance
+    with its own ordered adapter list.
+
+    First-match dispatch: iterates adapters, calls matches() on each,
+    and delivers to the first match only. If no adapter matches, the
+    message is silently skipped (web channel handles it via WebSocket).
+    """
+
+    def __init__(
+        self, adapters: list[InteractionChannelAdapter], team_id: uuid.UUID
+    ) -> None:
+        self._adapters = adapters
+        self._team_id = team_id
+        self._restoring = False
+
+    def set_restoring(self, restoring: bool) -> None:
+        """Toggle restore mode to suppress delivery during event replay."""
+        self._restoring = restoring
+
+    def on_message(self, msg: Message) -> None:
+        """Dispatch a SentMessage to the first matching adapter.
+
+        Skips delivery entirely during restore mode. Ignores non-SentMessage
+        events. Silently skips if no adapter matches.
+
+        Args:
+            msg: Orchestrator event message.
+        """
+        if self._restoring:
+            return
+        if not isinstance(msg, SentMessage):
+            return
+        for adapter in self._adapters:
+            if adapter.matches(msg):
+                adapter.deliver(msg)
+                break
+
+    def on_stop(self) -> None:
+        """Clean up all registered adapters when the team stops."""
+        for adapter in self._adapters:
+            adapter.on_stop(self._team_id)

--- a/src/akgentic/infra/adapters/telemetry_subscriber.py
+++ b/src/akgentic/infra/adapters/telemetry_subscriber.py
@@ -21,12 +21,21 @@ class TelemetrySubscriber:
     subscriber across all teams.
     """
 
+    def __init__(self) -> None:
+        self._restoring = False
+
+    def set_restoring(self, restoring: bool) -> None:
+        """Toggle restore mode to suppress span emission during event replay."""
+        self._restoring = restoring
+
     def on_message(self, msg: Message) -> None:
         """Log and trace an orchestrator event via logfire.
 
         Args:
             msg: Orchestrator telemetry message
         """
+        if self._restoring:
+            return
         msg_type = type(msg).__name__
         logfire.info(
             "orchestrator event: {msg_type}",

--- a/tests/test_channel_dispatcher.py
+++ b/tests/test_channel_dispatcher.py
@@ -22,13 +22,17 @@ class _MatchingAdapter:
         self.deliver_called = False
         self.stop_called = False
         self.stop_team_id: uuid.UUID | None = None
+        self.matches_msg: SentMessage | None = None
+        self.deliver_msg: SentMessage | None = None
 
     def matches(self, msg: SentMessage) -> bool:
         self.matches_called = True
+        self.matches_msg = msg
         return True
 
     def deliver(self, msg: SentMessage) -> None:
         self.deliver_called = True
+        self.deliver_msg = msg
 
     def on_stop(self, team_id: uuid.UUID) -> None:
         self.stop_called = True
@@ -92,10 +96,13 @@ class TestDispatchToMatchingAdapter:
     def test_calls_matches_then_deliver(self) -> None:
         adapter = _MatchingAdapter()
         dispatcher = InteractionChannelDispatcher(adapters=[adapter], team_id=TEAM_ID)
-        dispatcher.on_message(_make_sent_message())
+        sent = _make_sent_message()
+        dispatcher.on_message(sent)
 
         assert adapter.matches_called
         assert adapter.deliver_called
+        assert adapter.matches_msg is sent
+        assert adapter.deliver_msg is sent
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_channel_dispatcher.py
+++ b/tests/test_channel_dispatcher.py
@@ -1,0 +1,239 @@
+"""Tests for InteractionChannelDispatcher adapter."""
+
+from __future__ import annotations
+
+import uuid
+
+from akgentic.core.actor_address_impl import ActorAddressProxy
+from akgentic.core.messages import Message
+from akgentic.core.messages.orchestrator import ReceivedMessage, SentMessage, StartMessage
+
+from akgentic.infra.adapters.channel_dispatcher import InteractionChannelDispatcher
+
+# ---------------------------------------------------------------------------
+# Stub adapters satisfying InteractionChannelAdapter protocol (structural)
+# ---------------------------------------------------------------------------
+
+class _MatchingAdapter:
+    """Adapter stub that always matches."""
+
+    def __init__(self) -> None:
+        self.matches_called = False
+        self.deliver_called = False
+        self.stop_called = False
+        self.stop_team_id: uuid.UUID | None = None
+
+    def matches(self, msg: SentMessage) -> bool:
+        self.matches_called = True
+        return True
+
+    def deliver(self, msg: SentMessage) -> None:
+        self.deliver_called = True
+
+    def on_stop(self, team_id: uuid.UUID) -> None:
+        self.stop_called = True
+        self.stop_team_id = team_id
+
+
+class _NonMatchingAdapter:
+    """Adapter stub that never matches."""
+
+    def __init__(self) -> None:
+        self.matches_called = False
+        self.deliver_called = False
+        self.stop_called = False
+        self.stop_team_id: uuid.UUID | None = None
+
+    def matches(self, msg: SentMessage) -> bool:
+        self.matches_called = True
+        return False
+
+    def deliver(self, msg: SentMessage) -> None:
+        self.deliver_called = True
+
+    def on_stop(self, team_id: uuid.UUID) -> None:
+        self.stop_called = True
+        self.stop_team_id = team_id
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_addr() -> ActorAddressProxy:
+    return ActorAddressProxy({
+        "__actor_address__": True,
+        "__actor_type__": "akgentic.core.actor_address_impl.ActorAddressProxy",
+        "agent_id": str(uuid.uuid4()),
+        "name": "test-agent",
+        "role": "tester",
+        "team_id": str(uuid.uuid4()),
+        "squad_id": str(uuid.uuid4()),
+        "user_message": False,
+    })
+
+
+def _make_sent_message() -> SentMessage:
+    addr = _make_addr()
+    inner = Message(sender=addr)
+    return SentMessage(message=inner, recipient=addr, sender=addr)
+
+
+TEAM_ID = uuid.uuid4()
+
+
+# ---------------------------------------------------------------------------
+# AC #1: matches() then deliver() on first matching adapter
+# ---------------------------------------------------------------------------
+
+class TestDispatchToMatchingAdapter:
+    """AC #1: Dispatcher calls matches() then deliver() on first match."""
+
+    def test_calls_matches_then_deliver(self) -> None:
+        adapter = _MatchingAdapter()
+        dispatcher = InteractionChannelDispatcher(adapters=[adapter], team_id=TEAM_ID)
+        dispatcher.on_message(_make_sent_message())
+
+        assert adapter.matches_called
+        assert adapter.deliver_called
+
+
+# ---------------------------------------------------------------------------
+# AC #2: non-SentMessage events are skipped
+# ---------------------------------------------------------------------------
+
+class TestSkipsNonSentMessage:
+    """Dispatcher ignores non-SentMessage events."""
+
+    def test_received_message_ignored(self) -> None:
+        adapter = _MatchingAdapter()
+        dispatcher = InteractionChannelDispatcher(adapters=[adapter], team_id=TEAM_ID)
+        dispatcher.on_message(ReceivedMessage(message_id=uuid.uuid4()))
+
+        assert not adapter.matches_called
+        assert not adapter.deliver_called
+
+    def test_start_message_ignored(self) -> None:
+        from akgentic.core.agent_config import BaseConfig
+
+        adapter = _MatchingAdapter()
+        dispatcher = InteractionChannelDispatcher(adapters=[adapter], team_id=TEAM_ID)
+        dispatcher.on_message(StartMessage(config=BaseConfig()))
+
+        assert not adapter.matches_called
+        assert not adapter.deliver_called
+
+
+# ---------------------------------------------------------------------------
+# AC #2: no adapter matches → silently skip
+# ---------------------------------------------------------------------------
+
+class TestNoAdapterMatch:
+    """When no adapter matches, message is silently skipped."""
+
+    def test_no_match_no_exception(self) -> None:
+        adapter = _NonMatchingAdapter()
+        dispatcher = InteractionChannelDispatcher(adapters=[adapter], team_id=TEAM_ID)
+        dispatcher.on_message(_make_sent_message())
+
+        assert adapter.matches_called
+        assert not adapter.deliver_called
+
+
+# ---------------------------------------------------------------------------
+# AC #1: first-match-wins — only first matching adapter gets deliver()
+# ---------------------------------------------------------------------------
+
+class TestFirstMatchWins:
+    """With multiple adapters, only the FIRST match receives deliver()."""
+
+    def test_only_first_matching_adapter_delivers(self) -> None:
+        first = _MatchingAdapter()
+        second = _MatchingAdapter()
+        dispatcher = InteractionChannelDispatcher(
+            adapters=[first, second], team_id=TEAM_ID
+        )
+        dispatcher.on_message(_make_sent_message())
+
+        assert first.matches_called
+        assert first.deliver_called
+        assert not second.matches_called
+        assert not second.deliver_called
+
+    def test_skips_non_matching_then_delivers_to_match(self) -> None:
+        non_match = _NonMatchingAdapter()
+        match = _MatchingAdapter()
+        dispatcher = InteractionChannelDispatcher(
+            adapters=[non_match, match], team_id=TEAM_ID
+        )
+        dispatcher.on_message(_make_sent_message())
+
+        assert non_match.matches_called
+        assert not non_match.deliver_called
+        assert match.matches_called
+        assert match.deliver_called
+
+
+# ---------------------------------------------------------------------------
+# AC #3: set_restoring(True) causes all events to be skipped
+# ---------------------------------------------------------------------------
+
+class TestRestoreMode:
+    """set_restoring suppresses delivery during event replay."""
+
+    def test_restoring_skips_all_events(self) -> None:
+        adapter = _MatchingAdapter()
+        dispatcher = InteractionChannelDispatcher(adapters=[adapter], team_id=TEAM_ID)
+        dispatcher.set_restoring(True)
+        dispatcher.on_message(_make_sent_message())
+
+        assert not adapter.matches_called
+        assert not adapter.deliver_called
+
+    def test_restoring_false_resumes_dispatch(self) -> None:
+        adapter = _MatchingAdapter()
+        dispatcher = InteractionChannelDispatcher(adapters=[adapter], team_id=TEAM_ID)
+        dispatcher.set_restoring(True)
+        dispatcher.on_message(_make_sent_message())
+        assert not adapter.deliver_called
+
+        dispatcher.set_restoring(False)
+        dispatcher.on_message(_make_sent_message())
+        assert adapter.deliver_called
+
+
+# ---------------------------------------------------------------------------
+# AC #4: on_stop() calls adapter.on_stop(team_id) on ALL adapters
+# ---------------------------------------------------------------------------
+
+class TestOnStop:
+    """on_stop() propagates to all registered adapters."""
+
+    def test_on_stop_calls_all_adapters(self) -> None:
+        a1 = _MatchingAdapter()
+        a2 = _NonMatchingAdapter()
+        dispatcher = InteractionChannelDispatcher(
+            adapters=[a1, a2], team_id=TEAM_ID
+        )
+        dispatcher.on_stop()
+
+        assert a1.stop_called
+        assert a1.stop_team_id == TEAM_ID
+        assert a2.stop_called
+        assert a2.stop_team_id == TEAM_ID
+
+    def test_on_stop_empty_adapter_list(self) -> None:
+        dispatcher = InteractionChannelDispatcher(adapters=[], team_id=TEAM_ID)
+        dispatcher.on_stop()  # should not raise
+
+
+# ---------------------------------------------------------------------------
+# Edge case: empty adapter list with SentMessage
+# ---------------------------------------------------------------------------
+
+class TestEmptyAdapterList:
+    """Dispatcher with empty adapter list handles messages without error."""
+
+    def test_sent_message_with_no_adapters(self) -> None:
+        dispatcher = InteractionChannelDispatcher(adapters=[], team_id=TEAM_ID)
+        dispatcher.on_message(_make_sent_message())  # should not raise

--- a/tests/test_telemetry_restore.py
+++ b/tests/test_telemetry_restore.py
@@ -1,0 +1,49 @@
+"""Tests for TelemetrySubscriber restore-awareness (Story 4.2 additions)."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from akgentic.infra.adapters.telemetry_subscriber import TelemetrySubscriber
+
+
+class TestTelemetryRestoreAwareness:
+    """AC #5, #6: TelemetrySubscriber supports set_restoring to skip logfire spans."""
+
+    def test_on_message_calls_logfire_for_live_events(self) -> None:
+        """AC #5: logfire.info is called for live (non-restoring) events."""
+        subscriber = TelemetrySubscriber()
+        msg = MagicMock()
+        msg.__class__.__name__ = "StartMessage"
+
+        with patch("akgentic.infra.adapters.telemetry_subscriber.logfire") as mock_lf:
+            subscriber.on_message(msg)
+            mock_lf.info.assert_called_once()
+
+    def test_restoring_skips_logfire_emission(self) -> None:
+        """AC #6: set_restoring(True) suppresses logfire.info calls."""
+        subscriber = TelemetrySubscriber()
+        subscriber.set_restoring(True)
+        msg = MagicMock()
+        msg.__class__.__name__ = "StartMessage"
+
+        with patch("akgentic.infra.adapters.telemetry_subscriber.logfire") as mock_lf:
+            subscriber.on_message(msg)
+            mock_lf.info.assert_not_called()
+
+    def test_restoring_false_resumes_logfire(self) -> None:
+        """set_restoring(False) resumes normal logfire emission."""
+        subscriber = TelemetrySubscriber()
+        subscriber.set_restoring(True)
+        subscriber.set_restoring(False)
+        msg = MagicMock()
+        msg.__class__.__name__ = "StartMessage"
+
+        with patch("akgentic.infra.adapters.telemetry_subscriber.logfire") as mock_lf:
+            subscriber.on_message(msg)
+            mock_lf.info.assert_called_once()
+
+    def test_on_stop_does_not_raise(self) -> None:
+        """on_stop completes without error."""
+        subscriber = TelemetrySubscriber()
+        subscriber.on_stop()


### PR DESCRIPTION
## Summary

- **InteractionChannelDispatcher**: Per-team `EventSubscriber` that routes `SentMessage` events to the first matching `InteractionChannelAdapter` via first-match dispatch. Restore-aware — suppresses delivery during event replay.
- **TelemetrySubscriber restore-awareness**: Added `_restoring` flag and `set_restoring()` method to suppress logfire span emission during event replay.
- Exported `InteractionChannelDispatcher` from `adapters/__init__.py` and top-level `__init__.py`.
- 15 unit tests covering all acceptance criteria with argument verification.

## Code Review Fixes Applied

- Defensive copy of adapters list in dispatcher constructor (prevents mutation after construction)
- Enhanced test stubs to capture and verify actual message arguments passed to `matches()`/`deliver()`
- Fixed dev agent record: corrected test count (11 dispatcher + 4 telemetry = 15 total)

Closes #33