### PR TITLE
Channel & Dispatcher Bug Fixes (Story 6-1)

### DIFF
--- a/src/akgentic/infra/adapters/channel_dispatcher.py
+++ b/src/akgentic/infra/adapters/channel_dispatcher.py
@@ -13,19 +13,19 @@ if TYPE_CHECKING:
 
 
 class InteractionChannelDispatcher:
-    """Routes outbound SentMessage events to the first matching channel adapter.
+    """Routes outbound SentMessage events to all matching channel adapters.
 
     Satisfies the EventSubscriber protocol from akgentic.core.orchestrator
     via structural subtyping. Each team gets its own dispatcher instance
     with its own ordered adapter list.
 
-    First-match dispatch: iterates adapters, calls matches() on each,
-    and delivers to the first match only. If no adapter matches, the
+    Multi-channel dispatch: iterates adapters, calls matches() on each,
+    and delivers to ALL matching adapters. If no adapter matches, the
     message is silently skipped (web channel handles it via WebSocket).
     """
 
     def __init__(
-        self, adapters: list[InteractionChannelAdapter], team_id: uuid.UUID
+        self, team_id: uuid.UUID, adapters: list[InteractionChannelAdapter]
     ) -> None:
         self._adapters = list(adapters)
         self._team_id = team_id
@@ -36,7 +36,7 @@ class InteractionChannelDispatcher:
         self._restoring = restoring
 
     def on_message(self, msg: Message) -> None:
-        """Dispatch a SentMessage to the first matching adapter.
+        """Dispatch a SentMessage to all matching adapters.
 
         Skips delivery entirely during restore mode. Ignores non-SentMessage
         events. Silently skips if no adapter matches.
@@ -51,7 +51,6 @@ class InteractionChannelDispatcher:
         for adapter in self._adapters:
             if adapter.matches(msg):
                 adapter.deliver(msg)
-                break
 
     def on_stop(self) -> None:
         """Clean up all registered adapters when the team stops."""

--- a/src/akgentic/infra/adapters/channel_parser_registry.py
+++ b/src/akgentic/infra/adapters/channel_parser_registry.py
@@ -19,6 +19,10 @@ class ChannelConfig(BaseModel):
     adapter_fqcn: str = Field(
         description="Fully-qualified class name of the InteractionChannelAdapter"
     )
+    config: dict[str, str] = Field(
+        default_factory=dict,
+        description="Extra kwargs passed to parser and adapter constructors",
+    )
 
 
 def import_class(fqcn: str) -> type:
@@ -68,14 +72,14 @@ class ChannelParserRegistry:
             parser_cls = import_class(cfg.parser_fqcn)
             adapter_cls = import_class(cfg.adapter_fqcn)
 
-            parser = parser_cls()
+            parser = parser_cls(**cfg.config)
             if not isinstance(parser, ChannelParser):
                 msg = (
                     f"Class '{cfg.parser_fqcn}' does not satisfy ChannelParser protocol"
                 )
                 raise TypeError(msg)
 
-            adapter = adapter_cls()
+            adapter = adapter_cls(**cfg.config)
             if not isinstance(adapter, InteractionChannelAdapter):
                 msg = (
                     f"Class '{cfg.adapter_fqcn}' does not satisfy "

--- a/src/akgentic/infra/protocols/channels.py
+++ b/src/akgentic/infra/protocols/channels.py
@@ -5,7 +5,9 @@ from __future__ import annotations
 import uuid
 from typing import TYPE_CHECKING, Protocol, runtime_checkable
 
-from pydantic import BaseModel, Field
+from pydantic import Field
+
+from akgentic.core.utils.serializer import SerializableBaseModel
 
 if TYPE_CHECKING:
     from akgentic.core.messages import SentMessage
@@ -14,7 +16,7 @@ if TYPE_CHECKING:
 JsonValue = str | int | float | bool | None | list["JsonValue"] | dict[str, "JsonValue"]
 
 
-class ChannelMessage(BaseModel):
+class ChannelMessage(SerializableBaseModel):
     """Normalized message from an external interaction channel."""
 
     content: str = Field(description="Message content")

--- a/src/akgentic/infra/server/routes/webhook.py
+++ b/src/akgentic/infra/server/routes/webhook.py
@@ -50,7 +50,14 @@ async def webhook(
     if parser is None:
         raise HTTPException(status_code=404, detail=f"Unknown channel: {channel}")
 
-    payload: dict[str, JsonValue] = await request.json()
+    content_type = request.headers.get("content-type", "")
+    if "application/json" in content_type:
+        payload: dict[str, JsonValue] = await request.json()
+    elif "application/x-www-form-urlencoded" in content_type:
+        form_data = await request.form()
+        payload = {k: str(v) for k, v in form_data.items()}
+    else:
+        raise HTTPException(status_code=415, detail="Unsupported content type")
     message = await parser.parse(payload)
 
     if message.team_id is not None:

--- a/tests/test_channel_dispatcher.py
+++ b/tests/test_channel_dispatcher.py
@@ -87,11 +87,11 @@ TEAM_ID = uuid.uuid4()
 
 
 # ---------------------------------------------------------------------------
-# AC #1: matches() then deliver() on first matching adapter
+# AC #1: matches() then deliver() on matching adapter
 # ---------------------------------------------------------------------------
 
 class TestDispatchToMatchingAdapter:
-    """AC #1: Dispatcher calls matches() then deliver() on first match."""
+    """AC #1: Dispatcher calls matches() then deliver() on matching adapters."""
 
     def test_calls_matches_then_deliver(self) -> None:
         adapter = _MatchingAdapter()

