### PR TITLE
V1 Frontend Adapter Completion

### DIFF
--- a/src/akgentic/infra/server/routes/frontend_adapter/angular_v1/__init__.py
+++ b/src/akgentic/infra/server/routes/frontend_adapter/angular_v1/__init__.py
@@ -11,11 +11,16 @@ from fastapi import FastAPI
 
 from akgentic.infra.server.routes.frontend_adapter import WrappedWsEvent
 from akgentic.infra.server.routes.frontend_adapter.angular_v1.router import (
+    config_router,
+    feedback_router,
     human_input_router,
     llm_context_router,
     messages_router,
     process_router,
+    relaunch_router,
+    state_update_router,
     states_router,
+    team_configs_router,
 )
 from akgentic.infra.server.routes.frontend_adapter.angular_v1.ws import wrap_event
 from akgentic.team.models import PersistedEvent
@@ -37,6 +42,11 @@ class AngularV1Adapter:
         app.include_router(messages_router)
         app.include_router(llm_context_router)
         app.include_router(states_router)
+        app.include_router(config_router)
+        app.include_router(team_configs_router)
+        app.include_router(feedback_router)
+        app.include_router(relaunch_router)
+        app.include_router(state_update_router)
 
     def wrap_ws_event(self, event: PersistedEvent) -> WrappedWsEvent:
         """Translate a V2 persisted event into a V1 WebSocket envelope."""

--- a/src/akgentic/infra/server/routes/frontend_adapter/angular_v1/models.py
+++ b/src/akgentic/infra/server/routes/frontend_adapter/angular_v1/models.py
@@ -6,14 +6,25 @@ These are independent from V2 models — no shared response models.
 
 from __future__ import annotations
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 
 class V1ActorAddress(BaseModel):
     """V1 actor address representation."""
 
+    model_config = ConfigDict(populate_by_name=True)
+
     name: str = Field(description="Actor display name")
     role: str = Field(description="Actor role from AgentCard")
+    actor_address: str = Field(
+        default="",
+        alias="__actor_address__",
+        description="String-serialized actor address",
+    )
+    address: str = Field(default="", description="Actor address string")
+    agent_id: str = Field(default="", description="Agent unique ID")
+    squad_id: str = Field(default="", description="Team ID string")
+    user_message: str = Field(default="", description="User message, populated when applicable")
 
 
 class V1ProcessParams(BaseModel):
@@ -38,6 +49,11 @@ class V1ProcessContext(BaseModel):
         default_factory=dict,
         description="Empty dict for V2 compat",
     )
+    orchestrator: str = Field(default="", description="Team entry point agent name")
+    running: bool = Field(default=False, description="Derived from status == running")
+    config_name: str = Field(default="", description="Team card name / catalog entry ID")
+    user_id: str = Field(default="", description="User who owns this team")
+    user_email: str = Field(default="", description="Email of the user who owns this team")
 
 
 class V1MessageEntry(BaseModel):
@@ -79,3 +95,34 @@ class V1StatusResponse(BaseModel):
     """V1 simple status response for action endpoints."""
 
     status: str = Field(description="Operation status, e.g. 'ok'")
+
+
+class V1DescriptionBody(BaseModel):
+    """Request body for PATCH /process/{id}/description."""
+
+    description: str = Field(description="New description for the process")
+
+
+class V1StateUpdateBody(BaseModel):
+    """Request body for PATCH /state/{id}/of/{agent}."""
+
+    content: str = Field(description="State update content to send to agent")
+
+
+class V1ConfigEntry(BaseModel):
+    """V1 catalog configuration entry for GET/PUT/DELETE /config."""
+
+    id: str = Field(description="Configuration entry ID")
+    type: str = Field(description="Configuration type: team, agent, tool, template")
+    data: dict[str, object] = Field(
+        default_factory=dict,
+        description="Configuration data",
+    )
+
+
+class V1FeedbackEntry(BaseModel):
+    """V1 feedback entry for GET/POST /feedback."""
+
+    id: str = Field(default="", description="Feedback entry ID")
+    content: str = Field(default="", description="Feedback content")
+    rating: int = Field(default=0, description="Feedback rating")

--- a/src/akgentic/infra/server/routes/frontend_adapter/angular_v1/router.py
+++ b/src/akgentic/infra/server/routes/frontend_adapter/angular_v1/router.py
@@ -422,7 +422,8 @@ def put_config(body: V1ConfigEntry, request: Request) -> V1StatusResponse:
     if existing is not None:
         catalog.update(body.id, existing.__class__.model_validate(body.data))
     else:
-        entry_cls = type(catalog.list()[0]) if catalog.list() else None
+        existing_entries = catalog.list()
+        entry_cls = type(existing_entries[0]) if existing_entries else None
         if entry_cls is None:
             raise HTTPException(status_code=400, detail="Cannot determine entry type")
         catalog.create(entry_cls.model_validate(body.data))

