### PR TITLE
Refactor WebSocket Handler to Use TeamHandle

### DIFF
--- a/src/akgentic/infra/server/routes/ws.py
+++ b/src/akgentic/infra/server/routes/ws.py
@@ -14,7 +14,6 @@ from typing import cast
 from fastapi import APIRouter, WebSocket, WebSocketDisconnect
 from starlette.websockets import WebSocketState
 
-from akgentic.core.orchestrator import Orchestrator
 from akgentic.infra.adapters.websocket_subscriber import WebSocketEventSubscriber
 from akgentic.infra.server.routes.frontend_adapter import FrontendAdapter
 from akgentic.infra.server.services.team_service import TeamService
@@ -110,14 +109,13 @@ async def _run_streaming_loop(
     adapter: FrontendAdapter | None = None,
 ) -> None:
     """Subscribe to orchestrator events and forward them over WebSocket."""
-    runtime = service.get_runtime(team_id)
-    if runtime is None:
+    handle = service.get_handle(team_id)
+    if handle is None:
         await websocket.close(code=1011, reason="Runtime not available")
         return
 
     subscriber = WebSocketEventSubscriber()
-    orch_proxy = runtime.actor_system.proxy_ask(runtime.orchestrator_addr, Orchestrator)
-    orch_proxy.subscribe(subscriber)
+    handle.subscribe(subscriber)
 
     try:
         await _send_loop(websocket, subscriber, team_id, adapter)