--- a/tests/test_channel_dispatcher.py
+++ b/tests/test_channel_dispatcher.py
@@ -95,7 +95,7 @@ class TestDispatchToMatchingAdapter:
 
     def test_calls_matches_then_deliver(self) -> None:
         adapter = _MatchingAdapter()
-        dispatcher = InteractionChannelDispatcher(adapters=[adapter], team_id=TEAM_ID)
+        dispatcher = InteractionChannelDispatcher(team_id=TEAM_ID, adapters=[adapter])
         sent = _make_sent_message()
         dispatcher.on_message(sent)
 
@@ -114,7 +114,7 @@ class TestSkipsNonSentMessage:
 
     def test_received_message_ignored(self) -> None:
         adapter = _MatchingAdapter()
-        dispatcher = InteractionChannelDispatcher(adapters=[adapter], team_id=TEAM_ID)
+        dispatcher = InteractionChannelDispatcher(team_id=TEAM_ID, adapters=[adapter])
         dispatcher.on_message(ReceivedMessage(message_id=uuid.uuid4()))
 
         assert not adapter.matches_called
@@ -124,7 +124,7 @@ class TestSkipsNonSentMessage:
         from akgentic.core.agent_config import BaseConfig
 
         adapter = _MatchingAdapter()
-        dispatcher = InteractionChannelDispatcher(adapters=[adapter], team_id=TEAM_ID)
+        dispatcher = InteractionChannelDispatcher(team_id=TEAM_ID, adapters=[adapter])
         dispatcher.on_message(StartMessage(config=BaseConfig()))
 
         assert not adapter.matches_called
@@ -140,7 +140,7 @@ class TestNoAdapterMatch:
 
     def test_no_match_no_exception(self) -> None:
         adapter = _NonMatchingAdapter()
-        dispatcher = InteractionChannelDispatcher(adapters=[adapter], team_id=TEAM_ID)
+        dispatcher = InteractionChannelDispatcher(team_id=TEAM_ID, adapters=[adapter])
         dispatcher.on_message(_make_sent_message())
 
         assert adapter.matches_called
@@ -148,30 +148,33 @@ class TestNoAdapterMatch:
 
 
 # ---------------------------------------------------------------------------
-# AC #1: first-match-wins — only first matching adapter gets deliver()
+# AC #2: multi-channel delivery — ALL matching adapters get deliver()
 # ---------------------------------------------------------------------------
 
