### PR TITLE
Integration Tests -- Spec Compliance

### DIFF
--- a/tests/integration/test_catalog.py
+++ b/tests/integration/test_catalog.py
@@ -18,19 +18,19 @@ class TestCatalogIntegration:
     def test_list_teams_returns_seeded_entry(
         self, integration_client: TestClient,
     ) -> None:
-        """AC #3: GET /catalog/teams returns at least the seeded test-team."""
-        resp = integration_client.get("/catalog/teams")
+        """AC #3: GET /catalog/api/teams returns at least the seeded test-team."""
+        resp = integration_client.get("/catalog/api/teams")
         assert resp.status_code == 200
         body = resp.json()
-        assert "teams" in body
-        ids = [t["id"] for t in body["teams"]]
+        assert isinstance(body, list)
+        ids = [t["id"] for t in body]
         assert "test-team" in ids, f"Expected 'test-team' in catalog, got: {ids}"
 
     def test_get_team_details(
         self, integration_client: TestClient,
     ) -> None:
-        """AC #3: GET /catalog/teams/test-team returns full details."""
-        resp = integration_client.get("/catalog/teams/test-team")
+        """AC #3: GET /catalog/api/teams/test-team returns full details."""
+        resp = integration_client.get("/catalog/api/teams/test-team")
         assert resp.status_code == 200
         body = resp.json()
         assert body["id"] == "test-team"
@@ -43,7 +43,7 @@ class TestCatalogIntegration:
     def test_get_nonexistent_team_returns_404(
         self, integration_client: TestClient,
     ) -> None:
-        """AC #3: GET /catalog/teams/nonexistent returns 404."""
-        resp = integration_client.get("/catalog/teams/nonexistent")
+        """AC #3: GET /catalog/api/teams/nonexistent returns 404."""
+        resp = integration_client.get("/catalog/api/teams/nonexistent")
         assert resp.status_code == 404
         assert "not found" in resp.json()["detail"].lower()

--- a/tests/integration/test_cli.py
+++ b/tests/integration/test_cli.py
@@ -386,30 +386,44 @@ class TestCliChat:
             renderer=renderer,
         )
 
-        # Mock stdin: send a message, wait for LLM to respond, then /quit
-        inputs = iter(["Say hello in one word", "/quit"])
+        # Mock stdin: send a message, wait for LLM to respond, then /quit.
+        # After /quit the mock must block (not StopIteration) so the session
+        # exits cleanly through the /quit break rather than an exception.
+        def _mock_read_input(_prompt: str) -> str:
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return "Say hello in one word"
+            if call_count == 2:
+                return "/quit"
+            # After /quit: block until cancelled (session should have exited)
+            import threading
+            threading.Event().wait(timeout=30)
+            return "/quit"
+
+        call_count = 0
 
         async def _run_session() -> None:
             with patch(
                 "akgentic.infra.cli.repl._read_input",
-                side_effect=lambda _prompt: next(inputs),
+                side_effect=_mock_read_input,
             ):
-                await asyncio.wait_for(session.run(), timeout=POLL_TIMEOUT_S)
+                await asyncio.wait_for(session.run(), timeout=30)
 
         try:
             asyncio.run(_run_session())
-        except TimeoutError:
+        except (TimeoutError, asyncio.TimeoutError):
             pass  # session may not exit instantly after /quit
+
+        # Cleanup — MUST run before assertion to avoid actor system hang
+        api_client.close()
+        integration_client.post(f"/teams/{team_id}/stop")
+        time.sleep(0.5)
 
         # Verify at least one WebSocket event was rendered (AC #2)
         assert len(rendered_events) > 0, (
             "ChatSession received no WebSocket events — expected at least one agent message"
         )
