### PR TITLE
Integration tests for interaction channel flows

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -12,6 +12,9 @@ from dotenv import load_dotenv
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
+from akgentic.infra.adapters.channel_parser_registry import ChannelParserRegistry
+from akgentic.infra.adapters.local_ingestion import LocalIngestion
+from akgentic.infra.adapters.yaml_channel_registry import YamlChannelRegistry
 from akgentic.infra.server.app import create_app
 from akgentic.infra.server.deps import CommunityServices
 from akgentic.infra.server.services.team_service import TeamService
@@ -227,3 +230,70 @@ def v1_adapter_app(
 def v1_adapter_client(v1_adapter_app: FastAPI) -> TestClient:
     """Sync HTTP test client hitting a V1-adapter-enabled FastAPI app."""
     return TestClient(v1_adapter_app)
+
+
+# ---------------------------------------------------------------------------
+# Channel Integration Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def test_adapter() -> object:
+    """Shared StubChannelAdapter instance for inspecting delivered messages."""
+    from .test_channels import StubChannelAdapter
+
+    return StubChannelAdapter()
+
+
+@pytest.fixture()
+def channel_parser_registry(
+    test_adapter: object,
+) -> ChannelParserRegistry:
+    """ChannelParserRegistry with test stubs manually injected."""
+    from .test_channels import StubChannelParser
+
+    registry = ChannelParserRegistry(channels_config={})
+    parser = StubChannelParser()
+    registry._parsers[parser.channel_name] = parser
+    registry._adapters.append(test_adapter)  # type: ignore[arg-type]
+    return registry
+
+
+@pytest.fixture()
+def channel_registry_instance(tmp_path: Path) -> YamlChannelRegistry:
+    """YamlChannelRegistry backed by tmp_path."""
+    return YamlChannelRegistry(registry_path=tmp_path / "channel-registry.yaml")
+
+
+@pytest.fixture()
+def channel_ingestion(
+    integration_team_service: TeamService,
+) -> LocalIngestion:
+    """LocalIngestion wired to the integration TeamService."""
+    return LocalIngestion(team_service=integration_team_service)
+
+
+@pytest.fixture()
+def channel_app(
+    integration_services: CommunityServices,
+    integration_team_service: TeamService,
+    integration_settings: ServerSettings,
+    channel_parser_registry: ChannelParserRegistry,
+    channel_registry_instance: YamlChannelRegistry,
+    channel_ingestion: LocalIngestion,
+) -> FastAPI:
+    """FastAPI app with webhook wiring for channel integration tests."""
+    return create_app(
+        integration_services,
+        integration_team_service,
+        settings=integration_settings,
+        channel_parser_registry=channel_parser_registry,
+        channel_registry=channel_registry_instance,
+        ingestion=channel_ingestion,
+    )
+
+
+@pytest.fixture()
+def channel_client(channel_app: FastAPI) -> TestClient:
+    """Sync HTTP test client hitting a channel-enabled FastAPI app."""
+    return TestClient(channel_app)

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import os
 from collections.abc import Generator
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import pytest
 import yaml
@@ -20,6 +21,9 @@ from akgentic.infra.server.deps import CommunityServices
 from akgentic.infra.server.services.team_service import TeamService
 from akgentic.infra.server.settings import ServerSettings
 from akgentic.infra.wiring import wire_community
+
+if TYPE_CHECKING:
+    from .test_channels import StubChannelAdapter
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -238,16 +242,16 @@ def v1_adapter_client(v1_adapter_app: FastAPI) -> TestClient:
 
 
 @pytest.fixture()
-def test_adapter() -> object:
+def test_adapter() -> StubChannelAdapter:
     """Shared StubChannelAdapter instance for inspecting delivered messages."""
-    from .test_channels import StubChannelAdapter
+    from .test_channels import StubChannelAdapter as _StubChannelAdapter
 
-    return StubChannelAdapter()
+    return _StubChannelAdapter()
 
 
 @pytest.fixture()
 def channel_parser_registry(
-    test_adapter: object,
+    test_adapter: StubChannelAdapter,
 ) -> ChannelParserRegistry:
     """ChannelParserRegistry with test stubs manually injected."""
     from .test_channels import StubChannelParser
@@ -255,7 +259,7 @@ def channel_parser_registry(
     registry = ChannelParserRegistry(channels_config={})
     parser = StubChannelParser()
     registry._parsers[parser.channel_name] = parser
-    registry._adapters.append(test_adapter)  # type: ignore[arg-type]
+    registry._adapters.append(test_adapter)
     return registry
 
 

--- a/tests/integration/test_channels.py
+++ b/tests/integration/test_channels.py
@@ -106,13 +106,7 @@ def _find_team_via_registry(
     """Synchronously look up a team from the YAML channel registry."""
     import asyncio
 
-    loop = asyncio.new_event_loop()
-    try:
-        return loop.run_until_complete(
-            registry.find_team(channel, channel_user_id),
-        )
-    finally:
-        loop.close()
+    return asyncio.run(registry.find_team(channel, channel_user_id))
 
 
 # ---------------------------------------------------------------------------
@@ -209,8 +203,8 @@ class TestChannelContinuation:
             "Channel registry should have mapping after initiation"
         )
 
-        # Brief pause to let team initialize
-        time.sleep(2)
+        # Wait for LLM to process first message before sending follow-up
+        wait_for_llm_response(channel_client, str(team_id))
 
         # Step 2: Follow-up with same channel_user_id, no team_id
         resp = channel_client.post(
@@ -304,3 +298,6 @@ class TestDispatcherRestoreSuppression:
         assert ev_resp.status_code == 200
         events_after = ev_resp.json()["events"]
         assert len(events_after) == events_before
+
+        # Stop the team to allow clean actor system teardown
+        channel_client.post(f"/teams/{team_id}/stop")

--- a/tests/integration/test_channels.py
+++ b/tests/integration/test_channels.py
@@ -1,0 +1,306 @@
+"""Integration tests — interaction channel flows with real LLM."""
+
+from __future__ import annotations
+
+import time
+import uuid
+
+import pytest
+from akgentic.core.messages import SentMessage
+from fastapi.testclient import TestClient
+
+from akgentic.infra.adapters.yaml_channel_registry import (
+    YamlChannelRegistry,
+)
+from akgentic.infra.protocols.channels import ChannelMessage, JsonValue
+
+from ._helpers import (
+    POLL_INTERVAL_S,
+    POLL_TIMEOUT_S,
+    has_llm_content,
+    wait_for_llm_response,
+)
+
+pytestmark = pytest.mark.integration
+
+FOLLOWUP_CONTENT = "What is 7 + 7? Answer with the number."
+
+
+# ---------------------------------------------------------------------------
+# Test stubs — structural subtyping against channel protocols
+# ---------------------------------------------------------------------------
+
+
+class StubChannelParser:
+    """Stub ChannelParser for integration tests.
+
+    Satisfies the ChannelParser protocol via structural subtyping.
+    Parses a simple dict payload into a ChannelMessage.
+    """
+
+    @property
+    def channel_name(self) -> str:
+        return "test-channel"
+
+    @property
+    def default_catalog_entry(self) -> str:
+        return "test-team"
+
+    async def parse(
+        self, payload: dict[str, JsonValue],
+    ) -> ChannelMessage:
+        """Parse test payload into ChannelMessage."""
+        content = str(payload.get("content", ""))
+        channel_user_id = str(payload.get("channel_user_id", ""))
+        raw_team_id = payload.get("team_id")
+        team_id = (
+            uuid.UUID(str(raw_team_id))
+            if raw_team_id is not None
+            else None
+        )
+        message_id = (
+            str(payload["message_id"])
+            if payload.get("message_id")
+            else None
+        )
+        return ChannelMessage(
+            content=content,
+            channel_user_id=channel_user_id,
+            team_id=team_id,
+            message_id=message_id,
+        )
+
+
+class StubChannelAdapter:
+    """Stub InteractionChannelAdapter for integration tests.
+
+    Captures outbound SentMessage events in a shared list.
+    Matches all messages (returns True for every SentMessage).
+    """
+
+    def __init__(self) -> None:
+        self.delivered: list[SentMessage] = []
+
+    def matches(self, msg: SentMessage) -> bool:  # noqa: ARG002
+        """Match all messages."""
+        return True
+
+    def deliver(self, msg: SentMessage) -> None:
+        """Capture delivered message."""
+        self.delivered.append(msg)
+
+    def on_stop(self, team_id: uuid.UUID) -> None:  # noqa: ARG002
+        """No-op cleanup."""
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _find_team_via_registry(
+    registry: YamlChannelRegistry,
+    channel: str,
+    channel_user_id: str,
+) -> uuid.UUID | None:
+    """Synchronously look up a team from the YAML channel registry."""
+    import asyncio
+
+    loop = asyncio.new_event_loop()
+    try:
+        return loop.run_until_complete(
+            registry.find_team(channel, channel_user_id),
+        )
+    finally:
+        loop.close()
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestChannelInitiation:
+    """AC #1: Webhook with no existing team creates team."""
+
+    def test_initiation_creates_team_and_gets_llm_response(
+        self,
+        channel_client: TestClient,
+        channel_registry_instance: YamlChannelRegistry,
+    ) -> None:
+        payload = {
+            "content": "What is 2 + 2? Answer with the number.",
+            "channel_user_id": "ext-user-1",
+        }
+        resp = channel_client.post(
+            "/webhook/test-channel", json=payload,
+        )
+        assert resp.status_code == 204
+
+        team_id = _find_team_via_registry(
+            channel_registry_instance, "test-channel", "ext-user-1",
+        )
+        assert team_id is not None, (
+            "Channel registry should map ext-user-1 after initiation"
+        )
+
+        events = wait_for_llm_response(
+            channel_client, str(team_id),
+        )
+        assert has_llm_content(events)
+
+        # Stop the team to allow clean actor system teardown
+        channel_client.post(f"/teams/{team_id}/stop")
+
+
+class TestChannelReply:
+    """AC #2: Webhook with team_id routes to the correct team."""
+
+    def test_reply_routes_to_existing_team(
+        self, channel_client: TestClient,
+    ) -> None:
+        create_resp = channel_client.post(
+            "/teams/", json={"catalog_entry_id": "test-team"},
+        )
+        assert create_resp.status_code == 201
+        team_id = create_resp.json()["team_id"]
+
+        resp = channel_client.post(
+            "/webhook/test-channel",
+            json={
+                "content": "What is 3 + 3? Answer with the number.",
+                "channel_user_id": "ext-user-2",
+                "team_id": team_id,
+            },
+        )
+        assert resp.status_code == 204
+
+        events = wait_for_llm_response(channel_client, team_id)
+        assert has_llm_content(events)
+
+        # Stop the team to allow clean actor system teardown
+        channel_client.post(f"/teams/{team_id}/stop")
+
+
+class TestChannelContinuation:
+    """AC #3: Webhook with known channel_user_id resolves team."""
+
+    def test_continuation_routes_to_same_team(
+        self,
+        channel_client: TestClient,
+        channel_registry_instance: YamlChannelRegistry,
+    ) -> None:
+        # Step 1: Initiate via webhook to establish channel mapping
+        payload = {
+            "content": "Respond with one word.",
+            "channel_user_id": "ext-user-cont",
+        }
+        resp = channel_client.post(
+            "/webhook/test-channel", json=payload,
+        )
+        assert resp.status_code == 204
+
+        team_id = _find_team_via_registry(
+            channel_registry_instance,
+            "test-channel",
+            "ext-user-cont",
+        )
+        assert team_id is not None, (
+            "Channel registry should have mapping after initiation"
+        )
+
+        # Brief pause to let team initialize
+        time.sleep(2)
+
+        # Step 2: Follow-up with same channel_user_id, no team_id
+        resp = channel_client.post(
+            "/webhook/test-channel",
+            json={
+                "content": FOLLOWUP_CONTENT,
+                "channel_user_id": "ext-user-cont",
+            },
+        )
+        assert resp.status_code == 204
+
+        # Verify follow-up is routed to the SAME team
+        deadline = time.monotonic() + POLL_TIMEOUT_S
+        found_followup = False
+        while time.monotonic() < deadline:
+            ev_resp = channel_client.get(
+                f"/teams/{team_id}/events",
+            )
+            assert ev_resp.status_code == 200
+            events = ev_resp.json()["events"]
+            for ev_wrapper in events:
+                ev = ev_wrapper["event"]
+                if not isinstance(ev, dict):
+                    continue
+                content = ev.get("content")
+                if content == FOLLOWUP_CONTENT:
+                    found_followup = True
+                    break
+                msg = ev.get("message")
+                if (
+                    isinstance(msg, dict)
+                    and msg.get("content") == FOLLOWUP_CONTENT
+                ):
+                    found_followup = True
+                    break
+            if found_followup:
+                break
+            time.sleep(POLL_INTERVAL_S)
+
+        assert found_followup, (
+            "Follow-up message should appear in the same team's "
+            "events (continuation flow via channel_user_id)"
+        )
+
+        # Stop the team to allow clean actor system teardown
+        channel_client.post(f"/teams/{team_id}/stop")
+
+
+class TestDispatcherRestoreSuppression:
+    """AC #4: Stop/restore preserves events without duplicating them.
+
+    Uses the same channel_client to verify the channel-enabled app
+    handles the stop/restore lifecycle correctly. Does not send
+    messages requiring LLM, avoiding rate-limit contention.
+    """
+
+    def test_restore_cycle_preserves_events(
+        self,
+        channel_client: TestClient,
+    ) -> None:
+        # Create team via REST (no LLM call needed)
+        create_resp = channel_client.post(
+            "/teams/", json={"catalog_entry_id": "test-team"},
+        )
+        assert create_resp.status_code == 201
+        team_id = create_resp.json()["team_id"]
+
+        # Verify running
+        resp = channel_client.get(f"/teams/{team_id}")
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "running"
+
+        # Count initial events (team creation events)
+        ev_resp = channel_client.get(f"/teams/{team_id}/events")
+        assert ev_resp.status_code == 200
+        events_before = len(ev_resp.json()["events"])
+
+        # Stop
+        resp = channel_client.post(f"/teams/{team_id}/stop")
+        assert resp.status_code == 204
+        resp = channel_client.get(f"/teams/{team_id}")
+        assert resp.json()["status"] == "stopped"
+
+        # Restore
+        resp = channel_client.post(f"/teams/{team_id}/restore")
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "running"
+
+        # Events preserved (not duplicated by restore replay)
+        ev_resp = channel_client.get(f"/teams/{team_id}/events")
+        assert ev_resp.status_code == 200
+        events_after = ev_resp.json()["events"]
+        assert len(events_after) == events_before


### PR DESCRIPTION
## Summary

- Add 4 integration tests covering the full interaction channel flow: initiation (new team via webhook), reply (existing team_id), continuation (channel_user_id lookup), and restore suppression (stop/restore event preservation)
- Channel-specific fixtures: channel_app, channel_client, channel_parser_registry, channel_registry_instance, channel_ingestion, test_adapter
- Test stubs (StubChannelParser, StubChannelAdapter) satisfy protocols via structural subtyping

## Code Review Fixes Applied

- Added missing team stop in restore suppression test for clean actor teardown
- Fixed test_adapter fixture return type from object to StubChannelAdapter
- Replaced fragile time.sleep(2) with wait_for_llm_response() in continuation test
- Replaced manual asyncio.new_event_loop() with idiomatic asyncio.run()

Closes #37