### PR TITLE
Settings-Driven App Factory

### DIFF
--- a/src/akgentic/infra/adapters/local_ingestion.py
+++ b/src/akgentic/infra/adapters/local_ingestion.py
@@ -3,8 +3,10 @@
 from __future__ import annotations
 
 import uuid
+from typing import TYPE_CHECKING
 
-from akgentic.infra.server.services.team_service import TeamService
+if TYPE_CHECKING:
+    from akgentic.infra.server.services.team_service import TeamService
 
 
 class LocalIngestion:
@@ -13,10 +15,31 @@ class LocalIngestion:
     Community-tier implementation of InteractionChannelIngestion.
     Delegates all operations to TeamService, which already encapsulates
     catalog resolution, TeamManager lifecycle, and runtime caching.
+
+    Supports deferred wiring: ``team_service`` can be ``None`` at construction
+    time and set later via the property, allowing ``wire_community`` to build
+    the ingestion instance before ``TeamService`` exists.
     """
 
-    def __init__(self, team_service: TeamService) -> None:
+    def __init__(self, team_service: TeamService | None = None) -> None:
         self._team_service = team_service
+
+    @property
+    def team_service(self) -> TeamService | None:
+        """Return the wired TeamService, or None if not yet wired."""
+        return self._team_service
+
+    @team_service.setter
+    def team_service(self, value: TeamService) -> None:
+        """Set the TeamService for deferred wiring."""
+        self._team_service = value
+
+    def _require_team_service(self) -> TeamService:
+        """Return the wired TeamService or raise if not yet wired."""
+        if self._team_service is None:
+            msg = "LocalIngestion.team_service has not been wired yet"
+            raise RuntimeError(msg)
+        return self._team_service
 
     async def route_reply(
         self,
@@ -31,7 +54,7 @@ class LocalIngestion:
             content: Message content from the human.
             original_message_id: Optional ID of the message being replied to.
         """
