### PR TITLE
Interactive Chat — In-Session Slash Commands

### DIFF
--- a/src/akgentic/infra/cli/commands.py
+++ b/src/akgentic/infra/cli/commands.py
@@ -1,0 +1,347 @@
+"""Slash command registry and dispatcher for in-session REPL commands."""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from akgentic.infra.cli.ws_client import WsClient
+
+if TYPE_CHECKING:
+    from akgentic.infra.cli.repl import ChatSession
+
+# Type alias for command handlers: async def handler(args: str, session: ChatSession) -> None
+CommandHandler = Callable[[str, "ChatSession"], Awaitable[None]]
+
+
+@dataclass
+class SlashCommand:
+    """A registered slash command."""
+
+    name: str
+    handler: CommandHandler
+    help_text: str
+    usage: str
+
+
+class CommandRegistry:
+    """Registry and dispatcher for slash commands."""
+
+    def __init__(self) -> None:
+        self._commands: dict[str, SlashCommand] = {}
+
+    def register(
+        self,
+        name: str,
+        handler: CommandHandler,
+        help_text: str,
+        usage: str,
+    ) -> None:
+        """Register a slash command."""
+        self._commands[name] = SlashCommand(
+            name=name, handler=handler, help_text=help_text, usage=usage
+        )
+
+    async def dispatch(self, line: str, session: ChatSession) -> bool:
+        """Parse and dispatch a slash command.
+
+        Returns True if a command was handled (or an unknown /command was caught),
+        False if the line is not a command (no / prefix).
+        """
+        stripped = line.strip()
+        if not stripped.startswith("/"):
+            return False
+
+        parts = stripped.split(maxsplit=1)
+        cmd_name = parts[0][1:]  # strip leading /
+        args = parts[1] if len(parts) > 1 else ""
+
+        if cmd_name in self._commands:
+            await self._commands[cmd_name].handler(args, session)
+            return True
+
+        print(f"Unknown command: /{cmd_name}. Type /help for available commands.")
+        return True
+
+    @property
+    def commands(self) -> dict[str, SlashCommand]:
+        """Return registered commands."""
+        return self._commands
+
+
+# -- Built-in commands --
+
+
+async def _help_handler(args: str, session: ChatSession) -> None:
+    """List all registered commands."""
+    registry = session.command_registry
+    print("Available commands:")
+    for cmd in registry.commands.values():
+        print(f"  /{cmd.name:<12s} {cmd.help_text}")
+        if cmd.usage:
+            print(f"  {'':12s}   Usage: {cmd.usage}")
+
+
+# -- Team inspection commands --
+
+
+async def _status_handler(args: str, session: ChatSession) -> None:
+    """Show team status and agent states."""
+    loop = asyncio.get_running_loop()
+    try:
+        team = await loop.run_in_executor(None, session.client.get_team, session.team_id)
+    except SystemExit:
+        print("Error fetching team status.", file=sys.stderr)
+        return
+
+    name = team.get("name", session.team_id)
+    status = team.get("status", "unknown")
+    agents: list[dict[str, Any]] = team.get("agents", [])
+    print(f"Team: {name}")
+    print(f"Status: {status}")
+    print(f"Agents: {len(agents)}")
+
+
+async def _agents_handler(args: str, session: ChatSession) -> None:
+    """List team members with roles and state."""
+    loop = asyncio.get_running_loop()
+    try:
+        team = await loop.run_in_executor(None, session.client.get_team, session.team_id)
+    except SystemExit:
+        print("Error fetching agents.", file=sys.stderr)
+        return
+
+    agents: list[dict[str, Any]] = team.get("agents", [])
+    if not agents:
+        print("No agents in team.")
+        return
+
+    # Print header
+    print(f"{'NAME':<20s} {'ROLE':<20s} {'STATE':<15s}")
+    print(f"{'-' * 20:<20s} {'-' * 20:<20s} {'-' * 15:<15s}")
+    for agent in agents:
+        name = agent.get("name", "unknown")
+        role = agent.get("role", "unknown")
+        state = agent.get("state", "unknown")
+        print(f"{name:<20s} {role:<20s} {state:<15s}")
+
+
+# -- History command --
+
+
+async def _history_handler(args: str, session: ChatSession) -> None:
+    """Show recent messages."""
+    limit = 20
+    if args.strip():
+        try:
+            limit = int(args.strip())
+        except ValueError:
+            print("Usage: /history [N]  — N must be a positive integer.")
+            return
+        if limit <= 0:
+            print("Usage: /history [N]  — N must be a positive integer.")
+            return
+
+    loop = asyncio.get_running_loop()
+    try:
+        events = await loop.run_in_executor(None, session.client.get_events, session.team_id)
+    except SystemExit:
+        print("Error fetching history.", file=sys.stderr)
+        return
+
+    from akgentic.infra.cli.repl import _print_event
+
+    # Filter to displayable events and take last N
+    displayable = [e for e in events if _is_displayable(e)]
+    for evt in displayable[-limit:]:
+        _print_event(evt)
+
+
+def _is_displayable(data: dict[str, Any]) -> bool:
+    """Check if an event is displayable (SentMessage or ErrorMessage)."""
+    import json as json_mod
+
+    event = data.get("event", data)
+    if isinstance(event, str):
+        try:
+            event = json_mod.loads(event)
+        except (json_mod.JSONDecodeError, TypeError):
+            return False
+    model = event.get("__model__", "")
+    return model in {"SentMessage", "ErrorMessage"}
+
+
+# -- Workspace commands --
+
+
+async def _files_handler(args: str, session: ChatSession) -> None:
+    """Show workspace file tree."""
+    loop = asyncio.get_running_loop()
+    try:
+        tree = await loop.run_in_executor(None, session.client.workspace_tree, session.team_id)
+    except SystemExit:
+        print("Error fetching file tree.", file=sys.stderr)
+        return
+
+    entries: list[dict[str, Any]] = tree.get("entries", [])
+    if not entries:
+        print("(empty workspace)")
+        return
+    for entry in entries:
+        prefix = "D " if entry.get("is_dir") else "  "
+        name = entry.get("name", "")
+        size = entry.get("size", 0)
+        suffix = f"  ({size} bytes)" if not entry.get("is_dir") else ""
+        print(f"{prefix}{name}{suffix}")
+
+
+async def _read_handler(args: str, session: ChatSession) -> None:
+    """Read a file from the workspace."""
+    path = args.strip()
+    if not path:
+        print("Usage: /read <path>")
+        return
+
+    loop = asyncio.get_running_loop()
+    try:
+        data = await loop.run_in_executor(
+            None, session.client.workspace_read, session.team_id, path
+        )
+    except SystemExit:
+        print(f"Error reading file: {path}", file=sys.stderr)
+        return
+
+    try:
+        print(data.decode("utf-8"), end="")
+    except UnicodeDecodeError:
+        print(f"(binary file, {len(data)} bytes)")
+
+
+async def _upload_handler(args: str, session: ChatSession) -> None:
+    """Upload a local file to the workspace."""
+    local_path = args.strip()
+    if not local_path:
+        print("Usage: /upload <local_path>")
+        return
+
+    p = Path(local_path)
+    if not p.is_file():  # noqa: ASYNC240
+        print(f"Error: {local_path} is not a file or does not exist.")
+        return
+
+    file_data = p.read_bytes()  # noqa: ASYNC240
+    loop = asyncio.get_running_loop()
+    try:
+        result = await loop.run_in_executor(
+            None, session.client.workspace_upload, session.team_id, p.name, file_data
+        )
+    except SystemExit:
+        print(f"Error uploading file: {local_path}", file=sys.stderr)
+        return
+
+    uploaded_path = result.get("path", p.name)
+    size = result.get("size", len(file_data))
+    print(f"Uploaded {uploaded_path} ({size} bytes)")
+
+
+# -- Lifecycle commands --
+
+
+async def _stop_handler(args: str, session: ChatSession) -> None:
+    """Stop the team."""
+    loop = asyncio.get_running_loop()
+    try:
+        await loop.run_in_executor(None, session.client.delete_team, session.team_id)
+    except SystemExit:
+        print("Error stopping team.", file=sys.stderr)
+        return
+
+    print(f"Team {session.team_id} stopped.")
+
+
+async def _restore_handler(args: str, session: ChatSession) -> None:
+    """Restore a stopped team."""
+    loop = asyncio.get_running_loop()
+    try:
+        await loop.run_in_executor(None, session.client.restore_team, session.team_id)
+    except SystemExit:
+        print("Error restoring team.", file=sys.stderr)
+        return
+
+    print(f"Team {session.team_id} restored. Live events resumed.")
+
+
+# -- Switch command --
+
+
+async def _switch_handler(args: str, session: ChatSession) -> None:
+    """Switch to a different team."""
+    new_team_id = args.strip()
+    if not new_team_id:
+        print("Usage: /switch <team_id>")
+        return
+
+    old_team_id = session.team_id
+    old_ws = session.ws_client
+
+    # Close current WebSocket
+    await old_ws.close()
+
+    # Create new WsClient for the new team
+    new_ws = WsClient(
+        base_url=old_ws.url.replace(f"/ws/{old_team_id}", "")
+        .replace("ws://", "http://")
+        .replace("wss://", "https://"),
+        team_id=new_team_id,
+        api_key=None,  # API key is already in the HTTP client
+    )
+
+    try:
+        await new_ws.connect()
+    except (SystemExit, Exception):  # noqa: BLE001
+        print(f"Team {new_team_id} not found.", file=sys.stderr)
+        # Restore previous connection
+        try:
+            await old_ws.connect()
+        except Exception:  # noqa: BLE001
+            print("Failed to restore previous connection.", file=sys.stderr)
+        return
+
+    # Update session state
+    session.team_id = new_team_id
+    session.ws_client = new_ws
+
+    # Replay history for the new team
+    session._replay_history()
+
+    # Cancel and restart the receive loop
+    if session._receive_task is not None:
+        session._receive_task.cancel()
+        try:
+            await session._receive_task
+        except asyncio.CancelledError:
+            pass
+
+    session._receive_task = asyncio.create_task(session._receive_loop())
+
+    print(f"Switched to team {new_team_id}.")
+
+
+def build_default_registry() -> CommandRegistry:
+    """Create a command registry with all built-in commands."""
+    registry = CommandRegistry()
+    registry.register("help", _help_handler, "Show available commands", "/help")
+    registry.register("status", _status_handler, "Show team status", "/status")
+    registry.register("agents", _agents_handler, "List team agents", "/agents")
+    registry.register("history", _history_handler, "Show recent messages", "/history [N]")
+    registry.register("files", _files_handler, "Show workspace files", "/files")
+    registry.register("read", _read_handler, "Read a workspace file", "/read <path>")
+    registry.register("upload", _upload_handler, "Upload a file to workspace", "/upload <path>")
+    registry.register("stop", _stop_handler, "Stop the team", "/stop")
+    registry.register("restore", _restore_handler, "Restore a stopped team", "/restore")
+    registry.register("switch", _switch_handler, "Switch to another team", "/switch <team_id>")
+    return registry

