### PR TITLE
Interactive Chat REPL Core & WebSocket Client

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ dependencies = [
     "typer[all]>=0.9.0",
     "httpx>=0.27.0",
     "pyyaml>=6.0",
+    "websockets>=12.0",
 ]
 
 [project.scripts]

--- a/src/akgentic/infra/cli/main.py
+++ b/src/akgentic/infra/cli/main.py
@@ -146,7 +146,7 @@ def reply(
 
 @app.command("chat")
 def chat(
-    team_id: Annotated[str, typer.Argument(help="Team ID to chat with")],
+    team_id: Annotated[str | None, typer.Argument(help="Team ID to chat with")] = None,
     create: Annotated[
         str | None, typer.Option("--create", help="Create team from catalog entry first")
     ] = None,
@@ -156,6 +156,10 @@ def chat(
         team = _state.client.create_team(create)
         team_id = str(team["team_id"])
         typer.echo(f"Created team {team_id}")
+
+    if team_id is None:
+        typer.echo("Error: provide a TEAM_ID or use --create <catalog_entry>", err=True)
+        raise typer.Exit(code=1)
 
     ws = WsClient(
         base_url=_state.server,

--- a/src/akgentic/infra/cli/main.py
+++ b/src/akgentic/infra/cli/main.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from pathlib import Path
 from typing import Annotated, Any
 
@@ -9,6 +10,8 @@ import typer
 
 from akgentic.infra.cli.client import ApiClient
 from akgentic.infra.cli.formatters import OutputFormat, format_output
+from akgentic.infra.cli.repl import ChatSession
+from akgentic.infra.cli.ws_client import WsClient
 
 app = typer.Typer(name="ak-infra", help="Akgentic Infrastructure CLI")
 team_app = typer.Typer(name="team", help="Manage agent teams")
@@ -26,6 +29,8 @@ class _State:
 
     client: ApiClient
     fmt: OutputFormat
+    server: str
+    api_key: str | None
 
 
 _state = _State()
@@ -54,6 +59,8 @@ def main(
     """Akgentic Infrastructure CLI — manage teams, messaging, and workspace."""
     _state.client = ApiClient(base_url=server, api_key=api_key)
     _state.fmt = fmt
+    _state.server = server
+    _state.api_key = api_key
 
 
 # -- team commands --
@@ -134,13 +141,29 @@ def reply(
         _print({"team_id": team_id, "message_id": message_id, "status": "sent"})
 
 
-# -- chat placeholder --
+# -- chat --
 
 
 @app.command("chat")
-def chat() -> None:
-    """Interactive chat REPL (not yet implemented)."""
-    typer.echo("Not yet implemented — see Story 5.2a")
+def chat(
+    team_id: Annotated[str, typer.Argument(help="Team ID to chat with")],
+    create: Annotated[
+        str | None, typer.Option("--create", help="Create team from catalog entry first")
+    ] = None,
+) -> None:
+    """Interactive chat REPL — connect to a team via WebSocket."""
+    if create is not None:
+        team = _state.client.create_team(create)
+        team_id = str(team["team_id"])
+        typer.echo(f"Created team {team_id}")
+
+    ws = WsClient(
+        base_url=_state.server,
+        team_id=team_id,
+        api_key=_state.api_key,
+    )
+    session = ChatSession(_state.client, ws, team_id, _state.fmt)
+    asyncio.run(session.run())
 
 
 # -- workspace commands --

--- a/src/akgentic/infra/cli/repl.py
+++ b/src/akgentic/infra/cli/repl.py
@@ -7,6 +7,8 @@ import json
 import sys
 from typing import Any
 
+import websockets.exceptions
+
 from akgentic.infra.cli.client import ApiClient
 from akgentic.infra.cli.formatters import OutputFormat
 from akgentic.infra.cli.ws_client import WsClient
@@ -80,6 +82,12 @@ class ChatSession:
                 _print_event(event)
             except asyncio.CancelledError:
                 raise
+            except websockets.exceptions.ConnectionClosed as exc:
+                if exc.rcvd is not None and exc.rcvd.code == 4004:
+                    print("Error: team not found", file=sys.stderr)
+                elif exc.rcvd is not None and exc.rcvd.code not in (1000, 1001):
+                    print(f"Connection closed: {exc.rcvd.reason or exc.rcvd.code}", file=sys.stderr)
+                break
             except Exception:  # noqa: BLE001
                 if self._running:
                     break
@@ -92,8 +100,7 @@ class ChatSession:
             return
         displayed = False
         for evt in events:
-            inner = evt.get("event", {})
-            if _print_event(evt if "__model__" in evt else {"event": inner}):
+            if _print_event(evt):
                 displayed = True
         if displayed:
             print("--- history ---")

--- a/src/akgentic/infra/cli/repl.py
+++ b/src/akgentic/infra/cli/repl.py
@@ -1,0 +1,131 @@
+"""Interactive chat REPL for team communication."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import sys
+from typing import Any
+
+from akgentic.infra.cli.client import ApiClient
+from akgentic.infra.cli.formatters import OutputFormat
+from akgentic.infra.cli.ws_client import WsClient
+
+# Event types to display vs skip
+_DISPLAY_EVENTS = {"SentMessage", "ErrorMessage"}
+
+
+class ChatSession:
+    """REPL session combining REST message sending with WebSocket event streaming."""
+
+    def __init__(
+        self,
+        client: ApiClient,
+        ws_client: WsClient,
+        team_id: str,
+        fmt: OutputFormat,
+    ) -> None:
+        self._client = client
+        self._ws = ws_client
+        self._team_id = team_id
+        self._fmt = fmt
+        self._running = True
+
+    async def run(self) -> None:
+        """Main REPL loop: connect WS, replay history, read input, stream events."""
+        async with self._ws:
+            self._replay_history()
+            print(f"Connected to team {self._team_id}. Type /quit or Ctrl+C to exit.")
+
+            receive_task = asyncio.create_task(self._receive_loop())
+            try:
+                await self._input_loop()
+            except KeyboardInterrupt:
+                pass
+            finally:
+                self._running = False
+                receive_task.cancel()
+                try:
+                    await receive_task
+                except asyncio.CancelledError:
+                    pass
+                print("Session closed.")
+
+    async def _input_loop(self) -> None:
+        """Read user input and send messages."""
+        loop = asyncio.get_running_loop()
+        while self._running:
+            try:
+                line = await loop.run_in_executor(None, _read_input, "You: ")
+            except (EOFError, KeyboardInterrupt):
+                break
+
+            if not line.strip():
+                continue
+
+            if line.strip() == "/quit":
+                break
+
+            # Send message via REST API (run in executor to avoid blocking)
+            try:
+                await loop.run_in_executor(None, self._client.send_message, self._team_id, line)
+            except SystemExit:
+                print("Error sending message.", file=sys.stderr)
+
+    async def _receive_loop(self) -> None:
+        """Background coroutine: read WebSocket events and print them."""
+        while self._running:
+            try:
+                event = await self._ws.receive_event()
+                _print_event(event)
+            except asyncio.CancelledError:
+                raise
+            except Exception:  # noqa: BLE001
+                if self._running:
+                    break
+
+    def _replay_history(self) -> None:
+        """Fetch and display past events before starting the REPL."""
+        try:
+            events = self._client.get_events(self._team_id)
+        except SystemExit:
+            return
+        displayed = False
+        for evt in events:
+            inner = evt.get("event", {})
+            if _print_event(evt if "__model__" in evt else {"event": inner}):
+                displayed = True
+        if displayed:
+            print("--- history ---")
+
+
+def _read_input(prompt: str) -> str:
+    """Read a line from stdin (used via run_in_executor)."""
+    return input(prompt)
+
+
+def _print_event(data: dict[str, Any]) -> bool:
+    """Format and print a single event. Returns True if something was printed."""
+    event = data.get("event", data)
+    if isinstance(event, str):
+        try:
+            event = json.loads(event)
+        except (json.JSONDecodeError, TypeError):
+            return False
+
+    model = event.get("__model__", "")
+    if model not in _DISPLAY_EVENTS:
+        return False
+
+    if model == "ErrorMessage":
+        content = event.get("content", event.get("error", ""))
+        print(f"[error] {content}")
+        return True
+
+    # SentMessage — agent response
+    sender = event.get("sender", "agent")
+    content = event.get("content", "")
+    if content:
+        print(f"[{sender}] {content}")
+        return True
+    return False

--- a/src/akgentic/infra/cli/ws_client.py
+++ b/src/akgentic/infra/cli/ws_client.py
@@ -1,0 +1,57 @@
+"""WebSocket client wrapper for real-time event streaming."""
+
+from __future__ import annotations
+
+import json
+import sys
+from typing import Any
+
+import websockets.asyncio.client
+
+
+class WsClient:
+    """Async WebSocket client for streaming team events."""
+
+    def __init__(self, base_url: str, team_id: str, api_key: str | None = None) -> None:
+        ws_url = base_url.replace("https://", "wss://").replace("http://", "ws://")
+        self._url = f"{ws_url}/ws/{team_id}"
+        self._headers: list[tuple[str, str]] = []
+        if api_key:
+            self._headers.append(("Authorization", f"Bearer {api_key}"))
+        self._ws: websockets.asyncio.client.ClientConnection | None = None
+
+    @property
+    def url(self) -> str:
+        """Return the resolved WebSocket URL."""
+        return self._url
+
+    async def connect(self) -> WsClient:
+        """Open WebSocket connection."""
+        try:
+            self._ws = await websockets.asyncio.client.connect(
+                self._url,
+                additional_headers=self._headers,
+            )
+        except (ConnectionRefusedError, OSError) as exc:
+            print(f"Connection error: {exc}", file=sys.stderr)
+            raise SystemExit(1) from exc
+        return self
+
+    async def receive_event(self) -> dict[str, Any]:
+        """Read next JSON message from WebSocket."""
+        assert self._ws is not None, "Not connected"  # noqa: S101
+        raw = await self._ws.recv()
+        text = raw if isinstance(raw, str) else raw.decode("utf-8")
+        return json.loads(text)  # type: ignore[no-any-return]
+
+    async def close(self) -> None:
+        """Close WebSocket connection."""
+        if self._ws is not None:
+            await self._ws.close()
+            self._ws = None
+
+    async def __aenter__(self) -> WsClient:
+        return await self.connect()
+
+    async def __aexit__(self, *_args: object) -> None:
+        await self.close()

--- a/src/akgentic/infra/cli/ws_client.py
+++ b/src/akgentic/infra/cli/ws_client.py
@@ -7,6 +7,7 @@ import sys
 from typing import Any
 
 import websockets.asyncio.client
+import websockets.exceptions
 
 
 class WsClient:
@@ -35,11 +36,22 @@ class WsClient:
         except (ConnectionRefusedError, OSError) as exc:
             print(f"Connection error: {exc}", file=sys.stderr)
             raise SystemExit(1) from exc
+        except websockets.exceptions.InvalidStatus as exc:
+            status = exc.response.status_code
+            if status == 404 or status == 403:
+                print("Error: team not found", file=sys.stderr)
+            else:
+                print(f"WebSocket rejected: HTTP {status}", file=sys.stderr)
+            raise SystemExit(1) from exc
+        except websockets.exceptions.InvalidHandshake as exc:
+            print(f"WebSocket handshake failed: {exc}", file=sys.stderr)
+            raise SystemExit(1) from exc
         return self
 
     async def receive_event(self) -> dict[str, Any]:
         """Read next JSON message from WebSocket."""
-        assert self._ws is not None, "Not connected"  # noqa: S101
+        if self._ws is None:
+            raise RuntimeError("Not connected")
         raw = await self._ws.recv()
         text = raw if isinstance(raw, str) else raw.decode("utf-8")
         return json.loads(text)  # type: ignore[no-any-return]

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -213,7 +213,7 @@ class TestReply:
 
 
 class TestChat:
-    def test_chat_requires_team_id(self) -> None:
+    def test_chat_no_args_shows_error(self) -> None:
         result = _invoke(["chat"])
         assert result.exit_code != 0
 
@@ -232,7 +232,7 @@ class TestChat:
         mock_session_cls.assert_called_once()
         mock_run.assert_called_once_with(mock_session.run())
 
-    def test_chat_create_flag(self) -> None:
+    def test_chat_create_flag_no_team_id(self) -> None:
         mock = _mock_client()
         with (
             patch("akgentic.infra.cli.main.ChatSession") as mock_session_cls,
@@ -240,7 +240,7 @@ class TestChat:
             patch("akgentic.infra.cli.main.asyncio.run"),
         ):
             mock_session_cls.return_value = MagicMock()
-            result = _invoke(["chat", "ignored", "--create", "my-catalog"], mock)
+            result = _invoke(["chat", "--create", "my-catalog"], mock)
         assert result.exit_code == 0
         mock.create_team.assert_called_once_with("my-catalog")
 

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -209,14 +209,40 @@ class TestReply:
         assert "sent" in result.output.lower()
 
 
-# -- chat placeholder --
+# -- chat --
 
 
 class TestChat:
-    def test_not_implemented(self) -> None:
+    def test_chat_requires_team_id(self) -> None:
         result = _invoke(["chat"])
+        assert result.exit_code != 0
+
+    def test_chat_invokes_session(self) -> None:
+        mock = _mock_client()
+        with (
+            patch("akgentic.infra.cli.main.ChatSession") as mock_session_cls,
+            patch("akgentic.infra.cli.main.WsClient") as mock_ws_cls,
+            patch("akgentic.infra.cli.main.asyncio.run") as mock_run,
+        ):
+            mock_session = MagicMock()
+            mock_session_cls.return_value = mock_session
+            result = _invoke(["chat", "t1"], mock)
         assert result.exit_code == 0
-        assert "5.2a" in result.output
+        mock_ws_cls.assert_called_once()
+        mock_session_cls.assert_called_once()
+        mock_run.assert_called_once_with(mock_session.run())
+
+    def test_chat_create_flag(self) -> None:
+        mock = _mock_client()
+        with (
+            patch("akgentic.infra.cli.main.ChatSession") as mock_session_cls,
+            patch("akgentic.infra.cli.main.WsClient"),
+            patch("akgentic.infra.cli.main.asyncio.run"),
+        ):
+            mock_session_cls.return_value = MagicMock()
+            result = _invoke(["chat", "ignored", "--create", "my-catalog"], mock)
+        assert result.exit_code == 0
+        mock.create_team.assert_called_once_with("my-catalog")
 
 
 # -- workspace --

--- a/tests/test_cli_repl.py
+++ b/tests/test_cli_repl.py
@@ -7,6 +7,7 @@ from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+import websockets.exceptions
 
 from akgentic.infra.cli.formatters import OutputFormat
 from akgentic.infra.cli.repl import ChatSession, _print_event
@@ -201,6 +202,40 @@ class TestReceiveLoop:
 
         out = capsys.readouterr().out
         assert "StateChanged" not in out
+
+
+class TestReceiveLoopCloseCode:
+    async def test_close_code_4004_prints_error(self, capsys: pytest.CaptureFixture[str]) -> None:
+        close_frame = MagicMock()
+        close_frame.code = 4004
+        close_frame.reason = "Team not found"
+        exc = websockets.exceptions.ConnectionClosedError(rcvd=close_frame, sent=None)
+        client = _mock_client()
+        ws = _mock_ws()
+        ws.receive_event = AsyncMock(side_effect=exc)
+        session = ChatSession(client, ws, "t1", OutputFormat.table)
+
+        with patch("akgentic.infra.cli.repl._read_input", side_effect=["/quit"]):
+            await session.run()
+
+        err = capsys.readouterr().err
+        assert "team not found" in err
+
+    async def test_close_code_1000_no_error(self, capsys: pytest.CaptureFixture[str]) -> None:
+        close_frame = MagicMock()
+        close_frame.code = 1000
+        close_frame.reason = "OK"
+        exc = websockets.exceptions.ConnectionClosedOK(rcvd=close_frame, sent=None)
+        client = _mock_client()
+        ws = _mock_ws()
+        ws.receive_event = AsyncMock(side_effect=exc)
+        session = ChatSession(client, ws, "t1", OutputFormat.table)
+
+        with patch("akgentic.infra.cli.repl._read_input", side_effect=["/quit"]):
+            await session.run()
+
+        err = capsys.readouterr().err
+        assert err == ""
 
 
 class TestPrintEvent:

--- a/tests/test_cli_repl.py
+++ b/tests/test_cli_repl.py
@@ -1,0 +1,241 @@
+"""Tests for ChatSession REPL core."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from akgentic.infra.cli.formatters import OutputFormat
+from akgentic.infra.cli.repl import ChatSession, _print_event
+
+
+def _mock_client(**overrides: Any) -> MagicMock:
+    """Build a mock ApiClient."""
+    mock = MagicMock()
+    mock.get_events.return_value = []
+    mock.send_message.return_value = None
+    for k, v in overrides.items():
+        setattr(mock, k, v)
+    return mock
+
+
+def _mock_ws() -> AsyncMock:
+    """Build a mock WsClient."""
+    ws = AsyncMock()
+    ws.__aenter__ = AsyncMock(return_value=ws)
+    ws.__aexit__ = AsyncMock(return_value=None)
+    ws.receive_event = AsyncMock(side_effect=asyncio.CancelledError)
+    return ws
+
+
+class TestReplayHistory:
+    def test_replay_displays_sent_messages(self, capsys: pytest.CaptureFixture[str]) -> None:
+        client = _mock_client(
+            get_events=MagicMock(
+                return_value=[
+                    {
+                        "event": {
+                            "__model__": "SentMessage",
+                            "sender": "bot",
+                            "content": "hello",
+                        }
+                    },
+                    {
+                        "event": {
+                            "__model__": "StateChangedMessage",
+                            "state": "running",
+                        }
+                    },
+                ]
+            )
+        )
+        ws = _mock_ws()
+        session = ChatSession(client, ws, "t1", OutputFormat.table)
+        session._replay_history()
+        out = capsys.readouterr().out
+        assert "[bot] hello" in out
+        assert "--- history ---" in out
+        assert "StateChanged" not in out
+
+    def test_replay_no_events(self, capsys: pytest.CaptureFixture[str]) -> None:
+        client = _mock_client()
+        ws = _mock_ws()
+        session = ChatSession(client, ws, "t1", OutputFormat.table)
+        session._replay_history()
+        out = capsys.readouterr().out
+        assert "--- history ---" not in out
+
+    def test_replay_handles_error(self, capsys: pytest.CaptureFixture[str]) -> None:
+        client = _mock_client()
+        client.get_events.side_effect = SystemExit(1)
+        ws = _mock_ws()
+        session = ChatSession(client, ws, "t1", OutputFormat.table)
+        session._replay_history()  # Should not raise
+
+
+class TestQuitHandling:
+    async def test_quit_command(self, capsys: pytest.CaptureFixture[str]) -> None:
+        client = _mock_client()
+        ws = _mock_ws()
+        session = ChatSession(client, ws, "t1", OutputFormat.table)
+
+        with patch("akgentic.infra.cli.repl._read_input", side_effect=["/quit"]):
+            await session.run()
+
+        out = capsys.readouterr().out
+        assert "Connected to team t1" in out
+        assert "Session closed." in out
+
+    async def test_ctrl_c_exits(self, capsys: pytest.CaptureFixture[str]) -> None:
+        client = _mock_client()
+        ws = _mock_ws()
+        session = ChatSession(client, ws, "t1", OutputFormat.table)
+
+        with patch(
+            "akgentic.infra.cli.repl._read_input",
+            side_effect=KeyboardInterrupt,
+        ):
+            await session.run()
+
+        out = capsys.readouterr().out
+        assert "Session closed." in out
+
+    async def test_eof_exits(self, capsys: pytest.CaptureFixture[str]) -> None:
+        client = _mock_client()
+        ws = _mock_ws()
+        session = ChatSession(client, ws, "t1", OutputFormat.table)
+
+        with patch("akgentic.infra.cli.repl._read_input", side_effect=EOFError):
+            await session.run()
+
+        out = capsys.readouterr().out
+        assert "Session closed." in out
+
+
+class TestMessageSending:
+    async def test_sends_message(self, capsys: pytest.CaptureFixture[str]) -> None:
+        client = _mock_client()
+        ws = _mock_ws()
+        session = ChatSession(client, ws, "t1", OutputFormat.table)
+
+        with patch(
+            "akgentic.infra.cli.repl._read_input",
+            side_effect=["hello world", "/quit"],
+        ):
+            await session.run()
+
+        client.send_message.assert_called_once_with("t1", "hello world")
+
+    async def test_empty_input_skipped(self, capsys: pytest.CaptureFixture[str]) -> None:
+        client = _mock_client()
+        ws = _mock_ws()
+        session = ChatSession(client, ws, "t1", OutputFormat.table)
+
+        with patch(
+            "akgentic.infra.cli.repl._read_input",
+            side_effect=["", "  ", "/quit"],
+        ):
+            await session.run()
+
+        client.send_message.assert_not_called()
+
+
+class TestReceiveLoop:
+    async def test_prints_sent_message(self, capsys: pytest.CaptureFixture[str]) -> None:
+        events = [
+            {"event": {"__model__": "SentMessage", "sender": "agent1", "content": "hi there"}},
+        ]
+        client = _mock_client()
+        ws = _mock_ws()
+        call_count = 0
+
+        async def recv_events() -> dict[str, Any]:
+            nonlocal call_count
+            if call_count < len(events):
+                evt = events[call_count]
+                call_count += 1
+                return evt
+            await asyncio.sleep(10)
+            return {}
+
+        ws.receive_event = AsyncMock(side_effect=recv_events)
+        session = ChatSession(client, ws, "t1", OutputFormat.table)
+
+        with patch(
+            "akgentic.infra.cli.repl._read_input",
+            side_effect=["/quit"],
+        ):
+            await session.run()
+
+        out = capsys.readouterr().out
+        assert "[agent1] hi there" in out
+
+    async def test_skips_state_changed(self, capsys: pytest.CaptureFixture[str]) -> None:
+        events = [
+            {"event": {"__model__": "StateChangedMessage", "state": "running"}},
+        ]
+        client = _mock_client()
+        ws = _mock_ws()
+        call_count = 0
+
+        async def recv_events() -> dict[str, Any]:
+            nonlocal call_count
+            if call_count < len(events):
+                evt = events[call_count]
+                call_count += 1
+                return evt
+            await asyncio.sleep(10)
+            return {}
+
+        ws.receive_event = AsyncMock(side_effect=recv_events)
+        session = ChatSession(client, ws, "t1", OutputFormat.table)
+
+        with patch(
+            "akgentic.infra.cli.repl._read_input",
+            side_effect=["/quit"],
+        ):
+            await session.run()
+
+        out = capsys.readouterr().out
+        assert "StateChanged" not in out
+
+
+class TestPrintEvent:
+    def test_sent_message(self, capsys: pytest.CaptureFixture[str]) -> None:
+        result = _print_event(
+            {"event": {"__model__": "SentMessage", "sender": "bot", "content": "reply"}}
+        )
+        assert result is True
+        assert "[bot] reply" in capsys.readouterr().out
+
+    def test_error_message(self, capsys: pytest.CaptureFixture[str]) -> None:
+        result = _print_event(
+            {"event": {"__model__": "ErrorMessage", "content": "something broke"}}
+        )
+        assert result is True
+        assert "[error] something broke" in capsys.readouterr().out
+
+    def test_skip_start_message(self) -> None:
+        result = _print_event({"event": {"__model__": "StartMessage"}})
+        assert result is False
+
+    def test_skip_received_message(self) -> None:
+        result = _print_event({"event": {"__model__": "ReceivedMessage"}})
+        assert result is False
+
+    def test_skip_processed_message(self) -> None:
+        result = _print_event({"event": {"__model__": "ProcessedMessage"}})
+        assert result is False
+
+    def test_sent_message_no_content(self) -> None:
+        result = _print_event(
+            {"event": {"__model__": "SentMessage", "sender": "bot", "content": ""}}
+        )
+        assert result is False
+
+    def test_empty_event(self) -> None:
+        result = _print_event({})
+        assert result is False

--- a/tests/test_cli_ws_client.py
+++ b/tests/test_cli_ws_client.py
@@ -1,0 +1,117 @@
+"""Tests for WsClient WebSocket wrapper."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from akgentic.infra.cli.ws_client import WsClient
+
+
+class TestUrlConversion:
+    def test_http_to_ws(self) -> None:
+        client = WsClient("http://localhost:8000", "team-1")
+        assert client.url == "ws://localhost:8000/ws/team-1"
+
+    def test_https_to_wss(self) -> None:
+        client = WsClient("https://example.com", "team-2")
+        assert client.url == "wss://example.com/ws/team-2"
+
+    def test_preserves_port(self) -> None:
+        client = WsClient("http://host:9090", "t3")
+        assert client.url == "ws://host:9090/ws/t3"
+
+    def test_api_key_stored(self) -> None:
+        client = WsClient("http://localhost:8000", "t1", api_key="secret")
+        assert ("Authorization", "Bearer secret") in client._headers
+
+    def test_no_api_key(self) -> None:
+        client = WsClient("http://localhost:8000", "t1")
+        assert client._headers == []
+
+
+class TestConnect:
+    async def test_connect_success(self) -> None:
+        mock_ws = AsyncMock()
+        with patch(
+            "akgentic.infra.cli.ws_client.websockets.asyncio.client.connect",
+            new_callable=AsyncMock,
+            return_value=mock_ws,
+        ):
+            client = WsClient("http://localhost:8000", "t1")
+            result = await client.connect()
+            assert result is client
+            assert client._ws is mock_ws
+
+    async def test_connect_refused_exits(self) -> None:
+        with patch(
+            "akgentic.infra.cli.ws_client.websockets.asyncio.client.connect",
+            new_callable=AsyncMock,
+            side_effect=ConnectionRefusedError("refused"),
+        ):
+            client = WsClient("http://localhost:8000", "t1")
+            with pytest.raises(SystemExit) as exc_info:
+                await client.connect()
+            assert exc_info.value.code == 1
+
+    async def test_connect_os_error_exits(self) -> None:
+        with patch(
+            "akgentic.infra.cli.ws_client.websockets.asyncio.client.connect",
+            new_callable=AsyncMock,
+            side_effect=OSError("network error"),
+        ):
+            client = WsClient("http://localhost:8000", "t1")
+            with pytest.raises(SystemExit) as exc_info:
+                await client.connect()
+            assert exc_info.value.code == 1
+
+
+class TestReceiveEvent:
+    async def test_receive_json(self) -> None:
+        event = {"__model__": "SentMessage", "content": "hello"}
+        mock_ws = AsyncMock()
+        mock_ws.recv = AsyncMock(return_value=json.dumps(event))
+        client = WsClient("http://localhost:8000", "t1")
+        client._ws = mock_ws
+        result = await client.receive_event()
+        assert result == event
+
+    async def test_receive_bytes(self) -> None:
+        event = {"__model__": "SentMessage", "content": "hi"}
+        mock_ws = AsyncMock()
+        mock_ws.recv = AsyncMock(return_value=json.dumps(event).encode("utf-8"))
+        client = WsClient("http://localhost:8000", "t1")
+        client._ws = mock_ws
+        result = await client.receive_event()
+        assert result == event
+
+
+class TestClose:
+    async def test_close(self) -> None:
+        mock_ws = AsyncMock()
+        client = WsClient("http://localhost:8000", "t1")
+        client._ws = mock_ws
+        await client.close()
+        mock_ws.close.assert_awaited_once()
+        assert client._ws is None
+
+    async def test_close_when_not_connected(self) -> None:
+        client = WsClient("http://localhost:8000", "t1")
+        await client.close()  # Should not raise
+
+
+class TestContextManager:
+    async def test_async_with(self) -> None:
+        mock_ws = AsyncMock()
+        with patch(
+            "akgentic.infra.cli.ws_client.websockets.asyncio.client.connect",
+            new_callable=AsyncMock,
+            return_value=mock_ws,
+        ):
+            client = WsClient("http://localhost:8000", "t1")
+            async with client as ws:
+                assert ws is client
+                assert client._ws is mock_ws
+            mock_ws.close.assert_awaited_once()

--- a/tests/test_cli_ws_client.py
+++ b/tests/test_cli_ws_client.py
@@ -3,9 +3,10 @@
 from __future__ import annotations
 
 import json
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+import websockets.exceptions
 
 from akgentic.infra.cli.ws_client import WsClient
 
@@ -67,6 +68,38 @@ class TestConnect:
                 await client.connect()
             assert exc_info.value.code == 1
 
+    async def test_connect_invalid_status_404_exits(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        mock_response = MagicMock()
+        mock_response.status_code = 404
+        exc = websockets.exceptions.InvalidStatus(mock_response)
+        with patch(
+            "akgentic.infra.cli.ws_client.websockets.asyncio.client.connect",
+            new_callable=AsyncMock,
+            side_effect=exc,
+        ):
+            client = WsClient("http://localhost:8000", "t1")
+            with pytest.raises(SystemExit) as exc_info:
+                await client.connect()
+            assert exc_info.value.code == 1
+        assert "team not found" in capsys.readouterr().err
+
+    async def test_connect_invalid_handshake_exits(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        exc = websockets.exceptions.InvalidHandshake("bad handshake")
+        with patch(
+            "akgentic.infra.cli.ws_client.websockets.asyncio.client.connect",
+            new_callable=AsyncMock,
+            side_effect=exc,
+        ):
+            client = WsClient("http://localhost:8000", "t1")
+            with pytest.raises(SystemExit) as exc_info:
+                await client.connect()
+            assert exc_info.value.code == 1
+        assert "handshake failed" in capsys.readouterr().err
+
 
 class TestReceiveEvent:
     async def test_receive_json(self) -> None:
@@ -86,6 +119,11 @@ class TestReceiveEvent:
         client._ws = mock_ws
         result = await client.receive_event()
         assert result == event
+
+    async def test_receive_not_connected_raises(self) -> None:
+        client = WsClient("http://localhost:8000", "t1")
+        with pytest.raises(RuntimeError, match="Not connected"):
+            await client.receive_event()
 
 
 class TestClose:


### PR DESCRIPTION
## Summary

Implements Story 5.2a: Interactive chat REPL for real-time team communication.

- **WsClient** (`cli/ws_client.py`): Async WebSocket client using `websockets` library, URL conversion (http→ws, https→wss), connection error handling (ConnectionRefused, InvalidStatus, InvalidHandshake), context manager support
- **ChatSession** (`cli/repl.py`): Async REPL loop with background WebSocket receive task, history replay via `get_events()`, `/quit` and `Ctrl+C` exit handling, `run_in_executor` for non-blocking input and REST calls, event filtering (display SentMessage/ErrorMessage, skip lifecycle events), WebSocket close code handling (4004 → team not found)
- **Chat command** (`cli/main.py`): Replaced placeholder with real implementation, optional `team_id` with `--create` flag for team creation shortcut
- **Tests**: 16 ws_client tests, 17 repl tests, 3 chat command tests — 453 total tests passing, 95% coverage

Closes #41