--- a/src/akgentic/infra/server/routes/frontend_adapter/angular_v1/router.py
+++ b/src/akgentic/infra/server/routes/frontend_adapter/angular_v1/router.py
@@ -6,7 +6,7 @@ Every route delegates to TeamService — zero business logic in the adapter.
 from __future__ import annotations
 
 import uuid
-from typing import NoReturn, cast
+from typing import Any, NoReturn, cast
 
 from fastapi import APIRouter, Depends, HTTPException, Request
 from pydantic import BaseModel, Field
@@ -20,21 +20,30 @@ from akgentic.infra.server.routes.frontend_adapter.angular_v1._helpers import (
     get_sender_name,
 )
 from akgentic.infra.server.routes.frontend_adapter.angular_v1.models import (
+    V1ConfigEntry,
+    V1DescriptionBody,
+    V1FeedbackEntry,
     V1LlmContextEntry,
     V1MessageEntry,
     V1ProcessContext,
     V1ProcessList,
     V1StateEntry,
+    V1StateUpdateBody,
     V1StatusResponse,
 )
 from akgentic.infra.server.services.team_service import TeamService
-from akgentic.team.models import PersistedEvent, Process
+from akgentic.team.models import PersistedEvent, Process, TeamStatus
 
 process_router = APIRouter(prefix="/process", tags=["v1-compat"])
 human_input_router = APIRouter(prefix="/process_human_input", tags=["v1-compat"])
 messages_router = APIRouter(prefix="/messages", tags=["v1-compat"])
 llm_context_router = APIRouter(prefix="/llm_context", tags=["v1-compat"])
 states_router = APIRouter(prefix="/states", tags=["v1-compat"])
+config_router = APIRouter(prefix="/config", tags=["v1-compat"])
+team_configs_router = APIRouter(prefix="/team-configs", tags=["v1-compat"])
+feedback_router = APIRouter(tags=["v1-compat"])
+relaunch_router = APIRouter(prefix="/relaunch", tags=["v1-compat"])
+state_update_router = APIRouter(prefix="/state", tags=["v1-compat"])
 
 
 class V1MessageBody(BaseModel):
@@ -64,6 +73,11 @@ def _to_v1_process_context(process: Process) -> V1ProcessContext:
         created_at=process.created_at.isoformat(),
         updated_at=process.updated_at.isoformat(),
         params={},
+        orchestrator=process.team_card.entry_point.card.config.name,
+        running=process.status == TeamStatus.RUNNING,
+        config_name=process.team_card.name,
+        user_id=process.user_id,
+        user_email=process.user_email,
     )
 
 
@@ -292,3 +306,168 @@ def get_states(
                 )
             )
     return result