--- a/src/akgentic/infra/cli/commands.py
+++ b/src/akgentic/infra/cli/commands.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import json as json_mod
 import sys
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
@@ -163,8 +164,6 @@ async def _history_handler(args: str, session: ChatSession) -> None:
 
 def _is_displayable(data: dict[str, Any]) -> bool:
     """Check if an event is displayable (SentMessage or ErrorMessage)."""
-    import json as json_mod
-
     event = data.get("event", data)
     if isinstance(event, str):
         try:
@@ -228,13 +227,15 @@ async def _upload_handler(args: str, session: ChatSession) -> None:
         print("Usage: /upload <local_path>")
         return
 
+    loop = asyncio.get_running_loop()
     p = Path(local_path)
-    if not p.is_file():  # noqa: ASYNC240
+
+    is_file = await loop.run_in_executor(None, p.is_file)
+    if not is_file:
         print(f"Error: {local_path} is not a file or does not exist.")
         return
 
-    file_data = p.read_bytes()  # noqa: ASYNC240
-    loop = asyncio.get_running_loop()
+    file_data = await loop.run_in_executor(None, p.read_bytes)
     try:
         result = await loop.run_in_executor(
             None, session.client.workspace_upload, session.team_id, p.name, file_data
@@ -291,13 +292,11 @@ async def _switch_handler(args: str, session: ChatSession) -> None:
     # Close current WebSocket
     await old_ws.close()
 
-    # Create new WsClient for the new team
+    # Create new WsClient using stored server_url and api_key
     new_ws = WsClient(
-        base_url=old_ws.url.replace(f"/ws/{old_team_id}", "")
-        .replace("ws://", "http://")
-        .replace("wss://", "https://"),
+        base_url=session.server_url,
         team_id=new_team_id,
-        api_key=None,  # API key is already in the HTTP client
+        api_key=session.api_key,
     )
 
     try:
@@ -305,8 +304,14 @@ async def _switch_handler(args: str, session: ChatSession) -> None:
     except (SystemExit, Exception):  # noqa: BLE001
         print(f"Team {new_team_id} not found.", file=sys.stderr)
         # Restore previous connection
+        restored = WsClient(
+            base_url=session.server_url,
+            team_id=old_team_id,
+            api_key=session.api_key,
+        )
         try:
-            await old_ws.connect()
+            await restored.connect()
+            session.ws_client = restored
         except Exception:  # noqa: BLE001
             print("Failed to restore previous connection.", file=sys.stderr)
         return
@@ -315,16 +320,16 @@ async def _switch_handler(args: str, session: ChatSession) -> None:
     session.team_id = new_team_id
     session.ws_client = new_ws
 
-    # Replay history for the new team
-    session._replay_history()
-
-    # Cancel and restart the receive loop
+    # Cancel old receive loop before replaying history
     if session._receive_task is not None:
         session._receive_task.cancel()
         try:
             await session._receive_task
         except asyncio.CancelledError:
             pass
+
+    # Replay history for the new team (non-blocking)
+    await session.replay_history_async()
 
     session._receive_task = asyncio.create_task(session._receive_loop())
 

--- a/src/akgentic/infra/cli/main.py
+++ b/src/akgentic/infra/cli/main.py
@@ -166,7 +166,10 @@ def chat(
         team_id=team_id,
         api_key=_state.api_key,
     )
-    session = ChatSession(_state.client, ws, team_id, _state.fmt)
+    session = ChatSession(
+        _state.client, ws, team_id, _state.fmt,
+        server_url=_state.server, api_key=_state.api_key,
+    )
     asyncio.run(session.run())
 
 

--- a/src/akgentic/infra/cli/repl.py
+++ b/src/akgentic/infra/cli/repl.py
@@ -27,11 +27,16 @@ class ChatSession:
         ws_client: WsClient,
         team_id: str,
         fmt: OutputFormat,
+        *,
+        server_url: str = "http://localhost:8000",
+        api_key: str | None = None,
     ) -> None:
         self.client = client
         self.ws_client = ws_client
         self.team_id = team_id
         self.fmt = fmt