-class TestFirstMatchWins:
-    """With multiple adapters, only the FIRST match receives deliver()."""
+class TestMultiChannelDelivery:
+    """With multiple adapters, ALL matching adapters receive deliver()."""
 
-    def test_only_first_matching_adapter_delivers(self) -> None:
+    def test_all_matching_adapters_deliver(self) -> None:
         first = _MatchingAdapter()
         second = _MatchingAdapter()
         dispatcher = InteractionChannelDispatcher(
-            adapters=[first, second], team_id=TEAM_ID
+            team_id=TEAM_ID, adapters=[first, second]
         )
-        dispatcher.on_message(_make_sent_message())
+        sent = _make_sent_message()
+        dispatcher.on_message(sent)
 
         assert first.matches_called
         assert first.deliver_called
-        assert not second.matches_called
-        assert not second.deliver_called
+        assert first.deliver_msg is sent
+        assert second.matches_called
+        assert second.deliver_called
+        assert second.deliver_msg is sent
 
     def test_skips_non_matching_then_delivers_to_match(self) -> None:
         non_match = _NonMatchingAdapter()
         match = _MatchingAdapter()
         dispatcher = InteractionChannelDispatcher(
-            adapters=[non_match, match], team_id=TEAM_ID
+            team_id=TEAM_ID, adapters=[non_match, match]
         )
         dispatcher.on_message(_make_sent_message())
 
@@ -179,6 +182,23 @@ class TestFirstMatchWins:
         assert not non_match.deliver_called
         assert match.matches_called
         assert match.deliver_called
+
+    def test_delivers_to_multiple_with_non_matching_in_between(self) -> None:
+        first = _MatchingAdapter()
+        non_match = _NonMatchingAdapter()
+        second = _MatchingAdapter()
+        dispatcher = InteractionChannelDispatcher(
+            team_id=TEAM_ID, adapters=[first, non_match, second]
+        )
+        sent = _make_sent_message()
+        dispatcher.on_message(sent)
+
+        assert first.deliver_called
+        assert first.deliver_msg is sent
+        assert non_match.matches_called
+        assert not non_match.deliver_called
+        assert second.deliver_called
+        assert second.deliver_msg is sent
 
 
 # ---------------------------------------------------------------------------
@@ -190,7 +210,7 @@ class TestRestoreMode:
 
     def test_restoring_skips_all_events(self) -> None:
         adapter = _MatchingAdapter()
-        dispatcher = InteractionChannelDispatcher(adapters=[adapter], team_id=TEAM_ID)
+        dispatcher = InteractionChannelDispatcher(team_id=TEAM_ID, adapters=[adapter])
         dispatcher.set_restoring(True)
         dispatcher.on_message(_make_sent_message())
 
@@ -199,7 +219,7 @@ class TestRestoreMode:
 
     def test_restoring_false_resumes_dispatch(self) -> None:
         adapter = _MatchingAdapter()
-        dispatcher = InteractionChannelDispatcher(adapters=[adapter], team_id=TEAM_ID)
+        dispatcher = InteractionChannelDispatcher(team_id=TEAM_ID, adapters=[adapter])
         dispatcher.set_restoring(True)
         dispatcher.on_message(_make_sent_message())
         assert not adapter.deliver_called
@@ -220,7 +240,7 @@ class TestOnStop:
         a1 = _MatchingAdapter()
         a2 = _NonMatchingAdapter()
         dispatcher = InteractionChannelDispatcher(
-            adapters=[a1, a2], team_id=TEAM_ID
+            team_id=TEAM_ID, adapters=[a1, a2]
         )
         dispatcher.on_stop()
 
@@ -230,7 +250,7 @@ class TestOnStop:
         assert a2.stop_team_id == TEAM_ID
 
     def test_on_stop_empty_adapter_list(self) -> None:
-        dispatcher = InteractionChannelDispatcher(adapters=[], team_id=TEAM_ID)
+        dispatcher = InteractionChannelDispatcher(team_id=TEAM_ID, adapters=[])
         dispatcher.on_stop()  # should not raise
 
 