+
+
+# --- Description route (extends process_router) ---
+
+
+@process_router.patch(
+    "/{id}/description", status_code=200, response_model=V1StatusResponse,
+)
+def update_description(
+    id: str,
+    body: V1DescriptionBody,
+    service: TeamService = Depends(get_team_service),
+) -> V1StatusResponse:
+    """PATCH /process/{id}/description -> no-op, V2 descriptions are immutable."""
+    team_id = _parse_uuid(id)
+    process = service.get_team(team_id)
+    if process is None:
+        raise HTTPException(status_code=404, detail="Team not found")
+    return V1StatusResponse(status="ok")
+
+
+# --- Relaunch route (extends process_router) ---
+
+
+@relaunch_router.post(
+    "/{id}/message/{msg_id}", status_code=200, response_model=V1StatusResponse,
+)
+def relaunch_message(
+    id: str,
+    msg_id: str,
+    service: TeamService = Depends(get_team_service),
+) -> V1StatusResponse:
+    """POST /relaunch/{id}/message/{msgId} -> re-send original message to team."""
+    team_id = _parse_uuid(id)
+    try:
+        events = service.get_events(team_id)
+    except ValueError:
+        raise HTTPException(status_code=404, detail="Team not found") from None
+    original_content: str | None = None
+    for ev in events:
+        if str(ev.event.id) == msg_id:
+            original_content = extract_message_content(ev.event)
+            break
+    if original_content is None:
+        raise HTTPException(status_code=404, detail="Message not found")
+    try:
+        service.send_message(team_id, original_content)
+    except ValueError as exc:
+        _raise_action_error(exc)
+    return V1StatusResponse(status="ok")
+
+
+# --- State update route ---
+
+
+@state_update_router.patch(
+    "/{id}/of/{agent}", status_code=200, response_model=V1StatusResponse,
+)
+def update_agent_state(
+    id: str,
+    agent: str,
+    body: V1StateUpdateBody,
+    service: TeamService = Depends(get_team_service),
+) -> V1StatusResponse:
+    """PATCH /state/{id}/of/{agent} -> send content to specific agent."""
+    team_id = _parse_uuid(id)
+    handle = service.get_handle(team_id)
+    if handle is None:
+        raise HTTPException(status_code=404, detail="Team not found or not running")
+    handle.send_to(agent, body.content)
+    return V1StatusResponse(status="ok")
+
+
+# --- Config routes ---
+
+
+def _get_catalog_for_type(request: Request, config_type: str) -> Any:
+    """Look up the catalog service for a given config type."""
+    services = request.app.state.services
+    catalogs: dict[str, Any] = {
+        "team": services.team_catalog,
+        "agent": services.agent_catalog,
+        "tool": services.tool_catalog,
+        "template": services.template_catalog,
+    }
+    catalog = catalogs.get(config_type)
+    if catalog is None:
+        raise HTTPException(
+            status_code=400, detail=f"Unknown config type: {config_type}",
+        )
+    return catalog
+
+
+@config_router.get("/{config_type}", response_model=list[V1ConfigEntry])
+def get_config(config_type: str, request: Request) -> list[V1ConfigEntry]:
+    """GET /config/{type} -> list catalog entries by type."""
+    catalog = _get_catalog_for_type(request, config_type)
+    entries = catalog.list()
+    return [
+        V1ConfigEntry(
+            id=entry.id,
+            type=config_type,
+            data=entry.model_dump(mode="json"),
+        )
+        for entry in entries
+    ]
+
+
+@config_router.put("/", status_code=200, response_model=V1StatusResponse)
+def put_config(body: V1ConfigEntry, request: Request) -> V1StatusResponse:
+    """PUT /config -> create or update a catalog entry."""
+    catalog = _get_catalog_for_type(request, body.type)
+    existing = catalog.get(body.id)
+    if existing is not None:
+        catalog.update(body.id, existing.__class__.model_validate(body.data))
+    else:
+        entry_cls = type(catalog.list()[0]) if catalog.list() else None
+        if entry_cls is None:
+            raise HTTPException(status_code=400, detail="Cannot determine entry type")
+        catalog.create(entry_cls.model_validate(body.data))
+    return V1StatusResponse(status="ok")
+
+
+@config_router.delete("/", status_code=200, response_model=V1StatusResponse)
+def delete_config(body: V1ConfigEntry, request: Request) -> V1StatusResponse:
+    """DELETE /config -> delete a catalog entry."""
+    catalog = _get_catalog_for_type(request, body.type)
+    existing = catalog.get(body.id)
+    if existing is None:
+        raise HTTPException(status_code=404, detail="Config entry not found")
+    catalog.delete(body.id)
+    return V1StatusResponse(status="ok")
+
+
+# --- Team configs route ---
+
+
+@team_configs_router.get("/", response_model=list[V1ConfigEntry])
+def get_team_configs(request: Request) -> list[V1ConfigEntry]:
+    """GET /team-configs -> list all team catalog entries."""
+    catalog = request.app.state.services.team_catalog
+    entries = catalog.list()
+    return [
+        V1ConfigEntry(
+            id=entry.id,
+            type="team",
+            data=entry.model_dump(mode="json"),
+        )
+        for entry in entries
+    ]
+
+
+# --- Feedback routes (stubs — no V2 feedback system) ---
+
+
+@feedback_router.get("/get-feedback", response_model=list[V1FeedbackEntry])
+def get_feedback() -> list[V1FeedbackEntry]:
+    """GET /get-feedback -> stub returning empty list."""
+    return []
+
+
+@feedback_router.post("/set-feedback", status_code=200, response_model=V1StatusResponse)
+def set_feedback(body: V1FeedbackEntry) -> V1StatusResponse:
+    """POST /set-feedback -> stub returning ok."""
+    return V1StatusResponse(status="ok")

--- a/src/akgentic/infra/server/routes/frontend_adapter/angular_v1/ws.py
+++ b/src/akgentic/infra/server/routes/frontend_adapter/angular_v1/ws.py
@@ -31,12 +31,14 @@ def _classify_envelope_type(event: Message) -> str:
         event: The V2 message from a persisted event.
 
     Returns:
-        One of ``"message"``, ``"state"``, or ``"tool_update"``.
+        One of ``"message"``, ``"state"``, ``"tool_update"``, or ``"llm_context"``.
     """
     if isinstance(event, StateChangedMessage):
         return "state"
     if isinstance(event, EventMessage):
         return "tool_update"
+    if type(event).__name__ == "ContextChangedMessage":
+        return "llm_context"
     return "message"
 
 
@@ -132,6 +134,30 @@ def _build_tool_update_envelope(event: EventMessage, timestamp: str) -> dict[str
     }
 
 
+def _build_llm_context_envelope(event: Message, timestamp: str) -> dict[str, Any]:
+    """Build a V1 ``type: "llm_context"`` envelope.
+
+    Args:
+        event: The context-changed message.
+        timestamp: ISO-formatted event timestamp.
+
+    Returns:
+        Dict with V1 llm_context envelope fields.
+    """
+    context_data: Any = {}
+    if hasattr(event, "context") and hasattr(event.context, "model_dump"):
+        context_data = event.context.model_dump(mode="json")
+    elif hasattr(event, "context") and isinstance(event.context, dict):
+        context_data = event.context
+    elif hasattr(event, "context"):
+        context_data = str(event.context)
+    return {
+        "type": "llm_context",
+        "context": context_data,
+        "timestamp": timestamp,
+    }
+
+
 def wrap_event(event: PersistedEvent) -> WrappedWsEvent:
     """Translate a V2 persisted event into a V1 WebSocket envelope.
 