+        self.server_url = server_url
+        self.api_key = api_key
         self.command_registry: CommandRegistry = build_default_registry()
         self._running = True
         self._receive_task: asyncio.Task[None] | None = None
@@ -106,6 +111,21 @@ class ChatSession:
             events = self.client.get_events(self.team_id)
         except SystemExit:
             return
+        self._display_events(events)
+
+    async def replay_history_async(self) -> None:
+        """Async version of _replay_history — uses run_in_executor to avoid blocking."""
+        loop = asyncio.get_running_loop()
+        try:
+            events = await loop.run_in_executor(
+                None, self.client.get_events, self.team_id
+            )
+        except SystemExit:
+            return
+        self._display_events(events)
+
+    def _display_events(self, events: list[dict[str, Any]]) -> None:
+        """Print a list of events, adding a history separator if any were displayed."""
         displayed = False
         for evt in events:
             if _print_event(evt):

--- a/src/akgentic/infra/cli/repl.py
+++ b/src/akgentic/infra/cli/repl.py
@@ -10,6 +10,7 @@ from typing import Any
 import websockets.exceptions
 
 from akgentic.infra.cli.client import ApiClient
+from akgentic.infra.cli.commands import CommandRegistry, build_default_registry
 from akgentic.infra.cli.formatters import OutputFormat
 from akgentic.infra.cli.ws_client import WsClient
 
