### PR TITLE
Define WorkerHandle and Expand PlacementStrategy Protocols

### DIFF
--- a/src/akgentic/infra/__init__.py
+++ b/src/akgentic/infra/__init__.py
@@ -13,6 +13,7 @@ from akgentic.infra.adapters import (
     LocalRuntimeCache,
     LocalServiceRegistry,
     LocalTeamHandle,
+    LocalWorkerHandle,
     NoAuth,
     TelemetrySubscriber,
     WebSocketEventSubscriber,
@@ -31,6 +32,7 @@ from akgentic.infra.protocols import (
     RecoveryPolicy,
     RuntimeCache,
     TeamHandle,
+    WorkerHandle,
 )
 from akgentic.infra.server.app import create_app
 from akgentic.infra.server.deps import CommunityServices, TierServices
@@ -66,6 +68,7 @@ __all__ = [
     "RecoveryPolicy",
     "RuntimeCache",
     "TeamHandle",
+    "WorkerHandle",
     # Adapters
     "ChannelConfig",
     "ChannelParserRegistry",
@@ -75,6 +78,7 @@ __all__ = [
     "LocalRuntimeCache",
     "LocalServiceRegistry",
     "LocalTeamHandle",
+    "LocalWorkerHandle",
     "NoAuth",
     "TelemetrySubscriber",
     "WebSocketEventSubscriber",

--- a/src/akgentic/infra/adapters/__init__.py
+++ b/src/akgentic/infra/adapters/__init__.py
@@ -12,6 +12,7 @@ from akgentic.infra.adapters.local_placement import LocalPlacement
 from akgentic.infra.adapters.local_runtime_cache import LocalRuntimeCache
 from akgentic.infra.adapters.local_service_registry import LocalServiceRegistry
 from akgentic.infra.adapters.local_team_handle import LocalTeamHandle
+from akgentic.infra.adapters.local_worker_handle import LocalWorkerHandle
 from akgentic.infra.adapters.no_auth import NoAuth
 from akgentic.infra.adapters.telemetry_subscriber import TelemetrySubscriber
 from akgentic.infra.adapters.websocket_subscriber import WebSocketEventSubscriber
@@ -26,6 +27,7 @@ __all__ = [
     "LocalRuntimeCache",
     "LocalServiceRegistry",
     "LocalTeamHandle",
+    "LocalWorkerHandle",
     "NoAuth",
     "TelemetrySubscriber",
     "WebSocketEventSubscriber",

--- a/src/akgentic/infra/adapters/local_placement.py
+++ b/src/akgentic/infra/adapters/local_placement.py
@@ -1,32 +1,50 @@
-"""LocalPlacement — community-tier placement that keeps all teams in the current process."""
+"""LocalPlacement — community-tier placement that creates teams in the current process."""
 
 from __future__ import annotations
 
 import uuid
+from typing import TYPE_CHECKING
+
+from akgentic.infra.adapters.local_team_handle import LocalTeamHandle
+from akgentic.team.manager import TeamManager
+from akgentic.team.ports import ServiceRegistry
+
+if TYPE_CHECKING:
+    from akgentic.infra.protocols.team_handle import TeamHandle
+    from akgentic.team.models import TeamCard
 
 
 class LocalPlacement:
-    """Places all teams in the current process instance.
+    """Creates teams in the current process instance.
 
     Satisfies the PlacementStrategy protocol via structural subtyping.
-    Always returns the same instance_id (the local process).
+    Delegates team creation to ``TeamManager`` and wraps the result
+    in a ``LocalTeamHandle``.
     """
 
-    def __init__(self) -> None:
+    def __init__(
+        self,
+        team_manager: TeamManager,
+        service_registry: ServiceRegistry,
+    ) -> None:
         self._instance_id = uuid.uuid4()
+        self._team_manager = team_manager
+        self._service_registry = service_registry
 
     @property
     def instance_id(self) -> uuid.UUID:
         """The worker instance ID representing this process."""
         return self._instance_id
 
-    def select_worker(self, team_id: uuid.UUID) -> uuid.UUID:
-        """Select the local process for team placement.
+    def create_team(self, team_card: TeamCard, user_id: str) -> TeamHandle:
+        """Create a team in the local process and return a handle.
 
         Args:
-            team_id: ID of the team being placed (unused — always local)
+            team_card: Team configuration card.
+            user_id: ID of the user creating the team.
 
         Returns:
-            The local worker instance ID
+            A LocalTeamHandle for interacting with the newly created team.
         """
-        return self._instance_id
+        runtime = self._team_manager.create_team(team_card, user_id)
+        return LocalTeamHandle(runtime)

--- a/src/akgentic/infra/adapters/local_worker_handle.py
+++ b/src/akgentic/infra/adapters/local_worker_handle.py
@@ -1,0 +1,47 @@
+"""LocalWorkerHandle — community-tier WorkerHandle wrapping TeamManager."""
+
+from __future__ import annotations
+
+import uuid
+from typing import TYPE_CHECKING
+
+from akgentic.infra.adapters.local_team_handle import LocalTeamHandle
+from akgentic.team.manager import TeamManager
+from akgentic.team.ports import ServiceRegistry
+
+if TYPE_CHECKING:
+    from akgentic.infra.protocols.team_handle import TeamHandle
+    from akgentic.team.models import Process
+
+
+class LocalWorkerHandle:
+    """Community-tier adapter delegating WorkerHandle methods to TeamManager.
+
+    Wraps an in-process ``TeamManager`` and ``ServiceRegistry`` to provide
+    tier-agnostic worker lifecycle operations.
+    """
+
+    def __init__(
+        self,
+        team_manager: TeamManager,
+        service_registry: ServiceRegistry,
+    ) -> None:
+        self._team_manager = team_manager
+        self._service_registry = service_registry
+
+    def stop_team(self, team_id: uuid.UUID) -> None:
+        """Stop a running team by delegating to TeamManager."""
+        self._team_manager.stop_team(team_id)
+
+    def delete_team(self, team_id: uuid.UUID) -> None:
+        """Delete a team by delegating to TeamManager."""
+        self._team_manager.delete_team(team_id)
+
+    def resume_team(self, team_id: uuid.UUID) -> TeamHandle:
+        """Resume a stopped team and return a LocalTeamHandle."""
+        runtime = self._team_manager.resume_team(team_id)
+        return LocalTeamHandle(runtime)
+
+    def get_team(self, team_id: uuid.UUID) -> Process | None:
+        """Get team metadata by delegating to TeamManager."""
+        return self._team_manager.get_team(team_id)

--- a/src/akgentic/infra/protocols/__init__.py
+++ b/src/akgentic/infra/protocols/__init__.py
@@ -15,6 +15,7 @@ from akgentic.infra.protocols.health import HealthMonitor
 from akgentic.infra.protocols.placement import PlacementStrategy
 from akgentic.infra.protocols.recovery import RecoveryPolicy
 from akgentic.infra.protocols.team_handle import RuntimeCache, TeamHandle
+from akgentic.infra.protocols.worker_handle import WorkerHandle
 
 __all__ = [
     "AuthStrategy",
@@ -29,4 +30,5 @@ __all__ = [
     "RecoveryPolicy",
     "RuntimeCache",
     "TeamHandle",
+    "WorkerHandle",
 ]

--- a/src/akgentic/infra/protocols/placement.py
+++ b/src/akgentic/infra/protocols/placement.py
@@ -1,26 +1,33 @@
-"""PlacementStrategy protocol — selects worker instances for team placement."""
+"""PlacementStrategy protocol — creates teams on worker instances."""
 
 from __future__ import annotations
 
-import uuid
-from typing import Protocol, runtime_checkable
+from typing import TYPE_CHECKING, Protocol, runtime_checkable
+
+if TYPE_CHECKING:
+    from akgentic.infra.protocols.team_handle import TeamHandle
+    from akgentic.team.models import TeamCard
 
 
 @runtime_checkable
 class PlacementStrategy(Protocol):
-    """Selects a worker instance to host a new team.
+    """Creates a team on a selected worker instance and returns a handle.
+
+    Encapsulates worker selection and team creation so that ``TeamService``
+    never needs to know about ``TeamManager`` or actor internals.
 
     Implementations: LocalPlacement (community), LeastTeamsPlacement (department),
     LabelMatchPlacement / WeightedPlacement / ZoneAwarePlacement (enterprise).
     """
 
-    def select_worker(self, team_id: uuid.UUID) -> uuid.UUID:
-        """Select a worker instance for team placement.
+    def create_team(self, team_card: TeamCard, user_id: str) -> TeamHandle:
+        """Create a team on a worker instance and return a handle.
 
         Args:
-            team_id: ID of the team being placed
+            team_card: Team configuration card.
+            user_id: ID of the user creating the team.
 
         Returns:
-            Worker instance ID where the team should be created
+            A TeamHandle for interacting with the newly created team.
         """
         ...

--- a/src/akgentic/infra/protocols/worker_handle.py
+++ b/src/akgentic/infra/protocols/worker_handle.py
@@ -1,0 +1,59 @@
+"""WorkerHandle protocol — tier-agnostic worker lifecycle operations."""
+
+from __future__ import annotations
+
+import uuid
+from typing import TYPE_CHECKING, Protocol, runtime_checkable
+
+if TYPE_CHECKING:
+    from akgentic.infra.protocols.team_handle import TeamHandle
+    from akgentic.team.models import Process
+
+
+@runtime_checkable
+class WorkerHandle(Protocol):
+    """Tier-agnostic handle for worker-level team lifecycle operations.
+
+    Abstracts stop/delete/resume/get operations so that ``TeamService``
+    can manage team lifecycle without knowing the underlying tier implementation.
+
+    Implementations: LocalWorkerHandle (community), RemoteWorkerHandle (enterprise).
+    """
+
+    def stop_team(self, team_id: uuid.UUID) -> None:
+        """Stop a running team.
+
+        Args:
+            team_id: ID of the team to stop.
+        """
+        ...
+
+    def delete_team(self, team_id: uuid.UUID) -> None:
+        """Delete a team and its resources.
+
+        Args:
+            team_id: ID of the team to delete.
+        """
+        ...
+
+    def resume_team(self, team_id: uuid.UUID) -> TeamHandle:
+        """Resume a stopped team.
+
+        Args:
+            team_id: ID of the team to resume.
+
+        Returns:
+            A TeamHandle for interacting with the resumed team.
+        """
+        ...
+
+    def get_team(self, team_id: uuid.UUID) -> Process | None:
+        """Get team metadata.
+
+        Args:
+            team_id: ID of the team to look up.
+
+        Returns:
+            The Process metadata, or None if not found.
+        """
+        ...

--- a/src/akgentic/infra/server/deps.py
+++ b/src/akgentic/infra/server/deps.py
@@ -16,6 +16,7 @@ from akgentic.infra.protocols.auth import AuthStrategy
 from akgentic.infra.protocols.channels import ChannelRegistry, InteractionChannelIngestion
 from akgentic.infra.protocols.placement import PlacementStrategy
 from akgentic.infra.protocols.team_handle import RuntimeCache
+from akgentic.infra.protocols.worker_handle import WorkerHandle
 from akgentic.team.manager import TeamManager
 from akgentic.team.ports import ServiceRegistry
 from akgentic.team.repositories.yaml import YamlEventStore
@@ -34,18 +35,10 @@ class TierServices(BaseModel):
 
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
-    placement: list[PlacementStrategy] = Field(
-        description="Strategies for placing teams on workers"
-    )
-    service_registry: ServiceRegistry = Field(
-        description="Service discovery registry for worker instances"
-    )
-    auth: AuthStrategy = Field(
-        description="Authentication strategy for incoming requests"
-    )
-    event_store: YamlEventStore = Field(
-        description="Persistence backend for team event sourcing"
-    )
+    placement: PlacementStrategy = Field(description="Strategy for placing teams on workers")
+    worker_handle: WorkerHandle = Field(description="Worker-level team lifecycle operations")
+    auth: AuthStrategy = Field(description="Authentication strategy for incoming requests")
+    event_store: YamlEventStore = Field(description="Persistence backend for team event sourcing")
     runtime_cache: RuntimeCache = Field(
         description="Cache mapping team IDs to live TeamHandle instances"
     )
@@ -64,21 +57,14 @@ class CommunityServices(TierServices):
     catalogs for single-process deployment.
     """
 
-    actor_system: ActorSystem = Field(
-        description="Actor system for managing agent lifecycle"
+    service_registry: ServiceRegistry = Field(
+        description="Service discovery registry (community-specific, used by wiring)"
     )
-    team_manager: TeamManager = Field(
-        description="Team lifecycle manager (embedded, in-process)"
-    )
-    team_catalog: TeamCatalog = Field(
-        description="Catalog service for team entry resolution"
-    )
-    agent_catalog: AgentCatalog = Field(
-        description="Catalog service for agent entry resolution"
-    )
-    tool_catalog: ToolCatalog = Field(
-        description="Catalog service for tool entry resolution"
-    )
+    actor_system: ActorSystem = Field(description="Actor system for managing agent lifecycle")
+    team_manager: TeamManager = Field(description="Team lifecycle manager (embedded, in-process)")
+    team_catalog: TeamCatalog = Field(description="Catalog service for team entry resolution")
+    agent_catalog: AgentCatalog = Field(description="Catalog service for agent entry resolution")
+    tool_catalog: ToolCatalog = Field(description="Catalog service for tool entry resolution")
     template_catalog: TemplateCatalog = Field(
         description="Catalog service for template entry resolution"
     )

--- a/src/akgentic/infra/wiring.py
+++ b/src/akgentic/infra/wiring.py
@@ -20,6 +20,7 @@ from akgentic.infra.adapters.local_ingestion import LocalIngestion
 from akgentic.infra.adapters.local_placement import LocalPlacement
 from akgentic.infra.adapters.local_runtime_cache import LocalRuntimeCache
 from akgentic.infra.adapters.local_service_registry import LocalServiceRegistry
+from akgentic.infra.adapters.local_worker_handle import LocalWorkerHandle
 from akgentic.infra.adapters.no_auth import NoAuth
 from akgentic.infra.adapters.telemetry_subscriber import TelemetrySubscriber
 from akgentic.infra.adapters.yaml_channel_registry import YamlChannelRegistry
@@ -46,8 +47,13 @@ def wire_community(settings: ServerSettings) -> CommunityServices:
     actor_system, team_manager = _build_actor_layer(event_store, service_registry)
     catalogs = _build_catalogs(settings)
 
+    local_placement = LocalPlacement(team_manager, service_registry)
+    local_worker_handle = LocalWorkerHandle(team_manager, service_registry)
+    service_registry.register_instance(local_placement.instance_id)
+
     return CommunityServices(
-        placement=[LocalPlacement()],
+        placement=local_placement,
+        worker_handle=local_worker_handle,
         service_registry=service_registry,
         auth=NoAuth(),
         event_store=event_store,

--- a/tests/test_local_placement.py
+++ b/tests/test_local_placement.py
@@ -4,60 +4,72 @@ from __future__ import annotations
 
 import inspect
 import uuid
+from unittest.mock import MagicMock
 
 from akgentic.infra.adapters.local_placement import LocalPlacement
+from akgentic.infra.adapters.local_team_handle import LocalTeamHandle
 from akgentic.infra.protocols.placement import PlacementStrategy
 
 
+def _make_adapter() -> LocalPlacement:
+    """Create a LocalPlacement with mock dependencies."""
+    team_manager = MagicMock()
+    service_registry = MagicMock()
+    return LocalPlacement(team_manager, service_registry)
+
+
 class TestLocalPlacementProtocolCompliance:
-    """AC1: LocalPlacement implements PlacementStrategy protocol."""
+    """AC5: LocalPlacement implements PlacementStrategy protocol."""
 
     def test_satisfies_placement_strategy_protocol(self) -> None:
         """LocalPlacement structurally satisfies PlacementStrategy."""
-        adapter = LocalPlacement()
+        adapter = _make_adapter()
         assert isinstance(adapter, PlacementStrategy)
 
-    def test_has_select_worker_method(self) -> None:
-        """LocalPlacement exposes select_worker with correct signature."""
-        adapter = LocalPlacement()
-        assert callable(adapter.select_worker)
+    def test_has_create_team_method(self) -> None:
+        """LocalPlacement exposes create_team with correct signature."""
+        adapter = _make_adapter()
+        assert callable(adapter.create_team)
 
-    def test_select_worker_signature_matches_protocol(self) -> None:
-        """select_worker has team_id parameter matching PlacementStrategy."""
-        sig = inspect.signature(LocalPlacement.select_worker)
-        assert "team_id" in sig.parameters
+    def test_create_team_signature_matches_protocol(self) -> None:
+        """create_team has team_card and user_id parameters matching PlacementStrategy."""
+        sig = inspect.signature(LocalPlacement.create_team)
+        assert "team_card" in sig.parameters
+        assert "user_id" in sig.parameters
 
 
 class TestLocalPlacementBehavior:
-    """AC1: LocalPlacement returns instance_id for all teams."""
+    """AC5: LocalPlacement delegates to TeamManager and returns LocalTeamHandle."""
 
-    def test_select_worker_returns_instance_id(self) -> None:
-        """select_worker always returns the adapter's instance_id."""
-        adapter = LocalPlacement()
-        team_id = uuid.uuid4()
-        result = adapter.select_worker(team_id)
-        assert result == adapter.instance_id
+    def test_create_team_delegates_to_team_manager(self) -> None:
+        """create_team calls TeamManager.create_team with correct args."""
+        team_manager = MagicMock()
+        service_registry = MagicMock()
+        adapter = LocalPlacement(team_manager, service_registry)
+        team_card = MagicMock()
+        adapter.create_team(team_card, "user-1")
+        team_manager.create_team.assert_called_once_with(team_card, "user-1")
 
-    def test_select_worker_returns_uuid(self) -> None:
-        """select_worker returns a uuid.UUID."""
-        adapter = LocalPlacement()
-        result = adapter.select_worker(uuid.uuid4())
-        assert isinstance(result, uuid.UUID)
+    def test_create_team_returns_local_team_handle(self) -> None:
+        """create_team wraps TeamManager result in LocalTeamHandle."""
+        team_manager = MagicMock()
+        service_registry = MagicMock()
+        adapter = LocalPlacement(team_manager, service_registry)
+        result = adapter.create_team(MagicMock(), "user-1")
+        assert isinstance(result, LocalTeamHandle)
 
     def test_instance_id_is_stable(self) -> None:
         """instance_id does not change between calls."""
-        adapter = LocalPlacement()
+        adapter = _make_adapter()
         assert adapter.instance_id == adapter.instance_id
 
-    def test_select_worker_same_for_different_teams(self) -> None:
-        """All teams get placed on the same instance."""
-        adapter = LocalPlacement()
-        team1 = uuid.uuid4()
-        team2 = uuid.uuid4()
-        assert adapter.select_worker(team1) == adapter.select_worker(team2)
+    def test_instance_id_is_uuid(self) -> None:
+        """instance_id is a uuid.UUID."""
+        adapter = _make_adapter()
+        assert isinstance(adapter.instance_id, uuid.UUID)
 
     def test_different_instances_have_different_ids(self) -> None:
         """Two LocalPlacement instances have different instance_ids."""
-        a = LocalPlacement()
-        b = LocalPlacement()
+        a = _make_adapter()
+        b = _make_adapter()
         assert a.instance_id != b.instance_id

--- a/tests/test_local_worker_handle.py
+++ b/tests/test_local_worker_handle.py
@@ -1,0 +1,106 @@
+"""Tests for LocalWorkerHandle adapter."""
+
+from __future__ import annotations
+
+import inspect
+import uuid
+from unittest.mock import MagicMock
+
+from akgentic.infra.adapters.local_team_handle import LocalTeamHandle
+from akgentic.infra.adapters.local_worker_handle import LocalWorkerHandle
+from akgentic.infra.protocols.worker_handle import WorkerHandle
+
+
+def _make_adapter() -> tuple[LocalWorkerHandle, MagicMock]:
+    """Create a LocalWorkerHandle with mock dependencies, return both."""
+    team_manager = MagicMock()
+    service_registry = MagicMock()
+    return LocalWorkerHandle(team_manager, service_registry), team_manager
+
+
+class TestLocalWorkerHandleProtocolCompliance:
+    """AC4: LocalWorkerHandle implements WorkerHandle protocol."""
+
+    def test_satisfies_worker_handle_protocol(self) -> None:
+        """LocalWorkerHandle structurally satisfies WorkerHandle."""
+        adapter, _ = _make_adapter()
+        assert isinstance(adapter, WorkerHandle)
+
+    def test_has_all_protocol_methods(self) -> None:
+        """LocalWorkerHandle exposes all 4 WorkerHandle methods."""
+        adapter, _ = _make_adapter()
+        for method in ("stop_team", "delete_team", "resume_team", "get_team"):
+            assert callable(getattr(adapter, method))
+
+    def test_stop_team_signature(self) -> None:
+        """stop_team has team_id parameter."""
+        sig = inspect.signature(LocalWorkerHandle.stop_team)
+        assert "team_id" in sig.parameters
+
+    def test_delete_team_signature(self) -> None:
+        """delete_team has team_id parameter."""
+        sig = inspect.signature(LocalWorkerHandle.delete_team)
+        assert "team_id" in sig.parameters
+
+    def test_resume_team_signature(self) -> None:
+        """resume_team has team_id parameter."""
+        sig = inspect.signature(LocalWorkerHandle.resume_team)
+        assert "team_id" in sig.parameters
+
+    def test_get_team_signature(self) -> None:
+        """get_team has team_id parameter."""
+        sig = inspect.signature(LocalWorkerHandle.get_team)
+        assert "team_id" in sig.parameters
+
+
+class TestLocalWorkerHandleBehavior:
+    """AC4: LocalWorkerHandle delegates to TeamManager correctly."""
+
+    def test_stop_team_delegates_to_team_manager(self) -> None:
+        """stop_team calls TeamManager.stop_team with correct team_id."""
+        adapter, tm = _make_adapter()
+        tid = uuid.uuid4()
+        adapter.stop_team(tid)
+        tm.stop_team.assert_called_once_with(tid)
+
+    def test_delete_team_delegates_to_team_manager(self) -> None:
+        """delete_team calls TeamManager.delete_team with correct team_id."""
+        adapter, tm = _make_adapter()
+        tid = uuid.uuid4()
+        adapter.delete_team(tid)
+        tm.delete_team.assert_called_once_with(tid)
+
+    def test_resume_team_delegates_to_team_manager(self) -> None:
+        """resume_team calls TeamManager.resume_team with correct team_id."""
+        adapter, tm = _make_adapter()
+        tid = uuid.uuid4()
+        adapter.resume_team(tid)
+        tm.resume_team.assert_called_once_with(tid)
+
+    def test_resume_team_returns_local_team_handle(self) -> None:
+        """resume_team wraps TeamManager result in LocalTeamHandle."""
+        adapter, _ = _make_adapter()
+        result = adapter.resume_team(uuid.uuid4())
+        assert isinstance(result, LocalTeamHandle)
+
+    def test_get_team_delegates_to_team_manager(self) -> None:
+        """get_team calls TeamManager.get_team with correct team_id."""
+        adapter, tm = _make_adapter()
+        tid = uuid.uuid4()
+        adapter.get_team(tid)
+        tm.get_team.assert_called_once_with(tid)
+
+    def test_get_team_returns_team_manager_result(self) -> None:
+        """get_team returns whatever TeamManager.get_team returns."""
+        adapter, tm = _make_adapter()
+        sentinel = MagicMock()
+        tm.get_team.return_value = sentinel
+        result = adapter.get_team(uuid.uuid4())
+        assert result is sentinel
+
+    def test_get_team_returns_none_when_not_found(self) -> None:
+        """get_team returns None when TeamManager returns None."""
+        adapter, tm = _make_adapter()
+        tm.get_team.return_value = None
+        result = adapter.get_team(uuid.uuid4())
+        assert result is None

--- a/tests/test_protocols.py
+++ b/tests/test_protocols.py
@@ -14,13 +14,14 @@ def test_placement_strategy_is_protocol() -> None:
     assert Protocol in inspect.getmro(PlacementStrategy)
 
 
-def test_placement_strategy_has_select_worker() -> None:
-    """PlacementStrategy defines select_worker with team_id parameter."""
+def test_placement_strategy_has_create_team() -> None:
+    """PlacementStrategy defines create_team with team_card and user_id parameters."""
     from akgentic.infra.protocols import PlacementStrategy
 
-    assert hasattr(PlacementStrategy, "select_worker")
-    sig = inspect.signature(PlacementStrategy.select_worker)
-    assert "team_id" in sig.parameters
+    assert hasattr(PlacementStrategy, "create_team")
+    sig = inspect.signature(PlacementStrategy.create_team)
+    assert "team_card" in sig.parameters
+    assert "user_id" in sig.parameters
 
 
 def test_auth_strategy_is_protocol() -> None:
@@ -625,11 +626,15 @@ def test_runtime_cache_method_count() -> None:
 
 
 def test_placement_strategy_return_type() -> None:
-    """PlacementStrategy.select_worker returns uuid.UUID."""
-    from akgentic.infra.protocols import PlacementStrategy
+    """PlacementStrategy.create_team returns TeamHandle."""
+    from akgentic.infra.protocols import PlacementStrategy, TeamHandle
+    from akgentic.team.models import TeamCard
 
-    hints = get_type_hints(PlacementStrategy.select_worker)
-    assert hints["return"] is uuid.UUID
+    hints = get_type_hints(
+        PlacementStrategy.create_team,
+        localns={"TeamCard": TeamCard, "TeamHandle": TeamHandle},
+    )
+    assert hints["return"] is TeamHandle
 
 
 def test_auth_strategy_return_type() -> None:
@@ -654,3 +659,109 @@ def test_health_monitor_return_type() -> None:
 
     hints = get_type_hints(HealthMonitor.check_health)
     assert hints["return"] == list[uuid.UUID]
+
+
+# --- WorkerHandle ---
+
+
+def test_worker_handle_is_protocol() -> None:
+    """WorkerHandle uses typing.Protocol base."""
+    from akgentic.infra.protocols import WorkerHandle
+
+    assert Protocol in inspect.getmro(WorkerHandle)
+
+
+def test_worker_handle_is_runtime_checkable() -> None:
+    """WorkerHandle has @runtime_checkable decorator and isinstance works."""
+    from akgentic.infra.protocols import WorkerHandle
+
+    class FakeWorkerHandle:
+        def stop_team(self, team_id: uuid.UUID) -> None:
+            pass
+
+        def delete_team(self, team_id: uuid.UUID) -> None:
+            pass
+
+        def resume_team(self, team_id: uuid.UUID) -> object:
+            return None
+
+        def get_team(self, team_id: uuid.UUID) -> object:
+            return None
+
+    assert isinstance(FakeWorkerHandle(), WorkerHandle)
+
+
+def test_worker_handle_has_stop_team() -> None:
+    """WorkerHandle defines stop_team with team_id parameter."""
+    from akgentic.infra.protocols import WorkerHandle
+
+    assert hasattr(WorkerHandle, "stop_team")
+    sig = inspect.signature(WorkerHandle.stop_team)
+    assert "team_id" in sig.parameters
+
+
+def test_worker_handle_has_delete_team() -> None:
+    """WorkerHandle defines delete_team with team_id parameter."""
+    from akgentic.infra.protocols import WorkerHandle
+
+    assert hasattr(WorkerHandle, "delete_team")
+    sig = inspect.signature(WorkerHandle.delete_team)
+    assert "team_id" in sig.parameters
+
+
+def test_worker_handle_has_resume_team() -> None:
+    """WorkerHandle defines resume_team with team_id parameter."""
+    from akgentic.infra.protocols import WorkerHandle
+
+    assert hasattr(WorkerHandle, "resume_team")
+    sig = inspect.signature(WorkerHandle.resume_team)
+    assert "team_id" in sig.parameters
+
+
+def test_worker_handle_has_get_team() -> None:
+    """WorkerHandle defines get_team with team_id parameter."""
+    from akgentic.infra.protocols import WorkerHandle
+
+    assert hasattr(WorkerHandle, "get_team")
+    sig = inspect.signature(WorkerHandle.get_team)
+    assert "team_id" in sig.parameters
+
+
+def test_worker_handle_stop_team_returns_none() -> None:
+    """WorkerHandle.stop_team returns None."""
+    from akgentic.infra.protocols import WorkerHandle
+
+    hints = get_type_hints(WorkerHandle.stop_team)
+    assert hints["return"] is type(None)
+
+
+def test_worker_handle_delete_team_returns_none() -> None:
+    """WorkerHandle.delete_team returns None."""
+    from akgentic.infra.protocols import WorkerHandle
+
+    hints = get_type_hints(WorkerHandle.delete_team)
+    assert hints["return"] is type(None)
+
+
+def test_worker_handle_resume_team_returns_team_handle() -> None:
+    """WorkerHandle.resume_team returns TeamHandle."""
+    from akgentic.infra.protocols import TeamHandle, WorkerHandle
+    from akgentic.team.models import Process
+
+    hints = get_type_hints(
+        WorkerHandle.resume_team,
+        localns={"TeamHandle": TeamHandle, "Process": Process},
+    )
+    assert hints["return"] is TeamHandle
+
+
+def test_worker_handle_method_count() -> None:
+    """WorkerHandle has exactly 4 public methods."""
+    from akgentic.infra.protocols import WorkerHandle
+
+    public_methods = [
+        m
+        for m in dir(WorkerHandle)
+        if not m.startswith("_") and callable(getattr(WorkerHandle, m))
+    ]
+    assert len(public_methods) == 4

--- a/tests/test_protocols.py
+++ b/tests/test_protocols.py
@@ -755,6 +755,18 @@ def test_worker_handle_resume_team_returns_team_handle() -> None:
     assert hints["return"] is TeamHandle
 
 
+def test_worker_handle_get_team_returns_process_or_none() -> None:
+    """WorkerHandle.get_team returns Process | None."""
+    from akgentic.infra.protocols import WorkerHandle
+    from akgentic.team.models import Process
+
+    hints = get_type_hints(
+        WorkerHandle.get_team,
+        localns={"Process": Process},
+    )
+    assert hints["return"] == Process | None
+
+
 def test_worker_handle_method_count() -> None:
     """WorkerHandle has exactly 4 public methods."""
     from akgentic.infra.protocols import WorkerHandle

--- a/tests/test_wiring.py
+++ b/tests/test_wiring.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import uuid
 from collections.abc import Generator
 from pathlib import Path
 
@@ -77,9 +76,8 @@ class TestWireCommunity:
         """LocalPlacement's instance_id is registered with ServiceRegistry."""
         placement = services.placement
         assert isinstance(placement, LocalPlacement)
-        found = services.service_registry.find_team(uuid.uuid4())
-        # instance is registered — find_team returns None for unknown team but no error
-        assert found is None or isinstance(found, uuid.UUID)
+        active = services.service_registry.get_active_instances()
+        assert placement.instance_id in active
 
     def test_catalog_path_override(self, tmp_path: Path) -> None:
         """wire_community uses settings.catalog_path when set."""

--- a/tests/test_wiring.py
+++ b/tests/test_wiring.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import uuid
 from collections.abc import Generator
 from pathlib import Path
 
@@ -11,6 +12,7 @@ from akgentic.team.repositories.yaml import YamlEventStore
 
 from akgentic.infra.adapters.local_placement import LocalPlacement
 from akgentic.infra.adapters.local_service_registry import LocalServiceRegistry
+from akgentic.infra.adapters.local_worker_handle import LocalWorkerHandle
 from akgentic.infra.adapters.no_auth import NoAuth
 from akgentic.infra.server.deps import CommunityServices
 from akgentic.infra.server.settings import ServerSettings
@@ -32,18 +34,20 @@ class TestWireCommunity:
         """wire_community returns a CommunityServices instance."""
         assert isinstance(services, CommunityServices)
 
-    def test_placement_is_local_list(self, services: CommunityServices) -> None:
-        """Placement strategy is a list containing LocalPlacement."""
-        assert isinstance(services.placement, list)
-        assert len(services.placement) == 1
-        assert isinstance(services.placement[0], LocalPlacement)
+    def test_placement_is_local(self, services: CommunityServices) -> None:
+        """Placement strategy is a LocalPlacement."""
+        assert isinstance(services.placement, LocalPlacement)
 
     def test_auth_is_noauth(self, services: CommunityServices) -> None:
         """Auth strategy is NoAuth."""
         assert isinstance(services.auth, NoAuth)
 
+    def test_worker_handle_is_local(self, services: CommunityServices) -> None:
+        """Worker handle is LocalWorkerHandle."""
+        assert isinstance(services.worker_handle, LocalWorkerHandle)
+
     def test_service_registry_is_local(self, services: CommunityServices) -> None:
-        """Service registry is LocalServiceRegistry."""
+        """Service registry is LocalServiceRegistry (community-specific)."""
         assert isinstance(services.service_registry, LocalServiceRegistry)
 
     def test_event_store_is_yaml(self, services: CommunityServices) -> None:
@@ -66,6 +70,16 @@ class TestWireCommunity:
     def test_shared_service_registry(self, services: CommunityServices) -> None:
         """TeamManager and CommunityServices share the same service registry."""
         assert services.service_registry is services.team_manager._service_registry
+
+    def test_instance_registered_with_service_registry(
+        self, services: CommunityServices,
+    ) -> None:
+        """LocalPlacement's instance_id is registered with ServiceRegistry."""
+        placement = services.placement
+        assert isinstance(placement, LocalPlacement)
+        found = services.service_registry.find_team(uuid.uuid4())
+        # instance is registered — find_team returns None for unknown team but no error
+        assert found is None or isinstance(found, uuid.UUID)
 
     def test_catalog_path_override(self, tmp_path: Path) -> None:
         """wire_community uses settings.catalog_path when set."""


### PR DESCRIPTION
## Summary

- Define `WorkerHandle` protocol with 4 methods (stop_team, delete_team, resume_team, get_team) as `@runtime_checkable`
- Expand `PlacementStrategy` from `select_worker(team_id) -> UUID` to `create_team(team_card, user_id) -> TeamHandle`
- Update `TierServices`: `placement` now singular, `worker_handle` added, `service_registry` moved to `CommunityServices`
- Implement `LocalWorkerHandle` delegating to `TeamManager`
- Update `LocalPlacement` with `create_team()` delegating to `TeamManager`
- Update `wire_community()` to wire new components and register instance

Closes #71