@@ -151,6 +177,8 @@ def wrap_event(event: PersistedEvent) -> WrappedWsEvent:
         payload = _build_state_envelope(msg, timestamp)
     elif envelope_type == "tool_update" and isinstance(msg, EventMessage):
         payload = _build_tool_update_envelope(msg, timestamp)
+    elif envelope_type == "llm_context":
+        payload = _build_llm_context_envelope(msg, timestamp)
     else:
         payload = _build_message_envelope(msg, timestamp)
 

--- a/tests/test_angular_v1_adapter.py
+++ b/tests/test_angular_v1_adapter.py
@@ -25,12 +25,16 @@ from akgentic.infra.server.routes.frontend_adapter import FrontendAdapter, Wrapp
 from akgentic.infra.server.routes.frontend_adapter.angular_v1 import AngularV1Adapter
 from akgentic.infra.server.routes.frontend_adapter.angular_v1.models import (
     V1ActorAddress,
+    V1ConfigEntry,
+    V1DescriptionBody,
+    V1FeedbackEntry,
     V1LlmContextEntry,
     V1MessageEntry,
     V1ProcessContext,
     V1ProcessList,
     V1ProcessParams,
     V1StateEntry,
+    V1StateUpdateBody,
     V1StatusResponse,
 )
 from akgentic.infra.server.settings import ServerSettings
@@ -52,9 +56,12 @@ def _make_agent_card(name: str = "@Human", role: str = "Human") -> Any:
 
 
 def _make_team_card(name: str = "Test Team") -> MagicMock:
-    """Create a minimal TeamCard mock."""
+    """Create a minimal TeamCard mock with entry_point for V1 translation."""
+    entry_point = MagicMock()
+    entry_point.card.config.name = "@Orchestrator"
     card = MagicMock(spec=TeamCard)
     card.name = name
+    card.entry_point = entry_point
     return card
 
 
@@ -170,10 +177,15 @@ class TestV1Models:
         assert restored == entry
 
     def test_v1_actor_address_serialization(self) -> None:
-        """V1ActorAddress serializes correctly."""
+        """V1ActorAddress serializes correctly with all fields."""
         addr = V1ActorAddress(name="@Human", role="Human")
         data = addr.model_dump()
-        assert data == {"name": "@Human", "role": "Human"}
+        assert data["name"] == "@Human"
+        assert data["role"] == "Human"
+        assert data["address"] == ""
+        assert data["agent_id"] == ""
+        assert data["squad_id"] == ""
+        assert data["user_message"] == ""
         restored = V1ActorAddress.model_validate(data)
         assert restored == addr
 
@@ -672,3 +684,396 @@ class TestV1ErrorCases:
         """Invalid UUID in states path returns 422."""
         resp = v1_client.get("/states/not-a-uuid")
         assert resp.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# Story 6.8: V1ProcessContext new fields (AC #1)