-        self._team_service.send_message(team_id, content)
+        self._require_team_service().send_message(team_id, content)
 
     async def initiate_team(
         self,
@@ -49,8 +72,7 @@ class LocalIngestion:
         Returns:
             The newly created team's ID.
         """
-        process = self._team_service.create_team(
-            catalog_entry_id, user_id=channel_user_id
-        )
-        self._team_service.send_message(process.team_id, content)
+        ts = self._require_team_service()
+        process = ts.create_team(catalog_entry_id, user_id=channel_user_id)
+        ts.send_message(process.team_id, content)
         return process.team_id

--- a/src/akgentic/infra/server/app.py
+++ b/src/akgentic/infra/server/app.py
@@ -5,8 +5,6 @@ from __future__ import annotations
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
-from akgentic.infra.adapters.channel_parser_registry import ChannelParserRegistry
-from akgentic.infra.protocols.channels import ChannelRegistry, InteractionChannelIngestion
 from akgentic.infra.server.deps import CommunityServices
 from akgentic.infra.server.routes.catalog import router as catalog_router
 from akgentic.infra.server.routes.frontend_adapter import load_frontend_adapter
@@ -17,39 +15,72 @@ from akgentic.infra.server.routes.ws import ConnectionManager
 from akgentic.infra.server.routes.ws import router as ws_router
 from akgentic.infra.server.services.team_service import TeamService
 from akgentic.infra.server.settings import ServerSettings
+from akgentic.infra.wiring import wire_community
 
 
-def create_app(
-    services: CommunityServices,
-    team_service: TeamService,
-    settings: ServerSettings | None = None,
-    cors_origins: list[str] | None = None,
-    channel_parser_registry: ChannelParserRegistry | None = None,
-    channel_registry: ChannelRegistry | None = None,
-    ingestion: InteractionChannelIngestion | None = None,
-) -> FastAPI:
+def create_app(settings: ServerSettings | None = None) -> FastAPI:
     """Create and configure the FastAPI application.
 
+    Single entry-point factory: wires community services, constructs
+    ``TeamService``, completes deferred ``LocalIngestion`` wiring, and
+    mounts all routes.
+
     Args:
-        services: Wired community services container.
-        team_service: Pre-built team service for dependency injection.
-        settings: Server settings. Defaults to ServerSettings().
-        cors_origins: Allowed CORS origins. Defaults to ["*"] for community tier.
-        channel_parser_registry: Optional channel parser registry for webhook support.
-        channel_registry: Required when channel_parser_registry is provided.
-        ingestion: Required when channel_parser_registry is provided.
+        settings: Server settings. Defaults to ``ServerSettings()``.
 
     Returns:
         Configured FastAPI application instance.
+    """
+    settings = settings or ServerSettings()
+    services = wire_community(settings)
+    team_service = _build_team_service(services)
+    _wire_ingestion(services, team_service)
+    return _build_app(services, team_service, settings)
 
-    Raises:
-        ValueError: If channel_parser_registry is provided without channel_registry/ingestion.
+
+def _build_team_service(services: CommunityServices) -> TeamService:
+    """Construct TeamService from wired community services."""
+    return TeamService(
+        services=services,
+        team_catalog=services.team_catalog,
+        agent_catalog=services.agent_catalog,
+        tool_catalog=services.tool_catalog,
+        template_catalog=services.template_catalog,
+    )
+
+
+def _wire_ingestion(services: CommunityServices, team_service: TeamService) -> None:
+    """Complete deferred LocalIngestion wiring with the constructed TeamService."""
+    from akgentic.infra.adapters.local_ingestion import LocalIngestion
+
+    if isinstance(services.ingestion, LocalIngestion):
+        services.ingestion.team_service = team_service
+
+
+def _build_app(
+    services: CommunityServices,
+    team_service: TeamService,
+    settings: ServerSettings,
+) -> FastAPI:
+    """Assemble the FastAPI app from pre-built services (shared by create_app and tests).
+
+    Args:
+        services: Wired community services container.
+        team_service: Pre-built team service.
+        settings: Server settings.
+
+    Returns:
+        Configured FastAPI application instance.
     """
     app = FastAPI(title="Akgentic Platform API")
+    _add_cors(app, settings.cors_origins)
+    _store_state(app, services, team_service, settings)
+    _mount_routes(app, settings)
+    return app
 
-    if cors_origins is None:
-        cors_origins = ["*"]
 
+def _add_cors(app: FastAPI, cors_origins: list[str]) -> None:
+    """Add CORS middleware to the application."""
     app.add_middleware(
         CORSMiddleware,
         allow_origins=cors_origins,
@@ -58,31 +89,32 @@ def create_app(
         allow_headers=["*"],
     )
 
+
+def _store_state(
+    app: FastAPI,
+    services: CommunityServices,
+    team_service: TeamService,
+    settings: ServerSettings,
+) -> None:
+    """Store services and configuration on app.state for dependency injection."""
     app.state.services = services
     app.state.team_service = team_service
-    app.state.settings = settings or ServerSettings()
+    app.state.settings = settings
     app.state.connection_manager = ConnectionManager()
+    app.state.channel_parser_registry = services.channel_parser_registry
+    app.state.channel_registry = services.channel_registry
+    app.state.ingestion = services.ingestion
 
+
+def _mount_routes(app: FastAPI, settings: ServerSettings) -> None:
+    """Mount all API routers and optional frontend adapter."""
     app.include_router(teams_router)
     app.include_router(catalog_router)
     app.include_router(workspace_router)
     app.include_router(ws_router)
+    app.include_router(webhook_router)
 
-    if channel_parser_registry is not None:
-        if channel_registry is None or ingestion is None:
-            msg = (
-                "channel_registry and ingestion are required "
-                "when channel_parser_registry is provided"
-            )
-            raise ValueError(msg)
-        app.state.channel_parser_registry = channel_parser_registry
-        app.state.channel_registry = channel_registry
-        app.state.ingestion = ingestion
-        app.include_router(webhook_router)
-
-    if app.state.settings.frontend_adapter:
-        adapter = load_frontend_adapter(app.state.settings.frontend_adapter)
+    if settings.frontend_adapter:
+        adapter = load_frontend_adapter(settings.frontend_adapter)
         adapter.register_routes(app)
         app.state.frontend_adapter = adapter
-
-    return app

--- a/src/akgentic/infra/server/deps.py
+++ b/src/akgentic/infra/server/deps.py
@@ -11,7 +11,9 @@ from akgentic.catalog.services import (
     ToolCatalog,
 )
 from akgentic.core import ActorSystem
+from akgentic.infra.adapters.channel_parser_registry import ChannelParserRegistry
 from akgentic.infra.protocols.auth import AuthStrategy
+from akgentic.infra.protocols.channels import ChannelRegistry, InteractionChannelIngestion
 from akgentic.infra.protocols.placement import PlacementStrategy
 from akgentic.infra.protocols.team_handle import RuntimeCache
 from akgentic.team.manager import TeamManager
@@ -32,8 +34,8 @@ class TierServices(BaseModel):
 
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
-    placement: PlacementStrategy = Field(
-        description="Strategy for placing teams on workers"
+    placement: list[PlacementStrategy] = Field(
+        description="Strategies for placing teams on workers"
     )
     service_registry: ServiceRegistry = Field(
         description="Service discovery registry for worker instances"
@@ -46,6 +48,12 @@ class TierServices(BaseModel):
     )
     runtime_cache: RuntimeCache = Field(
         description="Cache mapping team IDs to live TeamHandle instances"
+    )
+    ingestion: InteractionChannelIngestion = Field(
+        description="Inbound channel message ingestion handler"
+    )
+    channel_registry: ChannelRegistry = Field(
+        description="Registry mapping channel IDs to team IDs"
     )
 
 
@@ -73,4 +81,7 @@ class CommunityServices(TierServices):
     )
     template_catalog: TemplateCatalog = Field(
         description="Catalog service for template entry resolution"
+    )
+    channel_parser_registry: ChannelParserRegistry = Field(
+        description="Registry of channel message parsers"
     )

--- a/src/akgentic/infra/server/settings.py
+++ b/src/akgentic/infra/server/settings.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Literal
 
 from pydantic import Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
@@ -37,11 +38,11 @@ class ServerSettings(BaseSettings):
         default=["*"],
         description="Allowed CORS origins for the HTTP server",
     )
-    event_store: str = Field(
+    event_store: Literal["yaml"] = Field(
         default="yaml",
-        description="Event store backend: 'yaml' or 'memory'",
+        description="Event store backend (only 'yaml' supported; 'memory' requires akgentic-team)",
     )
-    catalog_backend: str = Field(
+    catalog_backend: Literal["yaml"] = Field(
         default="yaml",
         description="Catalog backend: 'yaml'",
     )

--- a/src/akgentic/infra/server/settings.py
+++ b/src/akgentic/infra/server/settings.py
@@ -37,3 +37,15 @@ class ServerSettings(BaseSettings):
         default=["*"],
         description="Allowed CORS origins for the HTTP server",
     )
+    event_store: str = Field(
+        default="yaml",
+        description="Event store backend: 'yaml' or 'memory'",
+    )
+    catalog_backend: str = Field(
+        default="yaml",
+        description="Catalog backend: 'yaml'",
+    )
+    catalog_path: Path | None = Field(
+        default=None,
+        description="Catalog directory; defaults to workspaces_root / 'catalog'",
+    )

--- a/src/akgentic/infra/wiring.py
+++ b/src/akgentic/infra/wiring.py
@@ -15,11 +15,14 @@ from akgentic.catalog.services import (
     ToolCatalog,
 )
 from akgentic.core import ActorSystem, EventSubscriber
+from akgentic.infra.adapters.channel_parser_registry import ChannelParserRegistry
+from akgentic.infra.adapters.local_ingestion import LocalIngestion
 from akgentic.infra.adapters.local_placement import LocalPlacement
 from akgentic.infra.adapters.local_runtime_cache import LocalRuntimeCache
 from akgentic.infra.adapters.local_service_registry import LocalServiceRegistry
 from akgentic.infra.adapters.no_auth import NoAuth
 from akgentic.infra.adapters.telemetry_subscriber import TelemetrySubscriber
+from akgentic.infra.adapters.yaml_channel_registry import YamlChannelRegistry
 from akgentic.infra.server.deps import CommunityServices
 from akgentic.infra.server.settings import ServerSettings
 from akgentic.team.manager import TeamManager
@@ -29,16 +32,8 @@ from akgentic.team.repositories.yaml import YamlEventStore
 def wire_community(settings: ServerSettings) -> CommunityServices:
     """Assemble community-tier services for single-process deployment.
 
-    Assembly order:
-    1. EventStore (YamlEventStore)
-    2. ServiceRegistry (LocalServiceRegistry)
-    3. Shared subscribers ([TelemetrySubscriber])
-    4. ActorSystem
-    5. TeamManager
-    6. PlacementStrategy (LocalPlacement)
-    7. AuthStrategy (NoAuth)
-    8. RuntimeCache (LocalRuntimeCache)
-    9. Catalogs: Template + Tool → Agent → Team
+    ``LocalIngestion`` is created with deferred ``team_service`` wiring —
+    callers must set ``ingestion.team_service`` after constructing ``TeamService``.
 
     Args:
         settings: Server configuration
@@ -47,6 +42,33 @@ def wire_community(settings: ServerSettings) -> CommunityServices:
         Fully wired CommunityServices container
     """
     event_store = YamlEventStore(data_dir=settings.workspaces_root)
+    actor_system, team_manager = _build_actor_layer(event_store)
+    catalogs = _build_catalogs(settings)
+
+    return CommunityServices(
+        placement=[LocalPlacement()],
+        service_registry=LocalServiceRegistry(),
+        auth=NoAuth(),
+        event_store=event_store,
+        runtime_cache=LocalRuntimeCache(),
+        ingestion=LocalIngestion(),
+        channel_registry=YamlChannelRegistry(
+            registry_path=settings.workspaces_root / "channel-registry.yaml",
+        ),
+        actor_system=actor_system,
+        team_manager=team_manager,
+        channel_parser_registry=ChannelParserRegistry(channels_config={}),
+        team_catalog=catalogs[0],
+        agent_catalog=catalogs[1],
+        tool_catalog=catalogs[2],
+        template_catalog=catalogs[3],
+    )
+
+
+def _build_actor_layer(
+    event_store: YamlEventStore,
+) -> tuple[ActorSystem, TeamManager]:
+    """Build ActorSystem and TeamManager."""
     service_registry = LocalServiceRegistry()
     shared_subscribers: list[EventSubscriber] = [TelemetrySubscriber()]
     actor_system = ActorSystem()
@@ -56,11 +78,14 @@ def wire_community(settings: ServerSettings) -> CommunityServices:
         service_registry=service_registry,
         subscribers=shared_subscribers,
     )
-    placement = LocalPlacement()
-    auth = NoAuth()
-    runtime_cache = LocalRuntimeCache()
+    return actor_system, team_manager
 
-    catalog_root = settings.workspaces_root / "catalog"
+
+def _build_catalogs(
+    settings: ServerSettings,
+) -> tuple[TeamCatalog, AgentCatalog, ToolCatalog, TemplateCatalog]:
+    """Build YAML-backed catalog services."""
+    catalog_root = settings.catalog_path or settings.workspaces_root / "catalog"
     template_catalog = TemplateCatalog(
         repository=YamlTemplateCatalogRepository(catalog_dir=catalog_root / "templates"),
     )
@@ -76,17 +101,4 @@ def wire_community(settings: ServerSettings) -> CommunityServices:
         repository=YamlTeamCatalogRepository(catalog_dir=catalog_root / "teams"),
         agent_catalog=agent_catalog,
     )
-
-    return CommunityServices(
-        placement=placement,
-        service_registry=service_registry,
-        auth=auth,
-        event_store=event_store,
-        runtime_cache=runtime_cache,
-        actor_system=actor_system,
-        team_manager=team_manager,
-        team_catalog=team_catalog,
-        agent_catalog=agent_catalog,
-        tool_catalog=tool_catalog,
-        template_catalog=template_catalog,
-    )
+    return team_catalog, agent_catalog, tool_catalog, template_catalog

--- a/src/akgentic/infra/wiring.py
+++ b/src/akgentic/infra/wiring.py
@@ -42,12 +42,13 @@ def wire_community(settings: ServerSettings) -> CommunityServices:
         Fully wired CommunityServices container
     """
     event_store = YamlEventStore(data_dir=settings.workspaces_root)
-    actor_system, team_manager = _build_actor_layer(event_store)
+    service_registry = LocalServiceRegistry()
+    actor_system, team_manager = _build_actor_layer(event_store, service_registry)
     catalogs = _build_catalogs(settings)
 
     return CommunityServices(
         placement=[LocalPlacement()],
-        service_registry=LocalServiceRegistry(),
+        service_registry=service_registry,
         auth=NoAuth(),
         event_store=event_store,
         runtime_cache=LocalRuntimeCache(),
@@ -67,9 +68,9 @@ def wire_community(settings: ServerSettings) -> CommunityServices:
 
 def _build_actor_layer(
     event_store: YamlEventStore,
+    service_registry: LocalServiceRegistry,
 ) -> tuple[ActorSystem, TeamManager]:
     """Build ActorSystem and TeamManager."""
-    service_registry = LocalServiceRegistry()
     shared_subscribers: list[EventSubscriber] = [TelemetrySubscriber()]
     actor_system = ActorSystem()
     team_manager = TeamManager(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -119,13 +119,11 @@ def team_service(community_services: CommunityServices) -> TeamService:
 
 
 @pytest.fixture()
-def app(
-    community_services: CommunityServices,
-    team_service: TeamService,
-    seeded_settings: ServerSettings,
-) -> FastAPI:
-    """FastAPI app with wired services."""
-    return create_app(community_services, team_service, settings=seeded_settings)
+def app(seeded_settings: ServerSettings) -> Generator[FastAPI, None, None]:
+    """FastAPI app via the single-arg factory."""
+    application = create_app(seeded_settings)
+    yield application
+    application.state.services.actor_system.shutdown()
 
 
 @pytest.fixture()

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -16,7 +16,7 @@ from fastapi.testclient import TestClient
 from akgentic.infra.adapters.channel_parser_registry import ChannelParserRegistry
 from akgentic.infra.adapters.local_ingestion import LocalIngestion
 from akgentic.infra.adapters.yaml_channel_registry import YamlChannelRegistry
-from akgentic.infra.server.app import create_app
+from akgentic.infra.server.app import _build_app, create_app
 from akgentic.infra.server.deps import CommunityServices
 from akgentic.infra.server.services.team_service import TeamService
 from akgentic.infra.server.settings import ServerSettings
@@ -158,14 +158,12 @@ def integration_team_service(
 
 @pytest.fixture()
 def integration_app(
-    integration_services: CommunityServices,
-    integration_team_service: TeamService,
     integration_settings: ServerSettings,
-) -> FastAPI:
+) -> Generator[FastAPI, None, None]:
     """FastAPI app backed by real actors and real LLM."""
-    return create_app(
-        integration_services, integration_team_service, settings=integration_settings,
-    )
+    application = create_app(integration_settings)
+    yield application
+    application.state.services.actor_system.shutdown()
 
 
 @pytest.fixture()
@@ -195,39 +193,13 @@ def v1_adapter_settings(tmp_path: Path) -> ServerSettings:
 
 
 @pytest.fixture()
-def v1_adapter_services(
-    v1_adapter_settings: ServerSettings,
-) -> Generator[CommunityServices, None, None]:
-    """Wired community services for V1 adapter tests — shuts down on teardown."""
-    services = wire_community(v1_adapter_settings)
-    yield services
-    services.actor_system.shutdown()
-
-
-@pytest.fixture()
-def v1_adapter_team_service(
-    v1_adapter_services: CommunityServices,
-) -> TeamService:
-    """TeamService wired to V1 adapter services."""
-    return TeamService(
-        services=v1_adapter_services,
-        team_catalog=v1_adapter_services.team_catalog,
-        agent_catalog=v1_adapter_services.agent_catalog,
-        tool_catalog=v1_adapter_services.tool_catalog,
-        template_catalog=v1_adapter_services.template_catalog,
-    )
-
-
-@pytest.fixture()
 def v1_adapter_app(
-    v1_adapter_services: CommunityServices,
-    v1_adapter_team_service: TeamService,
     v1_adapter_settings: ServerSettings,
-) -> FastAPI:
+) -> Generator[FastAPI, None, None]:
     """FastAPI app with V1 frontend adapter loaded."""
-    return create_app(
-        v1_adapter_services, v1_adapter_team_service, settings=v1_adapter_settings,
-    )
+    application = create_app(v1_adapter_settings)
+    yield application
+    application.state.services.actor_system.shutdown()
 
 
 @pytest.fixture()
@@ -286,14 +258,17 @@ def channel_app(
     channel_registry_instance: YamlChannelRegistry,
     channel_ingestion: LocalIngestion,
 ) -> FastAPI:
-    """FastAPI app with webhook wiring for channel integration tests."""
-    return create_app(
+    """FastAPI app with webhook wiring for channel integration tests.
+
+    Uses _build_app with overridden channel deps on the services container.
+    """
+    integration_services.channel_parser_registry = channel_parser_registry
+    integration_services.channel_registry = channel_registry_instance
+    integration_services.ingestion = channel_ingestion
+    return _build_app(
         integration_services,
         integration_team_service,
-        settings=integration_settings,
-        channel_parser_registry=channel_parser_registry,
-        channel_registry=channel_registry_instance,
-        ingestion=channel_ingestion,
+        integration_settings,
     )
 
 

--- a/tests/test_angular_v1_adapter.py
+++ b/tests/test_angular_v1_adapter.py
@@ -20,7 +20,7 @@ from akgentic.team.models import PersistedEvent, Process, TeamCard, TeamStatus
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
-from akgentic.infra.server.app import create_app
+from akgentic.infra.server.app import _build_app
 from akgentic.infra.server.routes.frontend_adapter import FrontendAdapter, WrappedWsEvent
 from akgentic.infra.server.routes.frontend_adapter.angular_v1 import AngularV1Adapter
 from akgentic.infra.server.routes.frontend_adapter.angular_v1.models import (
@@ -97,7 +97,7 @@ def v1_client() -> TestClient:
     settings = ServerSettings(
         frontend_adapter="akgentic.infra.server.routes.frontend_adapter.angular_v1.AngularV1Adapter",
     )
-    app = create_app(mock_services, mock_team_service, settings=settings)
+    app = _build_app(mock_services, mock_team_service, settings)
     return TestClient(app)
 
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -2,27 +2,20 @@
 
 from __future__ import annotations
 
-from pathlib import Path
-from unittest.mock import MagicMock
-
-import pytest
 from fastapi.testclient import TestClient
 
 from akgentic.infra.server.app import create_app
-from akgentic.infra.server.deps import CommunityServices
-from akgentic.infra.server.services.team_service import TeamService
+from akgentic.infra.server.settings import ServerSettings
 
 
-def test_create_app_returns_fastapi(
-    community_services: CommunityServices,
-    team_service: TeamService,
-) -> None:
+def test_create_app_returns_fastapi(seeded_settings: ServerSettings) -> None:
     """create_app returns a FastAPI instance with routes mounted."""
-    app = create_app(community_services, team_service)
+    app = create_app(seeded_settings)
     assert app.title == "Akgentic Platform API"
     route_paths = [r.path for r in app.routes]  # type: ignore[union-attr]
     assert "/teams/" in route_paths
     assert "/teams/{team_id}" in route_paths
+    app.state.services.actor_system.shutdown()
 
 
 def test_cors_headers_present(client: TestClient) -> None:
@@ -38,12 +31,13 @@ def test_cors_headers_present(client: TestClient) -> None:
     assert "access-control-allow-origin" in resp.headers
 
 
-def test_custom_cors_origins(
-    community_services: CommunityServices,
-    team_service: TeamService,
-) -> None:
-    """create_app respects custom cors_origins."""
-    app = create_app(community_services, team_service, cors_origins=["http://example.com"])
+def test_custom_cors_origins(seeded_settings: ServerSettings) -> None:
+    """create_app respects custom cors_origins from settings."""
+    settings = ServerSettings(
+        workspaces_root=seeded_settings.workspaces_root,
+        cors_origins=["http://example.com"],
+    )
+    app = create_app(settings)
     test_client = TestClient(app)
     resp = test_client.options(
         "/teams/",
@@ -53,6 +47,7 @@ def test_custom_cors_origins(
         },
     )
     assert resp.headers.get("access-control-allow-origin") == "http://example.com"
+    app.state.services.actor_system.shutdown()
 
 
 # ---------------------------------------------------------------------------
@@ -60,56 +55,9 @@ def test_custom_cors_origins(
 # ---------------------------------------------------------------------------
 
 
-def test_create_app_includes_webhook_routes_when_channel_deps_provided(
-    community_services: CommunityServices,
-    team_service: TeamService,
-    tmp_path: Path,
-) -> None:
-    """create_app includes /webhook routes when channel deps are provided."""
-    from akgentic.infra.adapters.channel_parser_registry import ChannelParserRegistry
-    from akgentic.infra.adapters.yaml_channel_registry import YamlChannelRegistry
-
-    parser_registry = ChannelParserRegistry.__new__(ChannelParserRegistry)
-    parser_registry._parsers = {}  # noqa: SLF001
-    parser_registry._adapters = []  # noqa: SLF001
-    channel_registry = YamlChannelRegistry(tmp_path / "registry.yaml")
-    ingestion = MagicMock()
-
-    app = create_app(
-        community_services,
-        team_service,
-        channel_parser_registry=parser_registry,
-        channel_registry=channel_registry,
-        ingestion=ingestion,
-    )
+def test_create_app_includes_webhook_routes(seeded_settings: ServerSettings) -> None:
+    """create_app always includes /webhook routes (channel deps are auto-wired)."""
+    app = create_app(seeded_settings)
     route_paths = [r.path for r in app.routes]  # type: ignore[union-attr]
     assert "/webhook/{channel}" in route_paths
-
-
-def test_create_app_excludes_webhook_routes_by_default(
-    community_services: CommunityServices,
-    team_service: TeamService,
-) -> None:
-    """create_app excludes /webhook routes when channel deps are not provided."""
-    app = create_app(community_services, team_service)
-    route_paths = [r.path for r in app.routes]  # type: ignore[union-attr]
-    assert "/webhook/{channel}" not in route_paths
-
-
-def test_create_app_raises_when_channel_deps_incomplete(
-    community_services: CommunityServices,
-    team_service: TeamService,
-) -> None:
-    """create_app raises ValueError when channel_parser_registry provided without others."""
-    from akgentic.infra.adapters.channel_parser_registry import ChannelParserRegistry
-
-    parser_registry = ChannelParserRegistry.__new__(ChannelParserRegistry)
-    parser_registry._parsers = {}  # noqa: SLF001
-    parser_registry._adapters = []  # noqa: SLF001
-
-    with pytest.raises(ValueError, match="channel_registry and ingestion are required"):
-        create_app(
-            community_services,
-            team_service,
-            channel_parser_registry=parser_registry,
-        )
+    app.state.services.actor_system.shutdown()

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -2,10 +2,25 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+
 from fastapi.testclient import TestClient
 
 from akgentic.infra.server.app import create_app
 from akgentic.infra.server.settings import ServerSettings
+
+
+def test_create_app_defaults_settings_when_none(tmp_path: Path) -> None:
+    """create_app(None) defaults to ServerSettings() and returns a working app."""
+    import os
+
+    os.environ["AKGENTIC_WORKSPACES_ROOT"] = str(tmp_path / "ws")
+    try:
+        app = create_app(None)
+        assert app.title == "Akgentic Platform API"
+        app.state.services.actor_system.shutdown()
+    finally:
+        os.environ.pop("AKGENTIC_WORKSPACES_ROOT", None)
 
 
 def test_create_app_returns_fastapi(seeded_settings: ServerSettings) -> None:

--- a/tests/test_frontend_adapter.py
+++ b/tests/test_frontend_adapter.py
@@ -252,9 +252,9 @@ class TestCreateAppAdapterIntegration:
         team_service: MagicMock,
         settings: ServerSettings,
     ) -> FastAPI:
-        from akgentic.infra.server.app import create_app
+        from akgentic.infra.server.app import _build_app
 
-        return create_app(services, team_service, settings=settings)
+        return _build_app(services, team_service, settings)
 
     @pytest.fixture()
     def community_services(self) -> MagicMock:
@@ -305,14 +305,9 @@ class TestWebSocketAdapterIntegration:
     @pytest.fixture()
     def client_with_adapter(
         self,
-        community_services: object,
-        team_service: object,
-        seeded_settings: ServerSettings,
+        app: FastAPI,
     ) -> TestClient:
         """TestClient with a stub adapter set on app.state."""
-        from akgentic.infra.server.app import create_app
-
-        app = create_app(community_services, team_service, settings=seeded_settings)
         app.state.frontend_adapter = _StubAdapter()
         return TestClient(app)
 

--- a/tests/test_wiring.py
+++ b/tests/test_wiring.py
@@ -62,3 +62,23 @@ class TestWireCommunity:
             assert isinstance(services.event_store, YamlEventStore)
         finally:
             services.team_manager._actor_system.shutdown(timeout=5)
+
+    def test_shared_service_registry(self, services: CommunityServices) -> None:
+        """TeamManager and CommunityServices share the same service registry."""
+        assert services.service_registry is services.team_manager._service_registry
+
+    def test_catalog_path_override(self, tmp_path: Path) -> None:
+        """wire_community uses settings.catalog_path when set."""
+        custom_catalog = tmp_path / "custom-catalog"
+        custom_catalog.mkdir()
+        for sub in ("teams", "agents", "tools", "templates"):
+            (custom_catalog / sub).mkdir()
+        settings = ServerSettings(
+            workspaces_root=tmp_path,
+            catalog_path=custom_catalog,
+        )
+        services = wire_community(settings)
+        try:
+            assert services.team_catalog is not None
+        finally:
+            services.team_manager._actor_system.shutdown(timeout=5)

--- a/tests/test_wiring.py
+++ b/tests/test_wiring.py
@@ -32,9 +32,11 @@ class TestWireCommunity:
         """wire_community returns a CommunityServices instance."""
         assert isinstance(services, CommunityServices)
 
-    def test_placement_is_local(self, services: CommunityServices) -> None:
-        """Placement strategy is LocalPlacement."""
-        assert isinstance(services.placement, LocalPlacement)
+    def test_placement_is_local_list(self, services: CommunityServices) -> None:
+        """Placement strategy is a list containing LocalPlacement."""
+        assert isinstance(services.placement, list)
+        assert len(services.placement) == 1
+        assert isinstance(services.placement[0], LocalPlacement)
 
     def test_auth_is_noauth(self, services: CommunityServices) -> None:
         """Auth strategy is NoAuth."""


### PR DESCRIPTION
## Summary

- Refactor `create_app` to single-arg `create_app(settings: ServerSettings | None = None)` factory
- Update `TierServices` with `ingestion`, `channel_registry`, and `placement: list[PlacementStrategy]`
- Extend `ServerSettings` with `event_store`, `catalog_backend`, `catalog_path` fields
- Absorb channel wiring into `wire_community` (YamlChannelRegistry, ChannelParserRegistry, LocalIngestion)
- Extract helpers to keep all methods under 50 lines
- Update all test callers to new API; mock-service tests use `_build_app` helper

## Code Review Fixes

- Fix duplicate LocalServiceRegistry regression from helper extraction
- Add Literal type validation for event_store/catalog_backend settings
- Add tests for create_app(None), shared service registry, and catalog_path override

Closes #61