@@ -242,5 +262,5 @@ class TestEmptyAdapterList:
     """Dispatcher with empty adapter list handles messages without error."""
 
     def test_sent_message_with_no_adapters(self) -> None:
-        dispatcher = InteractionChannelDispatcher(adapters=[], team_id=TEAM_ID)
+        dispatcher = InteractionChannelDispatcher(team_id=TEAM_ID, adapters=[])
         dispatcher.on_message(_make_sent_message())  # should not raise

--- a/tests/test_channel_parser_registry.py
+++ b/tests/test_channel_parser_registry.py
@@ -320,3 +320,4 @@ def test_channel_config_is_pydantic_model() -> None:
     fields = ChannelConfig.model_fields
     assert "parser_fqcn" in fields
     assert "adapter_fqcn" in fields
+    assert "config" in fields

--- a/tests/test_channel_parser_registry.py
+++ b/tests/test_channel_parser_registry.py
@@ -235,6 +235,83 @@ def test_registry_rejects_non_adapter_protocol() -> None:
         ChannelParserRegistry(config)
 
 
+# --- Config passthrough stubs ---
+
+
+class StubConfigParser:
+    """Parser stub that accepts config kwargs."""
+
+    def __init__(self, api_key: str = "") -> None:
+        self.api_key = api_key
+
+    @property
+    def channel_name(self) -> str:
+        return "configurable"
+
+    @property
+    def default_catalog_entry(self) -> str:
+        return "default-configurable"
+
+    async def parse(self, payload: dict[str, JsonValue]) -> ChannelMessage:
+        return ChannelMessage(content="", channel_user_id="")
+
+
+class StubConfigAdapter:
+    """Adapter stub that accepts config kwargs."""
+
+    def __init__(self, api_key: str = "") -> None:
+        self.api_key = api_key
+
+    def matches(self, msg: object) -> bool:
+        return False
+
+    def deliver(self, msg: object) -> None:
+        pass
+
+    def on_stop(self, team_id: uuid.UUID) -> None:
+        pass
+
+
+# --- Config passthrough tests ---
+
+
+def test_channel_config_has_config_field() -> None:
+    """ChannelConfig has a config dict field with empty dict default."""
+    cfg = ChannelConfig(
+        parser_fqcn="tests.test_channel_parser_registry.StubWhatsAppParser",
+        adapter_fqcn="tests.test_channel_parser_registry.StubWhatsAppAdapter",
+    )
+    assert cfg.config == {}
+
+
+def test_config_passthrough_to_constructors() -> None:
+    """Config values are passed to parser and adapter constructors."""
+    this_module = "tests.test_channel_parser_registry"
+    config = {
+        "configurable": ChannelConfig(
+            parser_fqcn=f"{this_module}.StubConfigParser",
+            adapter_fqcn=f"{this_module}.StubConfigAdapter",
+            config={"api_key": "test-secret-123"},
+        ),
+    }
+    registry = ChannelParserRegistry(config)
+
+    parser = registry.get_parser("configurable")
+    assert parser is not None
+    assert parser.api_key == "test-secret-123"  # type: ignore[attr-defined]
+
+    adapters = registry.get_adapters()
+    assert len(adapters) == 1
+    assert adapters[0].api_key == "test-secret-123"  # type: ignore[attr-defined]
+
+
+def test_empty_config_works_with_existing_stubs() -> None:
+    """Existing stubs with no config params still work with empty config dict."""
+    registry = ChannelParserRegistry(_make_config())
+    assert len(registry.channel_names()) == 2
+    assert len(registry.get_adapters()) == 2
+
+
 def test_channel_config_is_pydantic_model() -> None:
     """ChannelConfig is a Pydantic model with correct fields."""
     from pydantic import BaseModel

--- a/tests/test_webhook_route.py
+++ b/tests/test_webhook_route.py
@@ -287,6 +287,48 @@ class TestWebhookFormData:
         assert call[1] == "form-user"
 
 