+# ---------------------------------------------------------------------------
+
+
+class TestV1ProcessContextNewFields:
+    """Test V1ProcessContext new fields: orchestrator, running, config_name, user_id, user_email."""
+
+    def test_new_fields_default_values(self) -> None:
+        """New fields have sensible defaults."""
+        ctx = V1ProcessContext(
+            id=str(_TEAM_ID),
+            type="Test",
+            status="running",
+            created_at=_NOW.isoformat(),
+            updated_at=_NOW.isoformat(),
+        )
+        assert ctx.orchestrator == ""
+        assert ctx.running is False
+        assert ctx.config_name == ""
+        assert ctx.user_id == ""
+        assert ctx.user_email == ""
+
+    def test_new_fields_populated(self) -> None:
+        """New fields can be explicitly populated."""
+        ctx = V1ProcessContext(
+            id=str(_TEAM_ID),
+            type="Test Team",
+            status="running",
+            created_at=_NOW.isoformat(),
+            updated_at=_NOW.isoformat(),
+            orchestrator="@Manager",
+            running=True,
+            config_name="my-team",
+            user_id="user-1",
+            user_email="user@example.com",
+        )
+        assert ctx.orchestrator == "@Manager"
+        assert ctx.running is True
+        assert ctx.config_name == "my-team"
+        assert ctx.user_id == "user-1"
+        assert ctx.user_email == "user@example.com"
+
+    def test_new_fields_serialization_roundtrip(self) -> None:
+        """V1ProcessContext with new fields survives roundtrip."""
+        ctx = V1ProcessContext(
+            id=str(_TEAM_ID),
+            type="Test",
+            status="running",
+            created_at=_NOW.isoformat(),
+            updated_at=_NOW.isoformat(),
+            orchestrator="@Bot",
+            running=True,
+            config_name="team-cfg",
+            user_id="u1",
+            user_email="e@e.com",
+        )
+        data = ctx.model_dump()
+        restored = V1ProcessContext.model_validate(data)
+        assert restored == ctx
+
+    def test_to_v1_process_context_populates_new_fields(
+        self, v1_client: TestClient, mock_service: MagicMock,
+    ) -> None:
+        """GET /process/{id} response includes new fields from Process."""
+        process = _make_process()
+        mock_service.get_team.return_value = process
+        resp = v1_client.get(f"/process/{_TEAM_ID}")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["orchestrator"] == "@Orchestrator"
+        assert data["running"] is True
+        assert data["config_name"] == "Test Team"
+        assert data["user_id"] == "anonymous"
+        assert data["user_email"] == ""
+
+    def test_running_false_when_stopped(
+        self, v1_client: TestClient, mock_service: MagicMock,
+    ) -> None:
+        """Running field is False when team is stopped."""
+        process = _make_process(status=TeamStatus.STOPPED)
+        mock_service.get_team.return_value = process
+        resp = v1_client.get(f"/process/{_TEAM_ID}")
+        assert resp.status_code == 200
+        assert resp.json()["running"] is False
+
+
+# ---------------------------------------------------------------------------
+# Story 6.8: V1ActorAddress new fields (AC #2)
+# ---------------------------------------------------------------------------
+
+
+class TestV1ActorAddressNewFields:
+    """Test V1ActorAddress new fields."""
+
+    def test_new_fields_default_values(self) -> None:
+        """New fields default to empty strings."""
+        addr = V1ActorAddress(name="@Agent", role="Worker")
+        assert addr.actor_address == ""
+        assert addr.address == ""
+        assert addr.agent_id == ""
+        assert addr.squad_id == ""
+        assert addr.user_message == ""
+
+    def test_new_fields_populated(self) -> None:
+        """New fields can be explicitly populated."""
+        addr = V1ActorAddress(
+            name="@Agent",
+            role="Worker",
+            actor_address="agent-addr-1",
+            address="agent-addr-1",
+            agent_id="agent-1",
+            squad_id=str(_TEAM_ID),
+            user_message="hello",
+        )
+        assert addr.actor_address == "agent-addr-1"
+        assert addr.address == "agent-addr-1"
+        assert addr.agent_id == "agent-1"
+        assert addr.squad_id == str(_TEAM_ID)
+        assert addr.user_message == "hello"
+
+    def test_alias_serialization(self) -> None:
+        """V1ActorAddress serializes actor_address with alias __actor_address__."""
+        addr = V1ActorAddress(name="@A", role="R", actor_address="addr-1")
+        data = addr.model_dump(by_alias=True)
+        assert "__actor_address__" in data
+        assert data["__actor_address__"] == "addr-1"
+
+    def test_alias_deserialization(self) -> None:
+        """V1ActorAddress can be deserialized from __actor_address__ alias."""
+        data = {
+            "name": "@A",
+            "role": "R",
+            "__actor_address__": "addr-from-alias",
+            "address": "",
+            "agent_id": "",
+            "squad_id": "",
+            "user_message": "",
+        }
+        addr = V1ActorAddress.model_validate(data)
+        assert addr.actor_address == "addr-from-alias"
+
+
+# ---------------------------------------------------------------------------
+# Story 6.8: New request/response models (AC #1, #2)
+# ---------------------------------------------------------------------------
+
+
+class TestNewRequestModels:
+    """Test new request/response models added for story 6.8."""
+
+    def test_v1_description_body(self) -> None:
+        """V1DescriptionBody serializes correctly."""
+        body = V1DescriptionBody(description="new desc")
+        assert body.description == "new desc"
+        data = body.model_dump()
+        assert V1DescriptionBody.model_validate(data) == body
+
+    def test_v1_state_update_body(self) -> None:
+        """V1StateUpdateBody serializes correctly."""
+        body = V1StateUpdateBody(content="new state")
+        assert body.content == "new state"
+
+    def test_v1_config_entry(self) -> None:
+        """V1ConfigEntry serializes correctly."""
+        entry = V1ConfigEntry(id="cfg-1", type="team", data={"name": "x"})
+        data = entry.model_dump()
+        restored = V1ConfigEntry.model_validate(data)
+        assert restored == entry
+
+    def test_v1_feedback_entry(self) -> None:
+        """V1FeedbackEntry serializes correctly."""
+        entry = V1FeedbackEntry(id="fb-1", content="great", rating=5)
+        data = entry.model_dump()
+        restored = V1FeedbackEntry.model_validate(data)
+        assert restored == entry
+
+    def test_v1_feedback_entry_defaults(self) -> None:
+        """V1FeedbackEntry has sensible defaults."""
+        entry = V1FeedbackEntry()
+        assert entry.id == ""
+        assert entry.content == ""
+        assert entry.rating == 0
+
+
+# ---------------------------------------------------------------------------
+# Story 6.8: New REST endpoints (AC #3)
+# ---------------------------------------------------------------------------
+
+
+class TestV1DescriptionEndpoint:
+    """Test PATCH /process/{id}/description endpoint."""
+
+    def test_update_description_ok(
+        self, v1_client: TestClient, mock_service: MagicMock,
+    ) -> None:
+        """AC3: PATCH /process/{id}/description returns ok."""
+        mock_service.get_team.return_value = _make_process()
+        resp = v1_client.patch(
+            f"/process/{_TEAM_ID}/description",
+            json={"description": "new desc"},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "ok"
+
+    def test_update_description_not_found(
+        self, v1_client: TestClient, mock_service: MagicMock,
+    ) -> None:
+        """PATCH /process/{id}/description returns 404 for missing team."""
+        mock_service.get_team.return_value = None
+        resp = v1_client.patch(
+            f"/process/{_TEAM_ID}/description",
+            json={"description": "new desc"},
+        )
+        assert resp.status_code == 404
+
+
+class TestV1RelaunchEndpoint:
+    """Test POST /relaunch/{id}/message/{msgId} endpoint."""
+
+    def test_relaunch_message_ok(
+        self, v1_client: TestClient, mock_service: MagicMock,
+    ) -> None:
+        """AC3: POST /relaunch/{id}/message/{msgId} re-sends message."""
+        msg = UserMessage(content="original message")
+        mock_service.get_events.return_value = [
+            _make_persisted_event(msg, sequence=1),
+        ]
+        mock_service.send_message.return_value = None
+        resp = v1_client.post(f"/relaunch/{_TEAM_ID}/message/{msg.id}")
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "ok"
+        mock_service.send_message.assert_called_once_with(_TEAM_ID, "original message")
+
+    def test_relaunch_message_not_found_team(
+        self, v1_client: TestClient, mock_service: MagicMock,
+    ) -> None:
+        """POST /relaunch/{id}/message/{msgId} returns 404 for unknown team."""
+        mock_service.get_events.side_effect = ValueError("not found")
+        resp = v1_client.post(f"/relaunch/{_TEAM_ID}/message/some-msg-id")
+        assert resp.status_code == 404
+
+    def test_relaunch_message_not_found_msg(
+        self, v1_client: TestClient, mock_service: MagicMock,
+    ) -> None:
+        """POST /relaunch/{id}/message/{msgId} returns 404 for unknown msg."""
+        mock_service.get_events.return_value = []
+        resp = v1_client.post(f"/relaunch/{_TEAM_ID}/message/nonexistent")
+        assert resp.status_code == 404
+
+
+class TestV1StateUpdateEndpoint:
+    """Test PATCH /state/{id}/of/{agent} endpoint."""
+
+    def test_update_agent_state_ok(
+        self, v1_client: TestClient, mock_service: MagicMock,
+    ) -> None:
+        """AC3: PATCH /state/{id}/of/{agent} sends to agent."""
+        mock_handle = MagicMock()
+        mock_service.get_handle.return_value = mock_handle
+        resp = v1_client.patch(
+            f"/state/{_TEAM_ID}/of/@Worker",
+            json={"content": "update state"},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "ok"
+        mock_handle.send_to.assert_called_once_with("@Worker", "update state")
+
+    def test_update_agent_state_not_found(
+        self, v1_client: TestClient, mock_service: MagicMock,
+    ) -> None:
+        """PATCH /state/{id}/of/{agent} returns 404 when no handle."""
+        mock_service.get_handle.return_value = None
+        resp = v1_client.patch(
+            f"/state/{_TEAM_ID}/of/@Worker",
+            json={"content": "update"},
+        )
+        assert resp.status_code == 404
+
+
+class TestV1FeedbackEndpoints:
+    """Test feedback stub endpoints."""
+
+    def test_get_feedback_returns_empty(self, v1_client: TestClient) -> None:
+        """AC3: GET /get-feedback returns empty list."""
+        resp = v1_client.get("/get-feedback")
+        assert resp.status_code == 200
+        assert resp.json() == []
+
+    def test_set_feedback_returns_ok(self, v1_client: TestClient) -> None:
+        """AC3: POST /set-feedback returns ok."""
+        resp = v1_client.post(
+            "/set-feedback",
+            json={"id": "fb-1", "content": "great", "rating": 5},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "ok"
+
+
+class TestV1TeamConfigsEndpoint:
+    """Test GET /team-configs endpoint."""
+
+    def test_get_team_configs(
+        self, v1_client: TestClient, mock_service: MagicMock,
+    ) -> None:
+        """AC3: GET /team-configs returns team catalog entries."""
+        mock_entry = MagicMock()
+        mock_entry.id = "team-1"
+        mock_entry.model_dump.return_value = {"id": "team-1", "name": "My Team"}
+        v1_client.app.state.services.team_catalog.list.return_value = [mock_entry]  # type: ignore[union-attr]
+        resp = v1_client.get("/team-configs/")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data) == 1
+        assert data[0]["id"] == "team-1"
+        assert data[0]["type"] == "team"
+
+    def test_get_team_configs_empty(
+        self, v1_client: TestClient, mock_service: MagicMock,
+    ) -> None:
+        """GET /team-configs returns empty list when no entries."""
+        v1_client.app.state.services.team_catalog.list.return_value = []  # type: ignore[union-attr]
+        resp = v1_client.get("/team-configs/")
+        assert resp.status_code == 200
+        assert resp.json() == []
+
+
+class TestV1ConfigEndpoints:
+    """Test config CRUD endpoints."""
+
+    def test_get_config_by_type(
+        self, v1_client: TestClient, mock_service: MagicMock,
+    ) -> None:
+        """AC3: GET /config/{type} returns catalog entries."""
+        mock_entry = MagicMock()
+        mock_entry.id = "agent-1"
+        mock_entry.model_dump.return_value = {"id": "agent-1", "name": "Bot"}
+        v1_client.app.state.services.agent_catalog.list.return_value = [mock_entry]  # type: ignore[union-attr]
+        resp = v1_client.get("/config/agent")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data) == 1
+        assert data[0]["id"] == "agent-1"
+        assert data[0]["type"] == "agent"
+
+    def test_get_config_unknown_type(self, v1_client: TestClient) -> None:
+        """GET /config/{type} returns 400 for unknown type."""
+        resp = v1_client.get("/config/unknown")
+        assert resp.status_code == 400
+
+    def test_delete_config_ok(
+        self, v1_client: TestClient, mock_service: MagicMock,
+    ) -> None:
+        """AC3: DELETE /config deletes catalog entry."""
+        mock_entry = MagicMock()
+        v1_client.app.state.services.tool_catalog.get.return_value = mock_entry  # type: ignore[union-attr]
+        resp = v1_client.request(
+            "DELETE", "/config/",
+            json={"id": "tool-1", "type": "tool", "data": {}},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "ok"
+
+    def test_delete_config_not_found(
+        self, v1_client: TestClient, mock_service: MagicMock,
+    ) -> None:
+        """DELETE /config returns 404 for missing entry."""
+        v1_client.app.state.services.tool_catalog.get.return_value = None  # type: ignore[union-attr]
+        resp = v1_client.request(
+            "DELETE", "/config/",
+            json={"id": "missing", "type": "tool", "data": {}},
+        )
+        assert resp.status_code == 404
+
+
+class TestV1AdapterNewRoutes:
+    """Test that new routes are registered by AngularV1Adapter."""
+
+    def test_new_routes_registered(self) -> None:
+        """AngularV1Adapter registers all new route paths."""
+        adapter = AngularV1Adapter()
+        app = FastAPI()
+        adapter.register_routes(app)
+        paths = {r.path for r in app.routes if hasattr(r, "path")}
+        assert "/config/{config_type}" in paths
+        assert "/team-configs/" in paths
+        assert "/get-feedback" in paths
+        assert "/set-feedback" in paths
+        assert "/relaunch/{id}/message/{msg_id}" in paths
+        assert "/state/{id}/of/{agent}" in paths
+        assert "/process/{id}/description" in paths

--- a/tests/test_angular_v1_adapter.py
+++ b/tests/test_angular_v1_adapter.py
@@ -1061,6 +1061,55 @@ class TestV1ConfigEndpoints:
         assert resp.status_code == 404
 
 
+class TestV1PutConfigEndpoint:
+    """Test PUT /config endpoint."""
+
+    def test_put_config_update_existing(
+        self, v1_client: TestClient, mock_service: MagicMock,
+    ) -> None:
+        """AC3: PUT /config updates existing catalog entry."""
+        mock_existing = MagicMock()
+        mock_existing.__class__ = type(mock_existing)
+        mock_existing.__class__.model_validate = MagicMock(return_value=mock_existing)
+        v1_client.app.state.services.agent_catalog.get.return_value = mock_existing  # type: ignore[union-attr]
+        resp = v1_client.put(
+            "/config/",
+            json={"id": "agent-1", "type": "agent", "data": {"name": "Bot"}},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "ok"
+        v1_client.app.state.services.agent_catalog.update.assert_called_once()  # type: ignore[union-attr]
+
+    def test_put_config_create_new(
+        self, v1_client: TestClient, mock_service: MagicMock,
+    ) -> None:
+        """AC3: PUT /config creates new catalog entry when not found."""
+        mock_entry = MagicMock()
+        mock_entry_cls = type(mock_entry)
+        mock_entry_cls.model_validate = MagicMock(return_value=mock_entry)
+        v1_client.app.state.services.agent_catalog.get.return_value = None  # type: ignore[union-attr]
+        v1_client.app.state.services.agent_catalog.list.return_value = [mock_entry]  # type: ignore[union-attr]
+        resp = v1_client.put(
+            "/config/",
+            json={"id": "new-1", "type": "agent", "data": {"name": "New"}},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "ok"
+        v1_client.app.state.services.agent_catalog.create.assert_called_once()  # type: ignore[union-attr]
+
+    def test_put_config_empty_catalog_returns_400(
+        self, v1_client: TestClient, mock_service: MagicMock,
+    ) -> None:
+        """PUT /config returns 400 when catalog is empty and entry type cannot be inferred."""
+        v1_client.app.state.services.agent_catalog.get.return_value = None  # type: ignore[union-attr]
+        v1_client.app.state.services.agent_catalog.list.return_value = []  # type: ignore[union-attr]
+        resp = v1_client.put(
+            "/config/",
+            json={"id": "new-1", "type": "agent", "data": {}},
+        )
+        assert resp.status_code == 400
+
+
 class TestV1AdapterNewRoutes:
     """Test that new routes are registered by AngularV1Adapter."""
 

--- a/tests/test_angular_v1_ws.py
+++ b/tests/test_angular_v1_ws.py
@@ -420,3 +420,69 @@ class TestWrappedEventSerialization:
         event = _make_persisted_event(msg)
         result = wrap_event(event)
         assert result.payload["sender"] == "system"
+
+
+# ---------------------------------------------------------------------------
+# Story 6.8: ContextChangedMessage → type: "llm_context" (AC #4)
+# ---------------------------------------------------------------------------
+
+
+class ContextChangedMessage(Message):
+    """Local placeholder for ContextChangedMessage (forward-compatible)."""
+
+    context: dict[str, object] = {}
+
+
+class TestWrapContextChangedMessage:
+    """Test ContextChangedMessage event wrapping (AC #4)."""
+
+    def test_llm_context_envelope_type(self) -> None:
+        """AC4: ContextChangedMessage produces type: 'llm_context' envelope."""
+        msg = ContextChangedMessage(context={"key": "value"})
+        event = _make_persisted_event(msg)
+        result = wrap_event(event)
+        assert result.payload["type"] == "llm_context"
+
+    def test_llm_context_envelope_fields(self) -> None:
+        """AC4: llm_context envelope has context and timestamp fields."""
+        msg = ContextChangedMessage(context={"agent": "bot", "tokens": 100})
+        event = _make_persisted_event(msg)
+        result = wrap_event(event)
+        payload = result.payload
+        assert payload["type"] == "llm_context"
+        assert payload["context"] == {"agent": "bot", "tokens": 100}
+        assert payload["timestamp"] == _NOW.isoformat()
+
+    def test_llm_context_json_serializable(self) -> None:
+        """WrappedWsEvent from ContextChangedMessage serializes to valid JSON."""
+        msg = ContextChangedMessage(context={"key": "val"})
+        event = _make_persisted_event(msg)
+        result = wrap_event(event)
+        json_str = result.model_dump_json()
+        assert '"type":"llm_context"' in json_str
+
+    def test_existing_envelope_types_unchanged(self) -> None:
+        """AC4: Existing envelope types continue to work unchanged."""
+        user_msg = UserMessage(content="hello")
+        event = _make_persisted_event(user_msg)
+        result = wrap_event(event)
+        assert result.payload["type"] == "message"
+
+        state_msg = StateChangedMessage(state=BaseState())
+        state_msg.sender = _make_sender("@Bot")
+        event2 = _make_persisted_event(state_msg)
+        result2 = wrap_event(event2)
+        assert result2.payload["type"] == "state"
+
+        tool_msg = EventMessage(event={"tool": "test"})
+        event3 = _make_persisted_event(tool_msg)
+        result3 = wrap_event(event3)
+        assert result3.payload["type"] == "tool_update"
+
+    def test_llm_context_empty_context(self) -> None:
+        """ContextChangedMessage with empty context produces valid envelope."""
+        msg = ContextChangedMessage()
+        event = _make_persisted_event(msg)
+        result = wrap_event(event)
+        assert result.payload["type"] == "llm_context"
+        assert result.payload["context"] == {}


### PR DESCRIPTION
## Summary

- Complete V1 response models: added `orchestrator`, `running`, `config_name`, `user_id`, `user_email` to `V1ProcessContext`; added `actor_address`, `address`, `agent_id`, `squad_id`, `user_message` to `V1ActorAddress`
- Implement 10 new REST endpoints: description update, message relaunch, agent state update, config CRUD, team-configs listing, feedback stubs
- Add `llm_context` WebSocket envelope type with string-based `ContextChangedMessage` detection for forward compatibility
- Add new request/response models: `V1DescriptionBody`, `V1StateUpdateBody`, `V1ConfigEntry`, `V1FeedbackEntry`
- 603 tests pass at 95.38% coverage, ruff clean, mypy clean

## Review Fixes Applied

- Fixed double `catalog.list()` call in `put_config` (performance issue)
- Added missing tests for `PUT /config` endpoint (update, create, and empty catalog paths)

Closes #63