@@ -27,30 +28,33 @@ class ChatSession:
         team_id: str,
         fmt: OutputFormat,
     ) -> None:
-        self._client = client
-        self._ws = ws_client
-        self._team_id = team_id
-        self._fmt = fmt
+        self.client = client
+        self.ws_client = ws_client
+        self.team_id = team_id
+        self.fmt = fmt
+        self.command_registry: CommandRegistry = build_default_registry()
         self._running = True
+        self._receive_task: asyncio.Task[None] | None = None
 
     async def run(self) -> None:
         """Main REPL loop: connect WS, replay history, read input, stream events."""
-        async with self._ws:
+        async with self.ws_client:
             self._replay_history()
-            print(f"Connected to team {self._team_id}. Type /quit or Ctrl+C to exit.")
+            print(f"Connected to team {self.team_id}. Type /quit or Ctrl+C to exit.")
 
-            receive_task = asyncio.create_task(self._receive_loop())
+            self._receive_task = asyncio.create_task(self._receive_loop())
             try:
                 await self._input_loop()
             except KeyboardInterrupt:
                 pass
             finally:
                 self._running = False
-                receive_task.cancel()
-                try:
-                    await receive_task
-                except asyncio.CancelledError:
-                    pass
+                if self._receive_task is not None:
+                    self._receive_task.cancel()
+                    try:
+                        await self._receive_task
+                    except asyncio.CancelledError:
+                        pass
                 print("Session closed.")
 
     async def _input_loop(self) -> None:
@@ -68,9 +72,13 @@ class ChatSession:
             if line.strip() == "/quit":
                 break
 
+            # Try dispatching as a slash command
+            if await self.command_registry.dispatch(line, self):
+                continue
+
             # Send message via REST API (run in executor to avoid blocking)
             try:
-                await loop.run_in_executor(None, self._client.send_message, self._team_id, line)
+                await loop.run_in_executor(None, self.client.send_message, self.team_id, line)
             except SystemExit:
                 print("Error sending message.", file=sys.stderr)
 
@@ -78,7 +86,7 @@ class ChatSession:
         """Background coroutine: read WebSocket events and print them."""
         while self._running:
             try:
-                event = await self._ws.receive_event()
+                event = await self.ws_client.receive_event()
                 _print_event(event)
             except asyncio.CancelledError:
                 raise
@@ -95,7 +103,7 @@ class ChatSession:
     def _replay_history(self) -> None:
         """Fetch and display past events before starting the REPL."""
         try:
-            events = self._client.get_events(self._team_id)
+            events = self.client.get_events(self.team_id)
         except SystemExit:
             return
         displayed = False