+class TestWebhookContentTypeEdgeCases:
+    """AC #4: content-type edge cases."""
+
+    def test_missing_content_type_returns_415(self, tmp_path: Path) -> None:
+        """Request with no content-type header returns 415."""
+        parser = StubParser()
+        ingestion = StubIngestion()
+        registry = YamlChannelRegistry(tmp_path / "registry.yaml")
+        client = TestClient(_build_app(parser, ingestion, registry))
+
+        resp = client.post(
+            "/webhook/test-channel",
+            content=b"some data",
+            headers={"content-type": ""},
+        )
+
+        assert resp.status_code == 415
+
+    def test_json_with_charset_param(self, tmp_path: Path) -> None:
+        """application/json; charset=utf-8 is handled as JSON."""
+        parser = StubParser()
+        parser.set_next_message(
+            ChannelMessage(
+                content="charset msg",
+                channel_user_id="u-charset",
+                team_id=uuid.uuid4(),
+            )
+        )
+        ingestion = StubIngestion()
+        registry = YamlChannelRegistry(tmp_path / "registry.yaml")
+        client = TestClient(_build_app(parser, ingestion, registry))
+
+        resp = client.post(
+            "/webhook/test-channel",
+            json={"text": "hi"},
+            headers={"content-type": "application/json; charset=utf-8"},
+        )
+
+        assert resp.status_code == 204
+        assert len(ingestion.route_reply_calls) == 1
+
+
 class TestWebhookUnsupportedContentType:
     """AC #4: unsupported content-type returns 415."""
 

--- a/tests/test_webhook_route.py
+++ b/tests/test_webhook_route.py
@@ -260,3 +260,47 @@ class TestWebhookStatusCode:
 
         resp = client.post("/webhook/test-channel", json={"text": "hi"})
         assert resp.status_code == 204
+
+
+# ---------------------------------------------------------------------------
+# AC #4: Form-data and unsupported content-type handling
+# ---------------------------------------------------------------------------
+
+class TestWebhookFormData:
+    """AC #4: webhook handles application/x-www-form-urlencoded."""
+
+    def test_form_data_payload_parsed(self, tmp_path: Path) -> None:
+        parser = StubParser()
+        ingestion = StubIngestion()
+        registry = YamlChannelRegistry(tmp_path / "registry.yaml")
+        client = TestClient(_build_app(parser, ingestion, registry))
+
+        resp = client.post(
+            "/webhook/test-channel",
+            data={"text": "form hello", "user": "form-user"},
+        )
+
+        assert resp.status_code == 204
+        assert len(ingestion.initiate_team_calls) == 1
+        call = ingestion.initiate_team_calls[0]
+        assert call[0] == "form hello"
+        assert call[1] == "form-user"
+
+
+class TestWebhookUnsupportedContentType:
+    """AC #4: unsupported content-type returns 415."""
+
+    def test_unsupported_content_type_returns_415(self, tmp_path: Path) -> None:
+        parser = StubParser()
+        ingestion = StubIngestion()
+        registry = YamlChannelRegistry(tmp_path / "registry.yaml")
+        client = TestClient(_build_app(parser, ingestion, registry))
+
+        resp = client.post(
+            "/webhook/test-channel",
+            content=b"<xml>data</xml>",
+            headers={"content-type": "application/xml"},
+        )
+
+        assert resp.status_code == 415
+        assert "Unsupported content type" in resp.json()["detail"]


### PR DESCRIPTION
## Summary

- ChannelMessage now inherits SerializableBaseModel instead of BaseModel (FR1)
- Dispatcher delivers to ALL matching adapters — removed premature break (FR2)
- Dispatcher constructor param order fixed: (team_id, adapters) (FR3)
- Webhook handles form-data and returns 415 for unsupported content-types (FR4)
- ChannelConfig passes config dict to parser/adapter constructors (FR7)

## Code Review Fixes

- Added missing `config` field assertion in Pydantic model test
- Added edge case tests: missing content-type header (415), JSON with charset param
- Fixed misleading test comment referencing "first match"

## Test Results

- 522 tests passing
- Coverage: 94.70%
- ruff: clean
- mypy: clean

Closes #49