@@ -125,7 +123,7 @@ async def _run_streaming_loop(
         pass
     finally:
         try:
-            orch_proxy.unsubscribe(subscriber)
+            handle.unsubscribe(subscriber)
         except Exception:  # noqa: BLE001
             logger.debug("Failed to unsubscribe (orchestrator may be stopped)")
 
@@ -210,16 +208,15 @@ def notify_restore(
     if not waiting:
         return
 
-    runtime = service.get_runtime(team_id)
-    if runtime is None:
+    handle = service.get_handle(team_id)
+    if handle is None:
         return
 
     for ws in waiting:
         if ws.client_state != WebSocketState.CONNECTED:
             continue
         subscriber = WebSocketEventSubscriber()
-        orch_proxy = runtime.actor_system.proxy_ask(runtime.orchestrator_addr, Orchestrator)
-        orch_proxy.subscribe(subscriber)
+        handle.subscribe(subscriber)
         conn_mgr.set_subscriber(ws, subscriber)
 
 

--- a/src/akgentic/infra/server/services/team_service.py
+++ b/src/akgentic/infra/server/services/team_service.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import uuid
-import warnings
 
 from akgentic.catalog.models.errors import EntryNotFoundError
 from akgentic.catalog.services import (
@@ -16,7 +15,7 @@ from akgentic.core.messages.message import Message
 from akgentic.infra.adapters.local_team_handle import LocalTeamHandle
 from akgentic.infra.protocols.team_handle import RuntimeCache, TeamHandle
 from akgentic.infra.server.deps import CommunityServices
-from akgentic.team.models import PersistedEvent, Process, TeamRuntime, TeamStatus
+from akgentic.team.models import PersistedEvent, Process, TeamStatus
 
 
 class TeamService:
@@ -172,24 +171,6 @@ class TeamService:
             TeamHandle if cached, else None.
         """
         return self._cache.get(team_id)
-
-    def get_runtime(self, team_id: uuid.UUID) -> TeamRuntime | None:
-        """Return the underlying TeamRuntime for a cached team.
-
-        .. deprecated::
-            Use ``get_handle()`` instead. This method exists only for backward
-            compatibility with ``ws.py`` until story 6.6 refactors WebSocket
-            handling to use ``TeamHandle.subscribe()/unsubscribe()``.
-        """
-        warnings.warn(
-            "get_runtime() is deprecated, use get_handle() instead",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        handle = self._cache.get(team_id)
-        if handle is not None and isinstance(handle, LocalTeamHandle):
-            return handle._runtime  # noqa: SLF001
-        return None
 
     def _get_running_handle(self, team_id: uuid.UUID) -> TeamHandle:
         """Look up a cached handle, verifying the team is running.

--- a/tests/test_team_action_service.py
+++ b/tests/test_team_action_service.py
@@ -3,10 +3,9 @@
 from __future__ import annotations
 
 import uuid
-import warnings
 
 import pytest
-from akgentic.team.models import TeamRuntime, TeamStatus
+from akgentic.team.models import TeamStatus
 
 from akgentic.infra.server.services.team_service import TeamService
 
@@ -133,25 +132,6 @@ def test_delete_team_removes_handle_cache(team_service: TeamService) -> None:
 def test_get_handle_unknown_team_returns_none(team_service: TeamService) -> None:
     """get_handle returns None for a team_id that was never cached."""
     assert team_service.get_handle(uuid.uuid4()) is None
-
-
-def test_get_runtime_returns_team_runtime(team_service: TeamService) -> None:
-    """Deprecated get_runtime returns the underlying TeamRuntime for a cached team."""
-    process = team_service.create_team("test-team", user_id="anonymous")
-    with warnings.catch_warnings(record=True) as caught:
-        warnings.simplefilter("always")
-        runtime = team_service.get_runtime(process.team_id)
-    assert isinstance(runtime, TeamRuntime)
-    assert len(caught) == 1
-    assert issubclass(caught[0].category, DeprecationWarning)
-    assert "get_runtime()" in str(caught[0].message)
-
-
-def test_get_runtime_unknown_team_returns_none(team_service: TeamService) -> None:
-    """Deprecated get_runtime returns None for an unknown team."""
-    with warnings.catch_warnings(record=True):
-        warnings.simplefilter("always")
-        assert team_service.get_runtime(uuid.uuid4()) is None
 
 
 def test_stop_team_deleted_raises(team_service: TeamService) -> None:

--- a/tests/test_websocket_route.py
+++ b/tests/test_websocket_route.py
@@ -130,8 +130,8 @@ class TestNotifyRestore:
         service = MagicMock()
         notify_restore(mgr, service, uuid.uuid4())
 
-    def test_notify_restore_no_runtime(self) -> None:
-        """No error when runtime is unavailable."""
+    def test_notify_restore_no_handle(self) -> None:
+        """No error when handle is unavailable."""
         from unittest.mock import MagicMock
 
         from akgentic.infra.server.routes.ws import notify_restore
@@ -142,11 +142,11 @@ class TestNotifyRestore:
         mgr.add_waiting(tid, ws)
 
         service = MagicMock()
-        service.get_runtime.return_value = None
+        service.get_handle.return_value = None
         notify_restore(mgr, service, tid)
 
     def test_notify_restore_activates_connections(self) -> None:
-        """notify_restore subscribes each waiting WS to the restored orchestrator."""
+        """notify_restore subscribes each waiting WS via TeamHandle."""
         from unittest.mock import MagicMock, PropertyMock
 
         from starlette.websockets import WebSocketState
@@ -159,16 +159,13 @@ class TestNotifyRestore:
         type(ws).client_state = PropertyMock(return_value=WebSocketState.CONNECTED)
         mgr.add_waiting(tid, ws)
 
-        runtime = MagicMock()
-        orch_proxy = MagicMock()
-        runtime.actor_system.proxy_ask.return_value = orch_proxy
-
+        handle = MagicMock()
         service = MagicMock()
-        service.get_runtime.return_value = runtime
+        service.get_handle.return_value = handle
 
         notify_restore(mgr, service, tid)
 
-        orch_proxy.subscribe.assert_called_once()
+        handle.subscribe.assert_called_once()
 
     def test_notify_restore_skips_disconnected(self) -> None:
         """notify_restore skips WebSocket connections that are no longer connected."""
@@ -184,16 +181,13 @@ class TestNotifyRestore:
         type(ws).client_state = PropertyMock(return_value=WebSocketState.DISCONNECTED)
         mgr.add_waiting(tid, ws)
 
-        runtime = MagicMock()
-        orch_proxy = MagicMock()
-        runtime.actor_system.proxy_ask.return_value = orch_proxy
-
+        handle = MagicMock()
         service = MagicMock()
-        service.get_runtime.return_value = runtime
+        service.get_handle.return_value = handle
 
         notify_restore(mgr, service, tid)
 
-        orch_proxy.subscribe.assert_not_called()
+        handle.subscribe.assert_not_called()
 
 
 def _trigger_subscriber_event(client: TestClient, team_id: str) -> None:


### PR DESCRIPTION
## Summary

- Refactored `_run_streaming_loop` to use `service.get_handle()` + `handle.subscribe()`/`handle.unsubscribe()` instead of direct actor-internal access via `proxy_ask`
- Refactored `notify_restore` to use `service.get_handle()` + `handle.subscribe()` instead of `runtime.actor_system.proxy_ask()`
- Removed `from akgentic.core.orchestrator import Orchestrator` import from ws.py — zero actor-internal access remains
- Deleted deprecated `get_runtime()` method from TeamService, removed `import warnings` and unused `TeamRuntime` import
- Updated `TestNotifyRestore` tests to mock `service.get_handle` returning a `TeamHandle` mock
- Removed deprecated `get_runtime` tests from `test_team_action_service.py`

Closes #59