--- a/tests/test_cli_commands_insession.py
+++ b/tests/test_cli_commands_insession.py
@@ -80,7 +80,10 @@ def _make_session(
         client = _mock_client()
     if ws is None:
         ws = _mock_ws()
-    return ChatSession(client, ws, team_id, OutputFormat.table)
+    return ChatSession(
+        client, ws, team_id, OutputFormat.table,
+        server_url="http://localhost:8000", api_key="test-key",
+    )
 
 
 # =============================================================================
@@ -283,6 +286,14 @@ class TestHistoryHandler:
         out = capsys.readouterr().out
         assert "Usage" in out
 
+    async def test_negative_limit(self, capsys: pytest.CaptureFixture[str]) -> None:
+        session = _make_session()
+
+        await _history_handler("-5", session)
+
+        out = capsys.readouterr().out
+        assert "Usage" in out
+
     async def test_filters_non_displayable(self, capsys: pytest.CaptureFixture[str]) -> None:
         events = [
             {"event": {"__model__": "StateChangedMessage", "state": "running"}},
@@ -477,12 +488,16 @@ class TestSwitchHandler:
         session._receive_task = asyncio.create_task(asyncio.sleep(100))
 
         new_ws_mock = _mock_ws()
-        with patch("akgentic.infra.cli.commands.WsClient", return_value=new_ws_mock):
+        with patch("akgentic.infra.cli.commands.WsClient", return_value=new_ws_mock) as ws_cls:
             await _switch_handler("t2", session)
 
         old_ws.close.assert_called_once()
         assert session.team_id == "t2"
         assert session.ws_client is new_ws_mock
+        # Verify server_url and api_key are passed to new WsClient
+        ws_cls.assert_called_once_with(
+            base_url="http://localhost:8000", team_id="t2", api_key="test-key",
+        )
         out = capsys.readouterr().out
         assert "Switched to team t2" in out
 
@@ -499,15 +514,21 @@ class TestSwitchHandler:
         old_ws = _mock_ws()
         session = _make_session(client=client, ws=old_ws)
 
+        # First call creates the new WsClient (connect will fail),
+        # second call creates the restored WsClient for the old team
         new_ws_mock = _mock_ws()
         new_ws_mock.connect = AsyncMock(side_effect=SystemExit(1))
-        with patch("akgentic.infra.cli.commands.WsClient", return_value=new_ws_mock):
+        restored_ws_mock = _mock_ws()
+        with patch(
+            "akgentic.infra.cli.commands.WsClient",
+            side_effect=[new_ws_mock, restored_ws_mock],
+        ):
             await _switch_handler("bad-team", session)
 
         err = capsys.readouterr().err
         assert "not found" in err
-        # Old ws should have been re-connected
-        old_ws.connect.assert_called_once()
+        # Session ws should be the restored connection
+        assert session.ws_client is restored_ws_mock
         assert session.team_id == "t1"  # unchanged
 
 

--- a/tests/test_cli_commands_insession.py
+++ b/tests/test_cli_commands_insession.py
@@ -1,0 +1,598 @@
+"""Tests for in-session slash command registry, handlers, and ChatSession integration."""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from akgentic.infra.cli.commands import (
+    CommandRegistry,
+    _agents_handler,
+    _files_handler,
+    _help_handler,
+    _history_handler,
+    _read_handler,
+    _restore_handler,
+    _status_handler,
+    _stop_handler,
+    _switch_handler,
+    _upload_handler,
+    build_default_registry,
+)
+from akgentic.infra.cli.formatters import OutputFormat
+from akgentic.infra.cli.repl import ChatSession
+
+# -- Helpers --
+
+
+def _mock_client(**overrides: Any) -> MagicMock:
+    """Build a mock ApiClient."""
+    mock = MagicMock()
+    mock.get_events.return_value = []
+    mock.send_message.return_value = None
+    mock.get_team.return_value = {
+        "team_id": "t1",
+        "name": "Test Team",
+        "status": "running",
+        "agents": [
+            {"name": "agent-a", "role": "researcher", "state": "idle"},
+            {"name": "agent-b", "role": "writer", "state": "busy"},
+        ],
+    }
+    mock.workspace_tree.return_value = {
+        "entries": [
+            {"name": "docs", "is_dir": True, "size": 0},
+            {"name": "readme.md", "is_dir": False, "size": 42},
+        ]
+    }
+    mock.workspace_read.return_value = b"file content here"
+    mock.workspace_upload.return_value = {"path": "test.txt", "size": 5}
+    mock.delete_team.return_value = None
+    mock.restore_team.return_value = {"team_id": "t1", "status": "running"}
+    for k, v in overrides.items():
+        setattr(mock, k, v)
+    return mock
+
+
+def _mock_ws() -> AsyncMock:
+    """Build a mock WsClient."""
+    ws = AsyncMock()
+    ws.__aenter__ = AsyncMock(return_value=ws)
+    ws.__aexit__ = AsyncMock(return_value=None)
+    ws.receive_event = AsyncMock(side_effect=asyncio.CancelledError)
+    ws.url = "ws://localhost:8000/ws/t1"
+    ws.close = AsyncMock()
+    ws.connect = AsyncMock(return_value=ws)
+    return ws
+
+
+def _make_session(
+    client: MagicMock | None = None,
+    ws: AsyncMock | None = None,
+    team_id: str = "t1",
+) -> ChatSession:
+    """Create a ChatSession with mocked dependencies."""
+    if client is None:
+        client = _mock_client()
+    if ws is None:
+        ws = _mock_ws()
+    return ChatSession(client, ws, team_id, OutputFormat.table)
+
+
+# =============================================================================
+# Task 8.1: Test CommandRegistry
+# =============================================================================
+
+
+class TestCommandRegistryDispatch:
+    """Test dispatch returns True for registered commands, False for non-commands."""
+
+    async def test_dispatch_returns_true_for_registered_command(self) -> None:
+        registry = CommandRegistry()
+        handler = AsyncMock()
+        registry.register("test", handler, "Test command", "/test")
+        session = _make_session()
+
+        result = await registry.dispatch("/test", session)
+
+        assert result is True
+        handler.assert_called_once_with("", session)
+
+    async def test_dispatch_returns_false_for_non_command(self) -> None:
+        registry = CommandRegistry()
+        session = _make_session()
+
+        result = await registry.dispatch("hello world", session)
+
+        assert result is False
+
+    async def test_dispatch_passes_args_to_handler(self) -> None:
+        registry = CommandRegistry()
+        handler = AsyncMock()
+        registry.register("test", handler, "Test", "/test <arg>")
+        session = _make_session()
+
+        await registry.dispatch("/test some args here", session)
+
+        handler.assert_called_once_with("some args here", session)
+
+    async def test_unknown_command_prints_error_returns_true(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        registry = CommandRegistry()
+        session = _make_session()
+
+        result = await registry.dispatch("/xxx", session)
+
+        assert result is True
+        out = capsys.readouterr().out
+        assert "Unknown command: /xxx" in out
+        assert "/help" in out
+
+    async def test_dispatch_strips_whitespace(self) -> None:
+        registry = CommandRegistry()
+        handler = AsyncMock()
+        registry.register("test", handler, "Test", "/test")
+        session = _make_session()
+
+        result = await registry.dispatch("  /test  ", session)
+
+        assert result is True
+        handler.assert_called_once()
+
+
+class TestHelpCommand:
+    """Test /help lists all registered commands."""
+
+    async def test_help_lists_all_commands(self, capsys: pytest.CaptureFixture[str]) -> None:
+        session = _make_session()
+        registry = build_default_registry()
+        session.command_registry = registry
+
+        await _help_handler("", session)
+
+        out = capsys.readouterr().out
+        assert "/status" in out
+        assert "/agents" in out
+        assert "/history" in out
+        assert "/files" in out
+        assert "/read" in out
+        assert "/upload" in out
+        assert "/stop" in out
+        assert "/restore" in out
+        assert "/switch" in out
+        assert "/help" in out
+
+
+# =============================================================================
+# Task 8.2: Test each command handler in isolation
+# =============================================================================
+
+
+class TestStatusHandler:
+    async def test_shows_team_info(self, capsys: pytest.CaptureFixture[str]) -> None:
+        client = _mock_client()
+        session = _make_session(client=client)
+
+        await _status_handler("", session)
+
+        out = capsys.readouterr().out
+        assert "Test Team" in out
+        assert "running" in out
+        assert "2" in out  # 2 agents
+
+    async def test_handles_api_error(self, capsys: pytest.CaptureFixture[str]) -> None:
+        client = _mock_client()
+        client.get_team.side_effect = SystemExit(1)
+        session = _make_session(client=client)
+
+        await _status_handler("", session)
+
+        err = capsys.readouterr().err
+        assert "Error" in err
+
+
+class TestAgentsHandler:
+    async def test_lists_agents(self, capsys: pytest.CaptureFixture[str]) -> None:
+        client = _mock_client()
+        session = _make_session(client=client)
+
+        await _agents_handler("", session)
+
+        out = capsys.readouterr().out
+        assert "agent-a" in out
+        assert "researcher" in out
+        assert "idle" in out
+        assert "agent-b" in out
+        assert "writer" in out
+        assert "busy" in out
+
+    async def test_no_agents(self, capsys: pytest.CaptureFixture[str]) -> None:
+        client = _mock_client()
+        client.get_team.return_value = {"agents": []}
+        session = _make_session(client=client)
+
+        await _agents_handler("", session)
+
+        out = capsys.readouterr().out
+        assert "No agents" in out
+
+    async def test_handles_api_error(self, capsys: pytest.CaptureFixture[str]) -> None:
+        client = _mock_client()
+        client.get_team.side_effect = SystemExit(1)
+        session = _make_session(client=client)
+
+        await _agents_handler("", session)
+
+        err = capsys.readouterr().err
+        assert "Error" in err
+
+
+class TestHistoryHandler:
+    async def test_shows_history_default_limit(self, capsys: pytest.CaptureFixture[str]) -> None:
+        events = [
+            {"event": {"__model__": "SentMessage", "sender": "bot", "content": f"msg-{i}"}}
+            for i in range(25)
+        ]
+        client = _mock_client()
+        client.get_events.return_value = events
+        session = _make_session(client=client)
+
+        await _history_handler("", session)
+
+        out = capsys.readouterr().out
+        # Default limit 20, so first 5 should be missing
+        assert "msg-0" not in out
+        assert "msg-4" not in out
+        assert "msg-5" in out
+        assert "msg-24" in out
+
+    async def test_custom_limit(self, capsys: pytest.CaptureFixture[str]) -> None:
+        events = [
+            {"event": {"__model__": "SentMessage", "sender": "bot", "content": f"msg-{i}"}}
+            for i in range(25)
+        ]
+        client = _mock_client()
+        client.get_events.return_value = events
+        session = _make_session(client=client)
+
+        await _history_handler("10", session)
+
+        out = capsys.readouterr().out
+        assert "msg-14" not in out
+        assert "msg-15" in out
+        assert "msg-24" in out
+
+    async def test_invalid_limit(self, capsys: pytest.CaptureFixture[str]) -> None:
+        session = _make_session()
+
+        await _history_handler("abc", session)
+
+        out = capsys.readouterr().out
+        assert "Usage" in out
+
+    async def test_zero_limit(self, capsys: pytest.CaptureFixture[str]) -> None:
+        session = _make_session()
+
+        await _history_handler("0", session)
+
+        out = capsys.readouterr().out
+        assert "Usage" in out
+
+    async def test_filters_non_displayable(self, capsys: pytest.CaptureFixture[str]) -> None:
+        events = [
+            {"event": {"__model__": "StateChangedMessage", "state": "running"}},
+            {"event": {"__model__": "SentMessage", "sender": "bot", "content": "visible"}},
+        ]
+        client = _mock_client()
+        client.get_events.return_value = events
+        session = _make_session(client=client)
+
+        await _history_handler("", session)
+
+        out = capsys.readouterr().out
+        assert "visible" in out
+        assert "StateChanged" not in out
+
+    async def test_handles_api_error(self, capsys: pytest.CaptureFixture[str]) -> None:
+        client = _mock_client()
+        client.get_events.side_effect = SystemExit(1)
+        session = _make_session(client=client)
+
+        await _history_handler("", session)
+
+        err = capsys.readouterr().err
+        assert "Error" in err
+
+
+class TestFilesHandler:
+    async def test_shows_file_tree(self, capsys: pytest.CaptureFixture[str]) -> None:
+        client = _mock_client()
+        session = _make_session(client=client)
+
+        await _files_handler("", session)
+
+        out = capsys.readouterr().out
+        assert "docs" in out
+        assert "readme.md" in out
+        assert "42 bytes" in out
+
+    async def test_empty_workspace(self, capsys: pytest.CaptureFixture[str]) -> None:
+        client = _mock_client()
+        client.workspace_tree.return_value = {"entries": []}
+        session = _make_session(client=client)
+
+        await _files_handler("", session)
+
+        out = capsys.readouterr().out
+        assert "empty" in out.lower()
+
+    async def test_handles_api_error(self, capsys: pytest.CaptureFixture[str]) -> None:
+        client = _mock_client()
+        client.workspace_tree.side_effect = SystemExit(1)
+        session = _make_session(client=client)
+
+        await _files_handler("", session)
+
+        err = capsys.readouterr().err
+        assert "Error" in err
+
+
+class TestReadHandler:
+    async def test_reads_file(self, capsys: pytest.CaptureFixture[str]) -> None:
+        client = _mock_client()
+        session = _make_session(client=client)
+
+        await _read_handler("readme.md", session)
+
+        out = capsys.readouterr().out
+        assert "file content here" in out
+
+    async def test_no_arg_shows_usage(self, capsys: pytest.CaptureFixture[str]) -> None:
+        session = _make_session()
+
+        await _read_handler("", session)
+
+        out = capsys.readouterr().out
+        assert "Usage" in out
+
+    async def test_binary_file(self, capsys: pytest.CaptureFixture[str]) -> None:
+        client = _mock_client()
+        client.workspace_read.return_value = bytes(range(256))
+        session = _make_session(client=client)
+
+        await _read_handler("binary.bin", session)
+
+        out = capsys.readouterr().out
+        assert "binary" in out.lower() or "bytes" in out.lower()
+
+    async def test_handles_api_error(self, capsys: pytest.CaptureFixture[str]) -> None:
+        client = _mock_client()
+        client.workspace_read.side_effect = SystemExit(1)
+        session = _make_session(client=client)
+
+        await _read_handler("test.txt", session)
+
+        err = capsys.readouterr().err
+        assert "Error" in err
+
+
+class TestUploadHandler:
+    async def test_uploads_file(self, tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+        f = tmp_path / "test.txt"
+        f.write_text("hello")
+        client = _mock_client()
+        session = _make_session(client=client)
+
+        await _upload_handler(str(f), session)
+
+        out = capsys.readouterr().out
+        assert "Uploaded" in out
+        client.workspace_upload.assert_called_once()
+
+    async def test_no_arg_shows_usage(self, capsys: pytest.CaptureFixture[str]) -> None:
+        session = _make_session()
+
+        await _upload_handler("", session)
+
+        out = capsys.readouterr().out
+        assert "Usage" in out
+
+    async def test_missing_file(self, capsys: pytest.CaptureFixture[str]) -> None:
+        session = _make_session()
+
+        await _upload_handler("/nonexistent/file.txt", session)
+
+        out = capsys.readouterr().out
+        assert "Error" in out or "not a file" in out
+
+    async def test_handles_api_error(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        f = tmp_path / "test.txt"
+        f.write_text("hello")
+        client = _mock_client()
+        client.workspace_upload.side_effect = SystemExit(1)
+        session = _make_session(client=client)
+
+        await _upload_handler(str(f), session)
+
+        err = capsys.readouterr().err
+        assert "Error" in err
+
+
+class TestStopHandler:
+    async def test_stops_team(self, capsys: pytest.CaptureFixture[str]) -> None:
+        client = _mock_client()
+        session = _make_session(client=client)
+
+        await _stop_handler("", session)
+
+        out = capsys.readouterr().out
+        assert "Team t1 stopped." in out
+        client.delete_team.assert_called_once_with("t1")
+
+    async def test_handles_api_error(self, capsys: pytest.CaptureFixture[str]) -> None:
+        client = _mock_client()
+        client.delete_team.side_effect = SystemExit(1)
+        session = _make_session(client=client)
+
+        await _stop_handler("", session)
+
+        err = capsys.readouterr().err
+        assert "Error" in err
+
+
+class TestRestoreHandler:
+    async def test_restores_team(self, capsys: pytest.CaptureFixture[str]) -> None:
+        client = _mock_client()
+        session = _make_session(client=client)
+
+        await _restore_handler("", session)
+
+        out = capsys.readouterr().out
+        assert "Team t1 restored. Live events resumed." in out
+        client.restore_team.assert_called_once_with("t1")
+
+    async def test_handles_api_error(self, capsys: pytest.CaptureFixture[str]) -> None:
+        client = _mock_client()
+        client.restore_team.side_effect = SystemExit(1)
+        session = _make_session(client=client)
+
+        await _restore_handler("", session)
+
+        err = capsys.readouterr().err
+        assert "Error" in err
+
+
+class TestSwitchHandler:
+    async def test_switches_team(self, capsys: pytest.CaptureFixture[str]) -> None:
+        client = _mock_client()
+        old_ws = _mock_ws()
+        session = _make_session(client=client, ws=old_ws)
+        session._receive_task = asyncio.create_task(asyncio.sleep(100))
+
+        new_ws_mock = _mock_ws()
+        with patch("akgentic.infra.cli.commands.WsClient", return_value=new_ws_mock):
+            await _switch_handler("t2", session)
+
+        old_ws.close.assert_called_once()
+        assert session.team_id == "t2"
+        assert session.ws_client is new_ws_mock
+        out = capsys.readouterr().out
+        assert "Switched to team t2" in out
+
+    async def test_no_arg_shows_usage(self, capsys: pytest.CaptureFixture[str]) -> None:
+        session = _make_session()
+
+        await _switch_handler("", session)
+
+        out = capsys.readouterr().out
+        assert "Usage" in out
+
+    async def test_switch_fails_restores_old(self, capsys: pytest.CaptureFixture[str]) -> None:
+        client = _mock_client()
+        old_ws = _mock_ws()
+        session = _make_session(client=client, ws=old_ws)
+
+        new_ws_mock = _mock_ws()
+        new_ws_mock.connect = AsyncMock(side_effect=SystemExit(1))
+        with patch("akgentic.infra.cli.commands.WsClient", return_value=new_ws_mock):
+            await _switch_handler("bad-team", session)
+
+        err = capsys.readouterr().err
+        assert "not found" in err
+        # Old ws should have been re-connected
+        old_ws.connect.assert_called_once()
+        assert session.team_id == "t1"  # unchanged
+
+
+# =============================================================================
+# Task 8.3: Test integration with ChatSession._input_loop
+# =============================================================================
+
+
+class TestChatSessionCommandIntegration:
+    async def test_status_dispatched_not_sent(self, capsys: pytest.CaptureFixture[str]) -> None:
+        client = _mock_client()
+        ws = _mock_ws()
+        session = ChatSession(client, ws, "t1", OutputFormat.table)
+
+        with patch(
+            "akgentic.infra.cli.repl._read_input",
+            side_effect=["/status", "/quit"],
+        ):
+            await session.run()
+
+        # /status should have triggered get_team, not send_message
+        client.get_team.assert_called_once_with("t1")
+        client.send_message.assert_not_called()
+
+    async def test_regular_text_sent_as_message(self, capsys: pytest.CaptureFixture[str]) -> None:
+        client = _mock_client()
+        ws = _mock_ws()
+        session = ChatSession(client, ws, "t1", OutputFormat.table)
+
+        with patch(
+            "akgentic.infra.cli.repl._read_input",
+            side_effect=["hello there", "/quit"],
+        ):
+            await session.run()
+
+        client.send_message.assert_called_once_with("t1", "hello there")
+
+    async def test_quit_still_exits(self, capsys: pytest.CaptureFixture[str]) -> None:
+        client = _mock_client()
+        ws = _mock_ws()
+        session = ChatSession(client, ws, "t1", OutputFormat.table)
+
+        with patch(
+            "akgentic.infra.cli.repl._read_input",
+            side_effect=["/quit"],
+        ):
+            await session.run()
+
+        out = capsys.readouterr().out
+        assert "Session closed." in out
+
+    async def test_unknown_slash_command_not_sent(self, capsys: pytest.CaptureFixture[str]) -> None:
+        client = _mock_client()
+        ws = _mock_ws()
+        session = ChatSession(client, ws, "t1", OutputFormat.table)
+
+        with patch(
+            "akgentic.infra.cli.repl._read_input",
+            side_effect=["/unknown", "/quit"],
+        ):
+            await session.run()
+
+        out = capsys.readouterr().out
+        assert "Unknown command: /unknown" in out
+        client.send_message.assert_not_called()
+
+
+# =============================================================================
+# Task 8.4: Verify build_default_registry has all commands
+# =============================================================================
+
+
+class TestBuildDefaultRegistry:
+    def test_all_commands_registered(self) -> None:
+        registry = build_default_registry()
+        expected = {
+            "help",
+            "status",
+            "agents",
+            "history",
+            "files",
+            "read",
+            "upload",
+            "stop",
+            "restore",
+            "switch",
+        }
+        assert set(registry.commands.keys()) == expected


### PR DESCRIPTION
## Summary

- Adds slash command registry and dispatcher (`SlashCommand`, `CommandRegistry`) with 10 built-in commands: `/help`, `/status`, `/agents`, `/history`, `/files`, `/read`, `/upload`, `/stop`, `/restore`, `/switch`
- All handlers are async with `run_in_executor` for synchronous API calls
- `/switch` tears down and rebuilds WebSocket connection with error recovery
- Integrates command dispatch into `ChatSession._input_loop()` alongside existing `/quit` handling
- 41 tests covering registry, all handlers, integration, and error cases

## Code Review Fixes Applied

| Severity | Issue | Fix |
|----------|-------|-----|
| HIGH | `/switch` hardcoded `api_key=None` | Pass `session.api_key` from stored config |
| HIGH | `/switch` blocked event loop via sync `_replay_history()` | Added async `replay_history_async()` |
| MEDIUM | `/switch` fragile URL reverse-engineering | Store `server_url` on ChatSession |
| MEDIUM | Inline `import json` in `_is_displayable` | Moved to module-level import |
| MEDIUM | `/upload` blocking file I/O in async context | Wrapped `is_file()`/`read_bytes()` in `run_in_executor` |
| MEDIUM | `/switch` error recovery left broken session state | Create fresh WsClient on rollback |
| LOW | Missing negative limit test for `/history` | Added test for `-5` |

Closes #43