### PR TITLE
CLI Foundation — Team Lifecycle & Workspace Commands

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ dependencies = [
     "fastapi>=0.100.0",
     "pydantic-settings>=2.0.0",
     "logfire>=0.1.0",
-    "typer>=0.9.0",
+    "typer[all]>=0.9.0",
     "httpx>=0.27.0",
     "pyyaml>=6.0",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,14 +19,19 @@ dependencies = [
     "fastapi>=0.100.0",
     "pydantic-settings>=2.0.0",
     "logfire>=0.1.0",
+    "typer>=0.9.0",
+    "httpx>=0.27.0",
+    "pyyaml>=6.0",
 ]
+
+[project.scripts]
+ak-infra = "akgentic.infra.cli.main:app"
 
 [project.optional-dependencies]
 dev = [
     "pytest>=8.0.0",
     "pytest-asyncio>=0.23.0",
     "pytest-cov>=4.1.0",
-    "httpx>=0.27.0",
     "mypy>=1.8.0",
     "ruff>=0.1.0",
     "python-dotenv>=1.0.0",

--- a/src/akgentic/infra/cli/__init__.py
+++ b/src/akgentic/infra/cli/__init__.py
@@ -1,1 +1,5 @@
-"""CLI module — implemented in future stories."""
+"""CLI module — ak-infra command-line interface."""
+
+from akgentic.infra.cli.main import app
+
+__all__ = ["app"]

--- a/src/akgentic/infra/cli/client.py
+++ b/src/akgentic/infra/cli/client.py
@@ -1,0 +1,117 @@
+"""HTTP client wrapper for the akgentic-infra REST API."""
+
+from __future__ import annotations
+
+import sys
+from typing import Any
+
+import httpx
+import typer
+
+
+class ApiClient:
+    """Thin HTTP client mapping CLI commands to server endpoints."""
+
+    def __init__(self, base_url: str, api_key: str | None = None) -> None:
+        headers: dict[str, str] = {}
+        if api_key:
+            headers["Authorization"] = f"Bearer {api_key}"
+        self._client = httpx.Client(base_url=base_url, headers=headers)
+
+    # -- helpers --
+
+    def _request(
+        self,
+        method: str,
+        path: str,
+        *,
+        json: dict[str, Any] | None = None,
+        params: dict[str, str] | None = None,
+        files: dict[str, Any] | None = None,
+        data: dict[str, str] | None = None,
+    ) -> httpx.Response:
+        resp = self._client.request(
+            method,
+            path,
+            json=json,
+            params=params,
+            files=files,
+            data=data,
+        )
+        if not resp.is_success:
+            detail = ""
+            try:
+                body = resp.json()
+                detail = body.get("detail", "")
+            except Exception:  # noqa: BLE001
+                pass
+            msg = f"HTTP {resp.status_code}"
+            if detail:
+                msg += f": {detail}"
+            print(msg, file=sys.stderr)
+            raise typer.Exit(code=1)
+        return resp
+
+    # -- team endpoints --
+
+    def list_teams(self) -> list[dict[str, Any]]:
+        """GET /teams → list of team dicts."""
+        resp = self._request("GET", "/teams")
+        return resp.json()["teams"]  # type: ignore[no-any-return]
+
+    def get_team(self, team_id: str) -> dict[str, Any]:
+        """GET /teams/{team_id} → team dict."""
+        return self._request("GET", f"/teams/{team_id}").json()  # type: ignore[no-any-return]
+
+    def create_team(self, catalog_entry_id: str) -> dict[str, Any]:
+        """POST /teams → created team dict."""
+        resp = self._request("POST", "/teams", json={"catalog_entry_id": catalog_entry_id})
+        return resp.json()  # type: ignore[no-any-return]
+
+    def delete_team(self, team_id: str) -> None:
+        """DELETE /teams/{team_id}."""
+        self._request("DELETE", f"/teams/{team_id}")
+
+    def restore_team(self, team_id: str) -> dict[str, Any]:
+        """POST /teams/{team_id}/restore → restored team dict."""
+        return self._request("POST", f"/teams/{team_id}/restore").json()  # type: ignore[no-any-return]
+
+    def get_events(self, team_id: str) -> list[dict[str, Any]]:
+        """GET /teams/{team_id}/events → list of event dicts."""
+        resp = self._request("GET", f"/teams/{team_id}/events")
+        return resp.json()["events"]  # type: ignore[no-any-return]
+
+    # -- messaging --
+
+    def send_message(self, team_id: str, content: str) -> None:
+        """POST /teams/{team_id}/message."""
+        self._request("POST", f"/teams/{team_id}/message", json={"content": content})
+
+    def human_input(self, team_id: str, content: str, message_id: str) -> None:
+        """POST /teams/{team_id}/human-input."""
+        self._request(
+            "POST",
+            f"/teams/{team_id}/human-input",
+            json={"content": content, "message_id": message_id},
+        )
+
+    # -- workspace --
+
+    def workspace_tree(self, team_id: str) -> dict[str, Any]:
+        """GET /workspace/{team_id}/tree → tree dict."""
+        return self._request("GET", f"/workspace/{team_id}/tree").json()  # type: ignore[no-any-return]
+
+    def workspace_read(self, team_id: str, path: str) -> bytes:
+        """GET /workspace/{team_id}/file → raw file bytes."""
+        resp = self._request("GET", f"/workspace/{team_id}/file", params={"path": path})
+        return resp.content
+
+    def workspace_upload(self, team_id: str, path: str, file_data: bytes) -> dict[str, Any]:
+        """POST /workspace/{team_id}/file → upload response dict."""
+        resp = self._request(
+            "POST",
+            f"/workspace/{team_id}/file",
+            data={"path": path},
+            files={"file": ("upload", file_data)},
+        )
+        return resp.json()  # type: ignore[no-any-return]

--- a/src/akgentic/infra/cli/client.py
+++ b/src/akgentic/infra/cli/client.py
@@ -18,6 +18,16 @@ class ApiClient:
             headers["Authorization"] = f"Bearer {api_key}"
         self._client = httpx.Client(base_url=base_url, headers=headers)
 
+    def close(self) -> None:
+        """Close the underlying HTTP client."""
+        self._client.close()
+
+    def __enter__(self) -> ApiClient:
+        return self
+
+    def __exit__(self, *_args: object) -> None:
+        self.close()
+
     # -- helpers --
 
     def _request(

--- a/src/akgentic/infra/cli/formatters.py
+++ b/src/akgentic/infra/cli/formatters.py
@@ -17,6 +17,13 @@ class OutputFormat(enum.StrEnum):
     yaml = "yaml"
 
 
+def _cell_str(val: object) -> str:
+    """Convert a cell value to a display string, serializing dicts as compact JSON."""
+    if isinstance(val, dict):
+        return json.dumps(val, default=str)
+    return str(val)
+
+
 def format_table(rows: list[dict[str, Any]], columns: list[str]) -> str:
     """Format rows as an aligned text table."""
     if not rows:
@@ -26,7 +33,7 @@ def format_table(rows: list[dict[str, Any]], columns: list[str]) -> str:
     widths: dict[str, int] = {col: len(col) for col in columns}
     for row in rows:
         for col in columns:
-            widths[col] = max(widths[col], len(str(row.get(col, ""))))
+            widths[col] = max(widths[col], len(_cell_str(row.get(col, ""))))
 
     # Header
     header = "  ".join(col.upper().ljust(widths[col]) for col in columns)
@@ -35,7 +42,7 @@ def format_table(rows: list[dict[str, Any]], columns: list[str]) -> str:
     # Rows
     lines = [header, separator]
     for row in rows:
-        line = "  ".join(str(row.get(col, "")).ljust(widths[col]) for col in columns)
+        line = "  ".join(_cell_str(row.get(col, "")).ljust(widths[col]) for col in columns)
         lines.append(line)
 
     return "\n".join(lines)

--- a/src/akgentic/infra/cli/formatters.py
+++ b/src/akgentic/infra/cli/formatters.py
@@ -1,0 +1,70 @@
+"""Output formatting for the ak-infra CLI."""
+
+from __future__ import annotations
+
+import enum
+import json
+from typing import Any
+
+import yaml
+
+
+class OutputFormat(enum.StrEnum):
+    """Supported CLI output formats."""
+
+    table = "table"
+    json = "json"
+    yaml = "yaml"
+
+
+def format_table(rows: list[dict[str, Any]], columns: list[str]) -> str:
+    """Format rows as an aligned text table."""
+    if not rows:
+        return "(no results)"
+
+    # Compute column widths
+    widths: dict[str, int] = {col: len(col) for col in columns}
+    for row in rows:
+        for col in columns:
+            widths[col] = max(widths[col], len(str(row.get(col, ""))))
+
+    # Header
+    header = "  ".join(col.upper().ljust(widths[col]) for col in columns)
+    separator = "  ".join("-" * widths[col] for col in columns)
+
+    # Rows
+    lines = [header, separator]
+    for row in rows:
+        line = "  ".join(str(row.get(col, "")).ljust(widths[col]) for col in columns)
+        lines.append(line)
+
+    return "\n".join(lines)
+
+
+def format_json(data: object) -> str:
+    """Format data as indented JSON."""
+    return json.dumps(data, indent=2, default=str)
+
+
+def format_yaml(data: object) -> str:
+    """Format data as YAML."""
+    return yaml.dump(data, default_flow_style=False, sort_keys=False)
+
+
+def format_output(
+    data: object,
+    fmt: OutputFormat,
+    columns: list[str] | None = None,
+) -> str:
+    """Dispatch to the appropriate formatter."""
+    if fmt == OutputFormat.json:
+        return format_json(data)
+    if fmt == OutputFormat.yaml:
+        return format_yaml(data)
+    # table
+    if isinstance(data, list) and columns:
+        return format_table(data, columns)
+    if isinstance(data, dict) and columns:
+        return format_table([data], columns)
+    # Fallback for table without columns — use json
+    return format_json(data)

--- a/src/akgentic/infra/cli/main.py
+++ b/src/akgentic/infra/cli/main.py
@@ -1,0 +1,180 @@
+"""Typer CLI application for akgentic-infra."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Annotated, Any
+
+import typer
+
+from akgentic.infra.cli.client import ApiClient
+from akgentic.infra.cli.formatters import OutputFormat, format_output
+
+app = typer.Typer(name="ak-infra", help="Akgentic Infrastructure CLI")
+team_app = typer.Typer(name="team", help="Manage agent teams")
+workspace_app = typer.Typer(name="workspace", help="Manage team workspace files")
+
+app.add_typer(team_app, name="team")
+app.add_typer(workspace_app, name="workspace")
+
+
+# -- shared state --
+
+
+class _State:
+    """Holds resolved global options for commands."""
+
+    client: ApiClient
+    fmt: OutputFormat
+
+
+_state = _State()
+
+
+def _print(data: object, columns: list[str] | None = None) -> None:
+    """Print formatted output using the current output format."""
+    typer.echo(format_output(data, _state.fmt, columns))
+
+
+# -- global callback --
+
+
+@app.callback()
+def main(
+    server: Annotated[
+        str, typer.Option("--server", help="Server base URL")
+    ] = "http://localhost:8000",
+    api_key: Annotated[
+        str | None, typer.Option("--api-key", help="API key for authentication")
+    ] = None,
+    fmt: Annotated[
+        OutputFormat, typer.Option("--format", help="Output format")
+    ] = OutputFormat.table,
+) -> None:
+    """Akgentic Infrastructure CLI — manage teams, messaging, and workspace."""
+    _state.client = ApiClient(base_url=server, api_key=api_key)
+    _state.fmt = fmt
+
+
+# -- team commands --
+
+_team_columns = ["team_id", "name", "status", "created_at"]
+_team_detail_columns = ["team_id", "name", "status", "user_id", "created_at", "updated_at"]
+
+
+@team_app.command("list")
+def team_list() -> None:
+    """List all teams."""
+    teams = _state.client.list_teams()
+    _print(teams, _team_columns)
+
+
+@team_app.command("get")
+def team_get(team_id: str) -> None:
+    """Show team detail."""
+    team = _state.client.get_team(team_id)
+    _print(team, _team_detail_columns)
+
+
+@team_app.command("create")
+def team_create(catalog_entry: str) -> None:
+    """Create a team from a catalog entry."""
+    team = _state.client.create_team(catalog_entry)
+    _print(team, _team_detail_columns)
+
+
+@team_app.command("delete")
+def team_delete(team_id: str) -> None:
+    """Delete a team."""
+    _state.client.delete_team(team_id)
+    typer.echo(f"Team {team_id} deleted.")
+
+
+@team_app.command("restore")
+def team_restore(team_id: str) -> None:
+    """Restore a stopped team."""
+    team = _state.client.restore_team(team_id)
+    _print(team, _team_detail_columns)
+
+
+@team_app.command("events")
+def team_events(team_id: str) -> None:
+    """Show team events."""
+    events = _state.client.get_events(team_id)
+    _print(events, ["sequence", "timestamp", "event"])
+
+
+# -- top-level message / reply --
+
+
+@app.command("message")
+def message(team_id: str, content: str) -> None:
+    """Send a message to a team (non-interactive)."""
+    _state.client.send_message(team_id, content)
+    typer.echo("Message sent.")
+
+
+@app.command("reply")
+def reply(
+    team_id: str,
+    content: str,
+    message_id: Annotated[str, typer.Option("--message-id", help="Original message ID")],
+) -> None:
+    """Reply with human input to an agent request."""
+    _state.client.human_input(team_id, content, message_id)
+    typer.echo("Reply sent.")
+
+
+# -- chat placeholder --
+
+
+@app.command("chat")
+def chat() -> None:
+    """Interactive chat REPL (not yet implemented)."""
+    typer.echo("Not yet implemented — see Story 5.2a")
+
+
+# -- workspace commands --
+
+
+@workspace_app.command("tree")
+def workspace_tree(team_id: str) -> None:
+    """Show workspace file tree."""
+    tree: dict[str, Any] = _state.client.workspace_tree(team_id)
+    if _state.fmt != OutputFormat.table:
+        _print(tree)
+        return
+    entries: list[dict[str, Any]] = tree.get("entries", [])
+    if not entries:
+        typer.echo("(empty workspace)")
+        return
+    for entry in entries:
+        prefix = "📁 " if entry.get("is_dir") else "   "
+        name = entry.get("name", "")
+        size = entry.get("size", 0)
+        suffix = f"  ({size} bytes)" if not entry.get("is_dir") else ""
+        typer.echo(f"{prefix}{name}{suffix}")
+
+
+@workspace_app.command("read")
+def workspace_read(team_id: str, path: str) -> None:
+    """Read a file from the workspace."""
+    data = _state.client.workspace_read(team_id, path)
+    try:
+        typer.echo(data.decode("utf-8"), nl=False)
+    except UnicodeDecodeError:
+        typer.echo(f"(binary file, {len(data)} bytes)")
+
+
+@workspace_app.command("upload")
+def workspace_upload(team_id: str, local_path: str) -> None:
+    """Upload a local file to the workspace."""
+    p = Path(local_path)
+    if not p.is_file():
+        typer.echo(f"Error: {local_path} is not a file", err=True)
+        raise typer.Exit(code=1)
+    file_data = p.read_bytes()
+    result: dict[str, Any] = _state.client.workspace_upload(team_id, p.name, file_data)
+    path = result.get("path", p.name)
+    size = result.get("size", len(file_data))
+    typer.echo(f"Uploaded {path} ({size} bytes)")

--- a/src/akgentic/infra/cli/main.py
+++ b/src/akgentic/infra/cli/main.py
@@ -87,7 +87,10 @@ def team_create(catalog_entry: str) -> None:
 def team_delete(team_id: str) -> None:
     """Delete a team."""
     _state.client.delete_team(team_id)
-    typer.echo(f"Team {team_id} deleted.")
+    if _state.fmt == OutputFormat.table:
+        typer.echo(f"Team {team_id} deleted.")
+    else:
+        _print({"team_id": team_id, "status": "deleted"})
 
 
 @team_app.command("restore")
@@ -111,7 +114,10 @@ def team_events(team_id: str) -> None:
 def message(team_id: str, content: str) -> None:
     """Send a message to a team (non-interactive)."""
     _state.client.send_message(team_id, content)
-    typer.echo("Message sent.")
+    if _state.fmt == OutputFormat.table:
+        typer.echo("Message sent.")
+    else:
+        _print({"team_id": team_id, "status": "sent"})
 
 
 @app.command("reply")
@@ -122,7 +128,10 @@ def reply(
 ) -> None:
     """Reply with human input to an agent request."""
     _state.client.human_input(team_id, content, message_id)
-    typer.echo("Reply sent.")
+    if _state.fmt == OutputFormat.table:
+        typer.echo("Reply sent.")
+    else:
+        _print({"team_id": team_id, "message_id": message_id, "status": "sent"})
 
 
 # -- chat placeholder --

--- a/tests/test_cli_client.py
+++ b/tests/test_cli_client.py
@@ -1,0 +1,196 @@
+"""Tests for akgentic.infra.cli.client.ApiClient."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import httpx
+import pytest
+
+from akgentic.infra.cli.client import ApiClient
+
+
+def _transport(
+    status: int = 200,
+    json_body: dict[str, Any] | list[dict[str, Any]] | None = None,
+    content: bytes = b"",
+) -> httpx.MockTransport:
+    """Build a MockTransport returning a fixed response."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if json_body is not None:
+            return httpx.Response(status, json=json_body)
+        return httpx.Response(status, content=content)
+
+    return httpx.MockTransport(handler)
+
+
+def _client(
+    transport: httpx.MockTransport | httpx.BaseTransport,
+    api_key: str | None = None,
+) -> ApiClient:
+    """Build an ApiClient backed by a mock transport."""
+    c = ApiClient(base_url="http://test", api_key=api_key)
+    headers: dict[str, str] = {}
+    if api_key:
+        headers["Authorization"] = f"Bearer {api_key}"
+    c._client = httpx.Client(base_url="http://test", transport=transport, headers=headers)
+    return c
+
+
+# -- team endpoints --
+
+
+class TestListTeams:
+    def test_returns_team_list(self) -> None:
+        teams = [{"team_id": "abc", "name": "t1", "status": "running"}]
+        client = _client(_transport(json_body={"teams": teams}))
+        result = client.list_teams()
+        assert result == teams
+
+    def test_empty_list(self) -> None:
+        client = _client(_transport(json_body={"teams": []}))
+        assert client.list_teams() == []
+
+
+class TestGetTeam:
+    def test_returns_team_dict(self) -> None:
+        team = {"team_id": "abc", "name": "t1"}
+        client = _client(_transport(json_body=team))
+        assert client.get_team("abc") == team
+
+
+class TestCreateTeam:
+    def test_sends_catalog_entry(self) -> None:
+        created = {"team_id": "new-id", "name": "new"}
+        sent_bodies: list[dict[str, Any]] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            sent_bodies.append(json.loads(request.content))
+            return httpx.Response(200, json=created)
+
+        client = _client(httpx.MockTransport(handler))
+        result = client.create_team("my-entry")
+        assert result == created
+        assert sent_bodies[0] == {"catalog_entry_id": "my-entry"}
+
+
+class TestDeleteTeam:
+    def test_no_return(self) -> None:
+        client = _client(_transport(status=204, content=b""))
+        # Should not raise
+        client.delete_team("abc")
+
+
+class TestRestoreTeam:
+    def test_returns_restored(self) -> None:
+        team = {"team_id": "abc", "status": "running"}
+        client = _client(_transport(json_body=team))
+        assert client.restore_team("abc") == team
+
+
+class TestGetEvents:
+    def test_returns_event_list(self) -> None:
+        events = [{"sequence": 1, "event": {"type": "msg"}}]
+        client = _client(_transport(json_body={"events": events}))
+        assert client.get_events("abc") == events
+
+
+# -- messaging --
+
+
+class TestSendMessage:
+    def test_sends_content(self) -> None:
+        sent: list[dict[str, Any]] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            sent.append(json.loads(request.content))
+            return httpx.Response(200, json={})
+
+        client = _client(httpx.MockTransport(handler))
+        client.send_message("team-1", "hello")
+        assert sent[0] == {"content": "hello"}
+
+
+class TestHumanInput:
+    def test_sends_content_and_message_id(self) -> None:
+        sent: list[dict[str, Any]] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            sent.append(json.loads(request.content))
+            return httpx.Response(200, json={})
+
+        client = _client(httpx.MockTransport(handler))
+        client.human_input("team-1", "yes", "msg-42")
+        assert sent[0] == {"content": "yes", "message_id": "msg-42"}
+
+
+# -- workspace --
+
+
+class TestWorkspaceTree:
+    def test_returns_tree(self) -> None:
+        tree = {"team_id": "t1", "path": "/", "entries": []}
+        client = _client(_transport(json_body=tree))
+        assert client.workspace_tree("t1") == tree
+
+
+class TestWorkspaceRead:
+    def test_returns_bytes(self) -> None:
+        client = _client(_transport(content=b"file content here"))
+        assert client.workspace_read("t1", "readme.md") == b"file content here"
+
+
+class TestWorkspaceUpload:
+    def test_sends_multipart(self) -> None:
+        result = {"path": "readme.md", "size": 5}
+        urls: list[str] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            urls.append(str(request.url))
+            return httpx.Response(200, json=result)
+
+        client = _client(httpx.MockTransport(handler))
+        resp = client.workspace_upload("t1", "readme.md", b"hello")
+        assert resp == result
+        assert "/workspace/t1/file" in urls[0]
+
+
+# -- error handling --
+
+
+class TestErrorHandling:
+    def test_404_raises_exit(self) -> None:
+        client = _client(_transport(status=404, json_body={"detail": "Not found"}))
+        with pytest.raises(RuntimeError):
+            client.get_team("missing")
+
+    def test_500_raises_exit(self) -> None:
+        client = _client(_transport(status=500, content=b"Internal error"))
+        with pytest.raises(RuntimeError):
+            client.list_teams()
+
+    def test_409_raises_exit(self) -> None:
+        client = _client(_transport(status=409, json_body={"detail": "Conflict"}))
+        with pytest.raises(RuntimeError):
+            client.delete_team("abc")
+
+    def test_404_prints_detail(self, capsys: pytest.CaptureFixture[str]) -> None:
+        client = _client(_transport(status=404, json_body={"detail": "Not found"}))
+        with pytest.raises(RuntimeError):
+            client.get_team("missing")
+        assert "Not found" in capsys.readouterr().err
+
+
+class TestApiKey:
+    def test_api_key_header(self) -> None:
+        headers: dict[str, str] = {}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            headers.update(dict(request.headers))
+            return httpx.Response(200, json={"teams": []})
+
+        client = _client(httpx.MockTransport(handler), api_key="secret-key")
+        client.list_teams()
+        assert headers.get("authorization") == "Bearer secret-key"

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import re
 from typing import Any
 from unittest.mock import MagicMock, patch
 
@@ -13,6 +14,13 @@ from typer.testing import CliRunner
 from akgentic.infra.cli.main import app
 
 runner = CliRunner()
+
+_ANSI_RE = re.compile(r"\x1b\[[0-9;]*m")
+
+
+def _strip_ansi(text: str) -> str:
+    """Remove ANSI escape codes from text."""
+    return _ANSI_RE.sub("", text)
 
 
 def _mock_client(**overrides: Any) -> MagicMock:
@@ -81,17 +89,19 @@ class TestHelp:
     def test_help_shows_groups(self) -> None:
         result = _invoke(["--help"])
         assert result.exit_code == 0
-        assert "team" in result.output
-        assert "workspace" in result.output
-        assert "chat" in result.output
-        assert "message" in result.output
-        assert "reply" in result.output
+        output = _strip_ansi(result.output)
+        assert "team" in output
+        assert "workspace" in output
+        assert "chat" in output
+        assert "message" in output
+        assert "reply" in output
 
     def test_help_shows_global_options(self) -> None:
         result = _invoke(["--help"])
-        assert "--server" in result.output
-        assert "--api-key" in result.output
-        assert "--format" in result.output
+        output = _strip_ansi(result.output)
+        assert "--server" in output
+        assert "--api-key" in output
+        assert "--format" in output
 
 
 # -- team commands --

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -1,0 +1,249 @@
+"""Tests for ak-infra CLI commands via typer.testing.CliRunner."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import typer
+import yaml
+from typer.testing import CliRunner
+
+from akgentic.infra.cli.main import app
+
+runner = CliRunner()
+
+
+def _mock_client(**overrides: Any) -> MagicMock:
+    """Build a mock ApiClient with sensible defaults."""
+    mock = MagicMock()
+    mock.list_teams.return_value = [
+        {"team_id": "t1", "name": "Team 1", "status": "running", "created_at": "2025-01-01"},
+    ]
+    mock.get_team.return_value = {
+        "team_id": "t1",
+        "name": "Team 1",
+        "status": "running",
+        "user_id": "u1",
+        "created_at": "2025-01-01",
+        "updated_at": "2025-01-02",
+    }
+    mock.create_team.return_value = {
+        "team_id": "new",
+        "name": "New Team",
+        "status": "created",
+        "user_id": "u1",
+        "created_at": "2025-01-01",
+        "updated_at": "2025-01-01",
+    }
+    mock.delete_team.return_value = None
+    mock.restore_team.return_value = {
+        "team_id": "t1",
+        "name": "Team 1",
+        "status": "running",
+        "user_id": "u1",
+        "created_at": "2025-01-01",
+        "updated_at": "2025-01-03",
+    }
+    mock.get_events.return_value = [
+        {"sequence": 1, "timestamp": "2025-01-01T00:00:00", "event": {"type": "started"}},
+    ]
+    mock.send_message.return_value = None
+    mock.human_input.return_value = None
+    mock.workspace_tree.return_value = {
+        "team_id": "t1",
+        "path": "/",
+        "entries": [
+            {"name": "docs", "is_dir": True, "size": 0},
+            {"name": "readme.md", "is_dir": False, "size": 42},
+        ],
+    }
+    mock.workspace_read.return_value = b"file content"
+    mock.workspace_upload.return_value = {"path": "readme.md", "size": 12}
+    for k, v in overrides.items():
+        setattr(mock, k, v)
+    return mock
+
+
+def _invoke(args: list[str], mock: MagicMock | None = None) -> Any:
+    """Invoke CLI with a mocked client, return the Result."""
+    if mock is None:
+        mock = _mock_client()
+    with patch("akgentic.infra.cli.main.ApiClient", return_value=mock):
+        return runner.invoke(app, args)
+
+
+# -- help --
+
+
+class TestHelp:
+    def test_help_shows_groups(self) -> None:
+        result = _invoke(["--help"])
+        assert result.exit_code == 0
+        assert "team" in result.output
+        assert "workspace" in result.output
+        assert "chat" in result.output
+        assert "message" in result.output
+        assert "reply" in result.output
+
+    def test_help_shows_global_options(self) -> None:
+        result = _invoke(["--help"])
+        assert "--server" in result.output
+        assert "--api-key" in result.output
+        assert "--format" in result.output
+
+
+# -- team commands --
+
+
+class TestTeamList:
+    def test_table_output(self) -> None:
+        result = _invoke(["team", "list"])
+        assert result.exit_code == 0
+        assert "Team 1" in result.output
+        assert "running" in result.output
+
+    def test_json_output(self) -> None:
+        result = _invoke(["--format", "json", "team", "list"])
+        assert result.exit_code == 0
+        parsed = json.loads(result.output)
+        assert isinstance(parsed, list)
+        assert parsed[0]["team_id"] == "t1"
+
+    def test_yaml_output(self) -> None:
+        result = _invoke(["--format", "yaml", "team", "list"])
+        assert result.exit_code == 0
+        parsed = yaml.safe_load(result.output)
+        assert isinstance(parsed, list)
+
+
+class TestTeamGet:
+    def test_shows_detail(self) -> None:
+        result = _invoke(["team", "get", "t1"])
+        assert result.exit_code == 0
+        assert "Team 1" in result.output
+
+    def test_json_output(self) -> None:
+        result = _invoke(["--format", "json", "team", "get", "t1"])
+        parsed = json.loads(result.output)
+        assert parsed["team_id"] == "t1"
+
+
+class TestTeamCreate:
+    def test_creates_team(self) -> None:
+        mock = _mock_client()
+        result = _invoke(["team", "create", "my-catalog-entry"], mock)
+        assert result.exit_code == 0
+        mock.create_team.assert_called_once_with("my-catalog-entry")
+        assert "New Team" in result.output
+
+
+class TestTeamDelete:
+    def test_deletes_team(self) -> None:
+        mock = _mock_client()
+        result = _invoke(["team", "delete", "t1"], mock)
+        assert result.exit_code == 0
+        mock.delete_team.assert_called_once_with("t1")
+        assert "deleted" in result.output.lower()
+
+
+class TestTeamRestore:
+    def test_restores_team(self) -> None:
+        mock = _mock_client()
+        result = _invoke(["team", "restore", "t1"], mock)
+        assert result.exit_code == 0
+        mock.restore_team.assert_called_once_with("t1")
+        assert "Team 1" in result.output
+
+
+class TestTeamEvents:
+    def test_shows_events(self) -> None:
+        result = _invoke(["team", "events", "t1"])
+        assert result.exit_code == 0
+        assert "started" in result.output
+
+
+# -- message / reply --
+
+
+class TestMessage:
+    def test_sends_message(self) -> None:
+        mock = _mock_client()
+        result = _invoke(["message", "t1", "hello world"], mock)
+        assert result.exit_code == 0
+        mock.send_message.assert_called_once_with("t1", "hello world")
+        assert "sent" in result.output.lower()
+
+
+class TestReply:
+    def test_sends_reply(self) -> None:
+        mock = _mock_client()
+        result = _invoke(["reply", "t1", "yes", "--message-id", "msg-42"], mock)
+        assert result.exit_code == 0
+        mock.human_input.assert_called_once_with("t1", "yes", "msg-42")
+        assert "sent" in result.output.lower()
+
+
+# -- chat placeholder --
+
+
+class TestChat:
+    def test_not_implemented(self) -> None:
+        result = _invoke(["chat"])
+        assert result.exit_code == 0
+        assert "5.2a" in result.output
+
+
+# -- workspace --
+
+
+class TestWorkspaceTree:
+    def test_shows_tree(self) -> None:
+        result = _invoke(["workspace", "tree", "t1"])
+        assert result.exit_code == 0
+        assert "docs" in result.output
+        assert "readme.md" in result.output
+
+    def test_json_output(self) -> None:
+        result = _invoke(["--format", "json", "workspace", "tree", "t1"])
+        parsed = json.loads(result.output)
+        assert "entries" in parsed
+
+
+class TestWorkspaceRead:
+    def test_shows_content(self) -> None:
+        result = _invoke(["workspace", "read", "t1", "readme.md"])
+        assert result.exit_code == 0
+        assert "file content" in result.output
+
+    def test_binary_file(self) -> None:
+        mock = _mock_client()
+        mock.workspace_read.return_value = bytes(range(256))
+        result = _invoke(["workspace", "read", "t1", "binary.bin"], mock)
+        assert "binary" in result.output.lower() or "bytes" in result.output.lower()
+
+
+class TestWorkspaceUpload:
+    def test_uploads_file(self, tmp_path: Any) -> None:
+        f = tmp_path / "test.txt"
+        f.write_text("hello")
+        mock = _mock_client()
+        result = _invoke(["workspace", "upload", "t1", str(f)], mock)
+        assert result.exit_code == 0
+        assert "readme.md" in result.output or "Uploaded" in result.output
+
+    def test_missing_file(self) -> None:
+        result = _invoke(["workspace", "upload", "t1", "/nonexistent/file.txt"])
+        assert result.exit_code != 0
+
+
+# -- error cases --
+
+
+class TestErrorCases:
+    def test_404_response(self) -> None:
+        mock = _mock_client()
+        mock.get_team.side_effect = typer.Exit(code=1)
+        result = _invoke(["team", "get", "missing"], mock)
+        assert result.exit_code != 0

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -157,6 +157,13 @@ class TestTeamDelete:
         mock.delete_team.assert_called_once_with("t1")
         assert "deleted" in result.output.lower()
 
+    def test_json_output(self) -> None:
+        mock = _mock_client()
+        result = _invoke(["--format", "json", "team", "delete", "t1"], mock)
+        assert result.exit_code == 0
+        parsed = json.loads(result.output)
+        assert parsed["status"] == "deleted"
+
 
 class TestTeamRestore:
     def test_restores_team(self) -> None:
@@ -184,6 +191,13 @@ class TestMessage:
         assert result.exit_code == 0
         mock.send_message.assert_called_once_with("t1", "hello world")
         assert "sent" in result.output.lower()
+
+    def test_json_output(self) -> None:
+        mock = _mock_client()
+        result = _invoke(["--format", "json", "message", "t1", "hello"], mock)
+        assert result.exit_code == 0
+        parsed = json.loads(result.output)
+        assert parsed["status"] == "sent"
 
 
 class TestReply:
@@ -218,6 +232,11 @@ class TestWorkspaceTree:
     def test_json_output(self) -> None:
         result = _invoke(["--format", "json", "workspace", "tree", "t1"])
         parsed = json.loads(result.output)
+        assert "entries" in parsed
+
+    def test_yaml_output(self) -> None:
+        result = _invoke(["--format", "yaml", "workspace", "tree", "t1"])
+        parsed = yaml.safe_load(result.output)
         assert "entries" in parsed
 
 

--- a/tests/test_cli_formatters.py
+++ b/tests/test_cli_formatters.py
@@ -1,0 +1,109 @@
+"""Tests for akgentic.infra.cli.formatters."""
+
+from __future__ import annotations
+
+import json
+
+import yaml
+
+from akgentic.infra.cli.formatters import (
+    OutputFormat,
+    format_json,
+    format_output,
+    format_table,
+    format_yaml,
+)
+
+
+class TestFormatTable:
+    def test_basic_table(self) -> None:
+        rows = [
+            {"name": "alpha", "status": "running"},
+            {"name": "beta", "status": "stopped"},
+        ]
+        result = format_table(rows, ["name", "status"])
+        lines = result.splitlines()
+        assert len(lines) == 4  # header + separator + 2 rows
+        assert "NAME" in lines[0]
+        assert "STATUS" in lines[0]
+        assert "alpha" in lines[2]
+        assert "beta" in lines[3]
+
+    def test_empty_rows(self) -> None:
+        assert format_table([], ["a", "b"]) == "(no results)"
+
+    def test_missing_keys(self) -> None:
+        rows = [{"name": "x"}]
+        result = format_table(rows, ["name", "missing_col"])
+        assert "x" in result
+
+    def test_column_alignment(self) -> None:
+        rows = [{"a": "short", "b": "x"}, {"a": "x", "b": "longvalue"}]
+        result = format_table(rows, ["a", "b"])
+        lines = result.splitlines()
+        # All lines should have the same length (padded)
+        assert len(set(len(line.rstrip()) for line in lines)) <= 2  # header might differ slightly
+
+
+class TestFormatJson:
+    def test_dict(self) -> None:
+        data = {"key": "value", "num": 42}
+        result = format_json(data)
+        parsed = json.loads(result)
+        assert parsed == data
+
+    def test_list(self) -> None:
+        data = [{"a": 1}, {"a": 2}]
+        result = format_json(data)
+        parsed = json.loads(result)
+        assert parsed == data
+
+    def test_datetime_serialization(self) -> None:
+        from datetime import datetime
+
+        data = {"ts": datetime(2025, 1, 1, 12, 0)}
+        result = format_json(data)
+        assert "2025-01-01" in result
+
+
+class TestFormatYaml:
+    def test_dict(self) -> None:
+        data = {"key": "value", "num": 42}
+        result = format_yaml(data)
+        parsed = yaml.safe_load(result)
+        assert parsed == data
+
+    def test_list(self) -> None:
+        data = [{"a": 1}, {"a": 2}]
+        result = format_yaml(data)
+        parsed = yaml.safe_load(result)
+        assert parsed == data
+
+
+class TestFormatOutput:
+    def test_json_format(self) -> None:
+        data = {"x": 1}
+        result = format_output(data, OutputFormat.json)
+        assert json.loads(result) == data
+
+    def test_yaml_format(self) -> None:
+        data = {"x": 1}
+        result = format_output(data, OutputFormat.yaml)
+        assert yaml.safe_load(result) == data
+
+    def test_table_format_with_list(self) -> None:
+        rows = [{"a": "1", "b": "2"}]
+        result = format_output(rows, OutputFormat.table, columns=["a", "b"])
+        assert "A" in result
+        assert "B" in result
+
+    def test_table_format_with_dict(self) -> None:
+        data = {"a": "1", "b": "2"}
+        result = format_output(data, OutputFormat.table, columns=["a", "b"])
+        assert "1" in result
+
+    def test_table_fallback_no_columns(self) -> None:
+        data = {"a": 1}
+        result = format_output(data, OutputFormat.table)
+        # Falls back to JSON
+        assert json.loads(result) == data

--- a/tests/test_cli_formatters.py
+++ b/tests/test_cli_formatters.py
@@ -37,6 +37,13 @@ class TestFormatTable:
         result = format_table(rows, ["name", "missing_col"])
         assert "x" in result
 
+    def test_nested_dict_values(self) -> None:
+        rows = [{"name": "evt1", "data": {"type": "started", "ts": 123}}]
+        result = format_table(rows, ["name", "data"])
+        # dict values should be JSON-serialized, not Python repr
+        assert '"type"' in result
+        assert "{'type'" not in result
+
     def test_column_alignment(self) -> None:
         rows = [{"a": "short", "b": "x"}, {"a": "x", "b": "longvalue"}]
         result = format_table(rows, ["a", "b"])


### PR DESCRIPTION
## Summary

- Implements the `ak-infra` CLI with Typer: team CRUD, messaging, workspace, and global `--server/--api-key/--format` options
- `ApiClient` HTTP wrapper mapping all 12 server endpoints
- `OutputFormat` enum with table/json/yaml formatters
- 56 unit tests, 96% coverage, ruff clean, mypy strict clean

Closes #39