-
-        api_client.close()
-        # Cleanup
-        integration_client.post(f"/teams/{team_id}/stop")
-        time.sleep(0.3)
 
     def test_cli_chat_create_shortcut(
         self,

--- a/tests/integration/test_spec_catalog.py
+++ b/tests/integration/test_spec_catalog.py
@@ -1,0 +1,132 @@
+"""Integration tests — catalog CRUD through mounted akgentic-catalog routers.
+
+Validates catalog routers mounted at /catalog from story 6.9.
+"""
+
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+
+pytestmark = pytest.mark.integration
+
+
+# ---------------------------------------------------------------------------
+# AC #6 — Catalog CRUD for teams
+# ---------------------------------------------------------------------------
+
+
+class TestCatalogTeamCrud:
+    """Exercise the mounted akgentic-catalog team router CRUD operations."""
+
+    def test_list_teams(self, integration_client: TestClient) -> None:
+        """AC #6: GET /catalog/api/teams returns seeded entries."""
+        resp = integration_client.get("/catalog/api/teams")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert isinstance(data, list)
+        ids = [t["id"] for t in data]
+        assert "test-team" in ids
+
+    def test_get_team(self, integration_client: TestClient) -> None:
+        """AC #6: GET /catalog/api/teams/{id} returns full entry."""
+        resp = integration_client.get("/catalog/api/teams/test-team")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["id"] == "test-team"
+        assert body["name"] == "Integration Test Team"
+
+    def test_create_update_delete_team(
+        self, integration_client: TestClient,
+    ) -> None:
+        """AC #6: POST/PUT/DELETE /catalog/api/teams for full CRUD."""
+        new_entry = {
+            "id": "crud-test-team",
+            "name": "CRUD Test Team",
+            "entry_point": "human-proxy",
+            "message_types": ["akgentic.agent.AgentMessage"],
+            "members": [{"agent_id": "human-proxy"}],
+            "profiles": [],
+        }
+
+        # Create
+        resp = integration_client.post("/catalog/api/teams/", json=new_entry)
+        assert resp.status_code == 201
+        assert resp.json()["id"] == "crud-test-team"
+
+        # Read back
+        resp = integration_client.get("/catalog/api/teams/crud-test-team")
+        assert resp.status_code == 200
+        assert resp.json()["name"] == "CRUD Test Team"
+
+        # Update
+        new_entry["name"] = "Updated CRUD Team"
+        resp = integration_client.put(
+            "/catalog/api/teams/crud-test-team", json=new_entry,
+        )
+        assert resp.status_code == 200
+        assert resp.json()["name"] == "Updated CRUD Team"
+
+        # Delete
+        resp = integration_client.delete("/catalog/api/teams/crud-test-team")
+        assert resp.status_code == 204
+
+    def test_get_nonexistent_team_404(
+        self, integration_client: TestClient,
+    ) -> None:
+        """AC #6: GET /catalog/api/teams/nonexistent returns 404."""
+        resp = integration_client.get("/catalog/api/teams/nonexistent-xyz")
+        assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# AC #6 — Catalog list+get for agents
+# ---------------------------------------------------------------------------
+
+
+class TestCatalogAgentCrud:
+    """Exercise the mounted akgentic-catalog agent router."""
+
+    def test_list_agents(self, integration_client: TestClient) -> None:
+        """AC #6: GET /catalog/api/agents returns seeded entries."""
+        resp = integration_client.get("/catalog/api/agents")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert isinstance(data, list)
+        ids = [a["id"] for a in data]
+        assert "human-proxy" in ids
+        assert "manager" in ids
+
+    def test_get_agent(self, integration_client: TestClient) -> None:
+        """AC #6: GET /catalog/api/agents/{id} returns entry."""
+        resp = integration_client.get("/catalog/api/agents/manager")
+        assert resp.status_code == 200
+        assert resp.json()["id"] == "manager"
+
+    def test_get_nonexistent_agent_404(
+        self, integration_client: TestClient,
+    ) -> None:
+        """AC #6: GET /catalog/api/agents/nonexistent returns 404."""
+        resp = integration_client.get("/catalog/api/agents/nonexistent-xyz")
+        assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# AC #6 — Catalog list+get for tools and templates
+# ---------------------------------------------------------------------------
+
+
+class TestCatalogToolsTemplates:
+    """Exercise the mounted tool and template catalog routers."""
+
+    def test_list_tools(self, integration_client: TestClient) -> None:
+        """AC #6: GET /catalog/api/tools returns 200 (may be empty)."""
+        resp = integration_client.get("/catalog/api/tools")
+        assert resp.status_code == 200
+        assert isinstance(resp.json(), list)
+
+    def test_list_templates(self, integration_client: TestClient) -> None:
+        """AC #6: GET /catalog/api/templates returns 200 (may be empty)."""
+        resp = integration_client.get("/catalog/api/templates")
+        assert resp.status_code == 200
+        assert isinstance(resp.json(), list)

--- a/tests/integration/test_spec_channels.py
+++ b/tests/integration/test_spec_channels.py
@@ -113,7 +113,7 @@ class TestFormEncodedWebhook:
 class StubParserWithConfig:
     """Parser stub that captures constructor config args."""
 
-    received_config: dict[str, str] = {}
+    received_config: dict[str, str]
 
     def __init__(self, **kwargs: str) -> None:
         StubParserWithConfig.received_config = dict(kwargs)
@@ -133,7 +133,7 @@ class StubParserWithConfig:
 class StubAdapterWithConfig:
     """Adapter stub that captures constructor config args."""
 
-    received_config: dict[str, str] = {}
+    received_config: dict[str, str]
 
     def __init__(self, **kwargs: str) -> None:
         StubAdapterWithConfig.received_config = dict(kwargs)

--- a/tests/integration/test_spec_channels.py
+++ b/tests/integration/test_spec_channels.py
@@ -1,0 +1,183 @@
+"""Integration tests — channel spec compliance: multi-adapter, form-encoded, config passthrough.
+
+Validates ADR-002 remediation for story 6.1 channel subsystem fixes.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from akgentic.core.actor_address_impl import ActorAddressProxy
+from akgentic.core.messages import SentMessage
+from akgentic.core.messages.message import UserMessage
+from fastapi.testclient import TestClient
+
+from akgentic.infra.adapters.channel_dispatcher import InteractionChannelDispatcher
+from akgentic.infra.adapters.channel_parser_registry import (
+    ChannelConfig,
+    ChannelParserRegistry,
+)
+
+from .test_channels import StubChannelAdapter
+
+pytestmark = pytest.mark.integration
+
+
+# ---------------------------------------------------------------------------
+# AC #3 — Multi-adapter dispatch
+# ---------------------------------------------------------------------------
+
+
+class TestMultiAdapterDispatch:
+    """Verify dispatcher delivers to ALL matching adapters (no break short-circuit)."""
+
+    def test_two_adapters_both_receive_message(self) -> None:
+        """AC #3: Register 2 StubChannelAdapters, dispatch, verify both received."""
+        adapter_a = StubChannelAdapter()
+        adapter_b = StubChannelAdapter()
+        dispatcher = InteractionChannelDispatcher(
+            team_id=uuid.uuid4(),
+            adapters=[adapter_a, adapter_b],
+        )
+
+        # Build a SentMessage to dispatch
+        addr_dict = {
+            "__actor_address__": True,
+            "__actor_type__": "test",
+            "agent_id": str(uuid.uuid4()),
+            "name": "@Test",
+            "role": "Test",
+            "team_id": str(uuid.uuid4()),
+            "squad_id": str(uuid.uuid4()),
+            "user_message": False,
+        }
+        proxy = ActorAddressProxy(addr_dict)
+        inner = UserMessage(content="test message")
+        sent = SentMessage(message=inner, sender=proxy, recipient=proxy)
+
+        dispatcher.on_message(sent)
+
+        assert len(adapter_a.delivered) == 1, "Adapter A should receive the message"
+        assert len(adapter_b.delivered) == 1, "Adapter B should receive the message"
+        assert adapter_a.delivered[0] is sent
+        assert adapter_b.delivered[0] is sent
+
+
+# ---------------------------------------------------------------------------
+# AC #3 — Form-encoded webhook payloads
+# ---------------------------------------------------------------------------
+
+
+class TestFormEncodedWebhook:
+    """Verify form-encoded webhook payloads are parsed correctly."""
+
+    def test_form_encoded_webhook_returns_204(
+        self, channel_client: TestClient,
+    ) -> None:
+        """AC #3: POST form-encoded to /webhook/{channel} returns 204.
+
+        Uses an existing team via reply flow to avoid creating a new team
+        with in-flight LLM calls that would block teardown.
+        """
+        import time
+
+        # Create a team first so we can use reply flow (no LLM initiation)
+        create_resp = channel_client.post(
+            "/teams/", json={"catalog_entry_id": "test-team"},
+        )
+        assert create_resp.status_code == 201
+        team_id = create_resp.json()["team_id"]
+
+        resp = channel_client.post(
+            "/webhook/test-channel",
+            data={
+                "content": "form test message",
+                "channel_user_id": "form-user-1",
+                "team_id": team_id,
+            },
+            headers={"content-type": "application/x-www-form-urlencoded"},
+        )
+        assert resp.status_code == 204
+
+        # Stop team to allow clean teardown
+        channel_client.post(f"/teams/{team_id}/stop")
+        time.sleep(0.5)
+
+
+# ---------------------------------------------------------------------------
+# AC #3 — ChannelConfig passthrough
+# ---------------------------------------------------------------------------
+
+
+class StubParserWithConfig:
+    """Parser stub that captures constructor config args."""
+
+    received_config: dict[str, str] = {}
+
+    def __init__(self, **kwargs: str) -> None:
+        StubParserWithConfig.received_config = dict(kwargs)
+
+    @property
+    def channel_name(self) -> str:
+        return "config-test-channel"
+
+    @property
+    def default_catalog_entry(self) -> str:
+        return "test-team"
+
+    async def parse(self, payload: dict[str, object]) -> None:
+        pass  # pragma: no cover
+
+
+class StubAdapterWithConfig:
+    """Adapter stub that captures constructor config args."""
+
+    received_config: dict[str, str] = {}
+
+    def __init__(self, **kwargs: str) -> None:
+        StubAdapterWithConfig.received_config = dict(kwargs)
+
+    def matches(self, msg: SentMessage) -> bool:
+        return True  # pragma: no cover
+
+    def deliver(self, msg: SentMessage) -> None:
+        pass  # pragma: no cover
+
+    def on_stop(self, team_id: uuid.UUID) -> None:
+        pass  # pragma: no cover
+
+
+class TestChannelConfigPassthrough:
+    """Verify ChannelConfig.config values reach adapter/parser constructors."""
+
+    def test_config_dict_reaches_constructors(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """AC #3: Configure channel with config dict, verify it reaches constructors."""
+        # Monkeypatch import_class to return our stubs
+        monkeypatch.setattr(
+            "akgentic.infra.adapters.channel_parser_registry.import_class",
+            lambda fqcn: (
+                StubParserWithConfig
+                if "Parser" in fqcn
+                else StubAdapterWithConfig
+            ),
+        )
+
+        config = {
+            "test-chan": ChannelConfig(
+                parser_fqcn="fake.module.Parser",
+                adapter_fqcn="fake.module.Adapter",
+                config={"key": "value", "api_token": "secret123"},
+            )
+        }
+
+        ChannelParserRegistry(channels_config=config)
+
+        assert StubParserWithConfig.received_config == {
+            "key": "value",
+            "api_token": "secret123",
+        }
+        assert StubAdapterWithConfig.received_config == {
+            "key": "value",
+            "api_token": "secret123",
+        }

--- a/tests/integration/test_spec_compliance.py
+++ b/tests/integration/test_spec_compliance.py
@@ -1,0 +1,188 @@
+"""Integration tests — spec compliance: app factory, RuntimeCache lifecycle, WS TeamHandle.
+
+Validates ADR-002 remediation for stories 6.1--6.10.
+"""
+
+from __future__ import annotations
+
+import time
+import uuid
+from pathlib import Path
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from akgentic.infra.server.app import create_app
+from akgentic.infra.server.settings import ServerSettings
+
+from ._helpers import create_team
+
+pytestmark = pytest.mark.integration
+
+
+# ---------------------------------------------------------------------------
+# AC #1 — 2-line fixture pattern
+# ---------------------------------------------------------------------------
+
+
+class TestAppFactory:
+    """Verify the 2-line fixture pattern: settings -> create_app -> TestClient."""
+
+    def test_app_starts_and_teams_returns_200(
+        self, integration_client: TestClient,
+    ) -> None:
+        """AC #1: App created via create_app(settings) serves /teams/ correctly."""
+        resp = integration_client.get("/teams/")
+        assert resp.status_code == 200
+
+    def test_two_line_fixture_pattern(self, tmp_path: Path) -> None:
+        """AC #1: Demonstrate the 2-line fixture pattern works end-to-end."""
+        from tests.integration.conftest import _seed_integration_catalog
+
+        settings = ServerSettings(workspaces_root=tmp_path / "workspaces")
+        _seed_integration_catalog(settings.workspaces_root / "catalog")
+        app = create_app(settings)
+        client = TestClient(app)
+
+        resp = client.get("/teams/")
+        assert resp.status_code == 200
+        assert "teams" in resp.json()
+
+        app.state.services.actor_system.shutdown()
+
+    def test_team_create_get_delete_via_test_client(
+        self, integration_client: TestClient, integration_app: FastAPI,
+    ) -> None:
+        """AC #1: Team create/get/delete work through TestClient."""
+        team_id = create_team(integration_client)
+
+        # GET returns the team
+        resp = integration_client.get(f"/teams/{team_id}")
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "running"
+
+        # Stop then delete
+        integration_client.post(f"/teams/{team_id}/stop")
+        time.sleep(0.5)
+
+        resp = integration_client.delete(f"/teams/{team_id}")
+        assert resp.status_code == 204
+
+        # GET after delete returns 404 or deleted status
+        resp = integration_client.get(f"/teams/{team_id}")
+        if resp.status_code == 200:
+            assert resp.json()["status"] == "deleted"
+        else:
+            assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# AC #2 — RuntimeCache/TeamHandle lifecycle
+# ---------------------------------------------------------------------------
+
+
+class TestRuntimeCacheLifecycle:
+    """Verify RuntimeCache store/get/remove through team lifecycle operations."""
+
+    def test_cache_lifecycle_create_stop_restore_delete(
+        self, integration_client: TestClient, integration_app: FastAPI,
+    ) -> None:
+        """AC #2: Full RuntimeCache lifecycle — create, stop, restore, delete."""
+        cache = integration_app.state.services.runtime_cache
+
+        # 1. Create team -> cache.get(team_id) is not None
+        team_id_str = create_team(integration_client)
+        team_id = uuid.UUID(team_id_str)
+        assert cache.get(team_id) is not None, (
+            "RuntimeCache should hold handle after create"
+        )
+
+        # 2. Stop team -> cache.get(team_id) returns None
+        resp = integration_client.post(f"/teams/{team_id_str}/stop")
+        assert resp.status_code == 204
+        assert cache.get(team_id) is None, (
+            "RuntimeCache should be empty after stop"
+        )
+
+        # 3. Verify events still accessible (event store preserved)
+        resp = integration_client.get(f"/teams/{team_id_str}/events")
+        assert resp.status_code == 200
+        events = resp.json()["events"]
+        assert len(events) >= 1, "Events should be preserved after stop"
+
+        # 4. Restore team -> cache.get(team_id) is not None again
+        resp = integration_client.post(f"/teams/{team_id_str}/restore")
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "running"
+        assert cache.get(team_id) is not None, (
+            "RuntimeCache should hold handle after restore"
+        )
+
+        # 5. Delete team -> team gone
+        resp = integration_client.post(f"/teams/{team_id_str}/stop")
+        assert resp.status_code == 204
+        resp = integration_client.delete(f"/teams/{team_id_str}")
+        assert resp.status_code == 204
+        assert cache.get(team_id) is None, (
+            "RuntimeCache should be empty after delete"
+        )
+
+
+# ---------------------------------------------------------------------------
+# AC #4 — WebSocket via TeamHandle
+# ---------------------------------------------------------------------------
+
+
+class TestWebSocketTeamHandle:
+    """Verify WebSocket events flow through TeamHandle.subscribe/unsubscribe."""
+
+    def test_ws_events_arrive_via_team_handle(
+        self, integration_client: TestClient,
+    ) -> None:
+        """AC #4: Create team, open WS, verify events arrive via TeamHandle."""
+        team_id = create_team(integration_client)
+
+        with integration_client.websocket_connect(f"/ws/{team_id}") as ws:
+            time.sleep(0.3)
+            integration_client.post(
+                f"/teams/{team_id}/message",
+                json={"content": "Say hello"},
+            )
+
+            data = ws.receive_json(mode="text")
+            assert isinstance(data, dict)
+            assert "__model__" in data
+            model = str(data.get("__model__", ""))
+            assert "SentMessage" in model or "ReceivedMessage" in model, (
+                f"Expected SentMessage or ReceivedMessage, got: {model}"
+            )
+
+        # Stop team to avoid LLM-in-flight hang
+        integration_client.post(f"/teams/{team_id}/stop")
+        time.sleep(0.5)
+
+    def test_ws_send_message_via_rest_receive_via_ws(
+        self, integration_client: TestClient,
+    ) -> None:
+        """AC #4: Send message via REST, verify WS receives events, close cleanly."""
+        team_id = create_team(integration_client)
+
+        with integration_client.websocket_connect(f"/ws/{team_id}") as ws:
+            time.sleep(0.3)
+            integration_client.post(
+                f"/teams/{team_id}/message",
+                json={"content": "Say yes"},
+            )
+
+            data = ws.receive_json(mode="text")
+            assert isinstance(data, dict)
+            assert "__model__" in data
+
+        # WS closed — verify no errors accessing team
+        resp = integration_client.get(f"/teams/{team_id}")
+        assert resp.status_code == 200
+
+        # Stop team
+        integration_client.post(f"/teams/{team_id}/stop")
+        time.sleep(0.5)

--- a/tests/integration/test_spec_frontend.py
+++ b/tests/integration/test_spec_frontend.py
@@ -122,6 +122,35 @@ class TestV1Story68Endpoints:
         assert resp.status_code == 200
         assert resp.json()["status"] == "ok"
 
+    def test_put_config_create_and_update(self, v1_adapter_client: TestClient) -> None:
+        """AC #5: PUT /config creates a new entry and updates an existing one."""
+        # Get an existing entry to know the data shape
+        resp = v1_adapter_client.get("/config/team")
+        assert resp.status_code == 200
+        existing = resp.json()[0]
+
+        # Create a new entry via PUT
+        new_entry = {
+            "id": "v1-put-test",
+            "type": "team",
+            "data": {**existing["data"], "id": "v1-put-test", "name": "V1 PUT Test"},
+        }
+        resp = v1_adapter_client.put("/config/", json=new_entry)
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "ok"
+
+        # Update the entry via PUT
+        new_entry["data"]["name"] = "V1 PUT Updated"
+        resp = v1_adapter_client.put("/config/", json=new_entry)
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "ok"
+
+        # Clean up
+        resp = v1_adapter_client.request(
+            "DELETE", "/config/", json=new_entry,
+        )
+        assert resp.status_code == 200
+
     def test_delete_config_not_found(self, v1_adapter_client: TestClient) -> None:
         """AC #5: DELETE /config for nonexistent entry returns 404."""
         resp = v1_adapter_client.request(
@@ -146,22 +175,9 @@ class TestLlmContextEnvelope:
             _classify_envelope_type,
         )
 
-        # Create a mock ContextChangedMessage-like object
-        class FakeContextChangedMessage:
-            __name__ = "ContextChangedMessage"
-
-            def __init__(self) -> None:
-                self.id = "test-id"
-                self.sender = None
-
-        # The function checks type(event).__name__ == "ContextChangedMessage"
-        fake = FakeContextChangedMessage()
-        type(fake).__name__ = "ContextChangedMessage"  # type: ignore[attr-defined]
-        # This won't work because __name__ is read-only on classes.
-        # Instead, rename the class itself.
-
+        # _classify_envelope_type checks type(event).__name__ == "ContextChangedMessage"
         class ContextChangedMessage:  # noqa: N801
-            """Fake message that has the right class name."""
+            """Fake message whose class name matches the real ContextChangedMessage."""
 
             def __init__(self) -> None:
                 self.id = "test-id"

--- a/tests/integration/test_spec_frontend.py
+++ b/tests/integration/test_spec_frontend.py
@@ -1,0 +1,183 @@
+"""Integration tests — V1 frontend adapter spec compliance for story 6.8 endpoints.
+
+Validates all V1 endpoints added in story 6.8 and the llm_context WS envelope type.
+"""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+from fastapi.testclient import TestClient
+
+pytestmark = pytest.mark.integration
+
+CATALOG_ENTRY_ID = "test-team"
+
+
+def _create_v1_team(client: TestClient) -> str:
+    """POST /process/{type} (V1) and return the team_id."""
+    resp = client.post(f"/process/{CATALOG_ENTRY_ID}")
+    assert resp.status_code == 200
+    data = resp.json()
+    return data["id"]
+
+
+# ---------------------------------------------------------------------------
+# AC #5 — V1 story-6.8 endpoint translations
+# ---------------------------------------------------------------------------
+
+
+class TestV1Story68Endpoints:
+    """Integration tests for V1 endpoints added in story 6.8."""
+
+    def test_patch_description(self, v1_adapter_client: TestClient) -> None:
+        """AC #5: PATCH /process/{id}/description returns ok."""
+        team_id = _create_v1_team(v1_adapter_client)
+
+        resp = v1_adapter_client.patch(
+            f"/process/{team_id}/description",
+            json={"description": "Updated description"},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "ok"
+
+        v1_adapter_client.delete(f"/process/{team_id}/archive")
+        time.sleep(0.5)
+
+    def test_relaunch_message_not_found(self, v1_adapter_client: TestClient) -> None:
+        """AC #5: POST /relaunch/{id}/message/{msgId} returns 404 for unknown msg."""
+        team_id = _create_v1_team(v1_adapter_client)
+
+        resp = v1_adapter_client.post(
+            f"/relaunch/{team_id}/message/00000000-0000-0000-0000-000000000000",
+        )
+        assert resp.status_code == 404
+        assert "not found" in resp.json()["detail"].lower()
+
+        v1_adapter_client.delete(f"/process/{team_id}/archive")
+        time.sleep(0.5)
+
+    def test_patch_state_not_running(self, v1_adapter_client: TestClient) -> None:
+        """AC #5: PATCH /state/{id}/of/{agent} returns 404 for stopped team."""
+        team_id = _create_v1_team(v1_adapter_client)
+
+        # Stop the team first
+        v1_adapter_client.delete(f"/process/{team_id}/archive")
+        time.sleep(0.5)
+
+        resp = v1_adapter_client.patch(
+            f"/state/{team_id}/of/@Manager",
+            json={"content": "state update"},
+        )
+        assert resp.status_code == 404
+
+    def test_get_config_team(self, v1_adapter_client: TestClient) -> None:
+        """AC #5: GET /config/team returns catalog entries."""
+        resp = v1_adapter_client.get("/config/team")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert isinstance(data, list)
+        assert len(data) >= 1
+        entry = data[0]
+        assert "id" in entry
+        assert "type" in entry
+        assert entry["type"] == "team"
+        assert "data" in entry
+
+    def test_get_config_agent(self, v1_adapter_client: TestClient) -> None:
+        """AC #5: GET /config/agent returns catalog entries."""
+        resp = v1_adapter_client.get("/config/agent")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert isinstance(data, list)
+        assert len(data) >= 1
+
+    def test_get_config_unknown_type(self, v1_adapter_client: TestClient) -> None:
+        """AC #5: GET /config/unknown returns 400."""
+        resp = v1_adapter_client.get("/config/unknown")
+        assert resp.status_code == 400
+
+    def test_get_team_configs(self, v1_adapter_client: TestClient) -> None:
+        """AC #5: GET /team-configs returns team catalog entries."""
+        resp = v1_adapter_client.get("/team-configs/")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert isinstance(data, list)
+        assert len(data) >= 1
+        assert data[0]["type"] == "team"
+
+    def test_get_feedback_empty(self, v1_adapter_client: TestClient) -> None:
+        """AC #5: GET /get-feedback returns empty list (stub)."""
+        resp = v1_adapter_client.get("/get-feedback")
+        assert resp.status_code == 200
+        assert resp.json() == []
+
+    def test_set_feedback_ok(self, v1_adapter_client: TestClient) -> None:
+        """AC #5: POST /set-feedback returns ok (stub)."""
+        resp = v1_adapter_client.post(
+            "/set-feedback",
+            json={"id": "fb-1", "content": "Great!", "rating": 5},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "ok"
+
+    def test_delete_config_not_found(self, v1_adapter_client: TestClient) -> None:
+        """AC #5: DELETE /config for nonexistent entry returns 404."""
+        resp = v1_adapter_client.request(
+            "DELETE",
+            "/config/",
+            json={"id": "nonexistent", "type": "team", "data": {}},
+        )
+        assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# AC #5 — llm_context WS envelope type
+# ---------------------------------------------------------------------------
+
+
+class TestLlmContextEnvelope:
+    """Verify the V1 WS handler emits llm_context envelope type."""
+
+    def test_classify_envelope_type_for_context_changed(self) -> None:
+        """AC #5: _classify_envelope_type returns 'llm_context' for ContextChangedMessage."""
+        from akgentic.infra.server.routes.frontend_adapter.angular_v1.ws import (
+            _classify_envelope_type,
+        )
+
+        # Create a mock ContextChangedMessage-like object
+        class FakeContextChangedMessage:
+            __name__ = "ContextChangedMessage"
+
+            def __init__(self) -> None:
+                self.id = "test-id"
+                self.sender = None
+
+        # The function checks type(event).__name__ == "ContextChangedMessage"
+        fake = FakeContextChangedMessage()
+        type(fake).__name__ = "ContextChangedMessage"  # type: ignore[attr-defined]
+        # This won't work because __name__ is read-only on classes.
+        # Instead, rename the class itself.
+
+        class ContextChangedMessage:  # noqa: N801
+            """Fake message that has the right class name."""
+
+            def __init__(self) -> None:
+                self.id = "test-id"
+                self.sender = None
+
+        result = _classify_envelope_type(ContextChangedMessage())  # type: ignore[arg-type]
+        assert result == "llm_context"
+
+    def test_classify_envelope_returns_message_for_user_message(self) -> None:
+        """AC #5: _classify_envelope_type returns 'message' for UserMessage."""
+        from akgentic.core.messages.message import UserMessage
+
+        from akgentic.infra.server.routes.frontend_adapter.angular_v1.ws import (
+            _classify_envelope_type,
+        )
+
+        msg = UserMessage(content="hello")
+        result = _classify_envelope_type(msg)
+        assert result == "message"


### PR DESCRIPTION
## Summary

- Add spec compliance integration tests covering all ADR-002 remediation changes from stories 6.1-6.10
- 4 new test files: test_spec_compliance.py, test_spec_channels.py, test_spec_frontend.py, test_spec_catalog.py
- Fix pre-existing test_catalog.py routes (broken by story 6.9 router mount) and test_cli.py teardown hang
- Code review fixes: add missing PUT /config test, remove dead code, fix mutable class defaults

Closes #69