### PR TITLE
Refactor TierServices, ServerSettings, TeamService, and create_app

### DIFF
--- a/src/akgentic/infra/__init__.py
+++ b/src/akgentic/infra/__init__.py
@@ -49,7 +49,7 @@ from akgentic.infra.server.models import (
     WorkspaceTreeResponse,
 )
 from akgentic.infra.server.services.team_service import TeamService
-from akgentic.infra.server.settings import ServerSettings
+from akgentic.infra.server.settings import CommunitySettings, ServerSettings
 from akgentic.infra.wiring import wire_community
 
 __path__ = extend_path(__path__, __name__)
@@ -84,6 +84,7 @@ __all__ = [
     "WebSocketEventSubscriber",
     "YamlChannelRegistry",
     # Server
+    "CommunitySettings",
     "CommunityServices",
     "CreateTeamRequest",
     "EventListResponse",

--- a/src/akgentic/infra/adapters/local_team_handle.py
+++ b/src/akgentic/infra/adapters/local_team_handle.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import uuid
 from typing import TYPE_CHECKING
 
 from akgentic.agent import HumanProxy
@@ -22,6 +23,11 @@ class LocalTeamHandle:
 
     def __init__(self, runtime: TeamRuntime) -> None:
         self._runtime = runtime
+
+    @property
+    def team_id(self) -> uuid.UUID:
+        """The unique identifier of the team this handle points to."""
+        return self._runtime.id
 
     def send(self, content: str) -> None:
         """Send a message to the team's default entry point."""
@@ -55,13 +61,15 @@ class LocalTeamHandle:
     def subscribe(self, subscriber: EventSubscriber) -> None:
         """Register an event subscriber with the team's orchestrator."""
         orch_proxy = self._runtime.actor_system.proxy_ask(
-            self._runtime.orchestrator_addr, Orchestrator,
+            self._runtime.orchestrator_addr,
+            Orchestrator,
         )
         orch_proxy.subscribe(subscriber)
 
     def unsubscribe(self, subscriber: EventSubscriber) -> None:
         """Remove an event subscriber from the team's orchestrator."""
         orch_proxy = self._runtime.actor_system.proxy_ask(
-            self._runtime.orchestrator_addr, Orchestrator,
+            self._runtime.orchestrator_addr,
+            Orchestrator,
         )
         orch_proxy.unsubscribe(subscriber)

--- a/src/akgentic/infra/protocols/team_handle.py
+++ b/src/akgentic/infra/protocols/team_handle.py
@@ -21,6 +21,11 @@ class TeamHandle(Protocol):
     Implementations: LocalTeamHandle (community), RemoteTeamHandle (enterprise).
     """
 
+    @property
+    def team_id(self) -> uuid.UUID:
+        """The unique identifier of the team this handle points to."""
+        ...
+
     def send(self, content: str) -> None:
         """Send a message to the team's default entry point.
 

--- a/src/akgentic/infra/server/__init__.py
+++ b/src/akgentic/infra/server/__init__.py
@@ -14,9 +14,10 @@ from akgentic.infra.server.models import (
     TeamResponse,
 )
 from akgentic.infra.server.services.team_service import TeamService
-from akgentic.infra.server.settings import ServerSettings
+from akgentic.infra.server.settings import CommunitySettings, ServerSettings
 
 __all__ = [
+    "CommunitySettings",
     "CommunityServices",
     "CreateTeamRequest",
     "EventListResponse",

--- a/src/akgentic/infra/server/app.py
+++ b/src/akgentic/infra/server/app.py
@@ -65,7 +65,7 @@ def _build_app(
     """Assemble the FastAPI app from pre-built services (shared by create_app and tests).
 
     Args:
-        services: Wired community services container.
+        services: Wired tier services container.
         team_service: Pre-built team service.
         settings: Server settings.
 

--- a/src/akgentic/infra/server/app.py
+++ b/src/akgentic/infra/server/app.py
@@ -16,7 +16,7 @@ from akgentic.catalog.api.agent_router import set_catalog as set_agent_catalog
 from akgentic.catalog.api.team_router import set_catalog as set_team_catalog
 from akgentic.catalog.api.template_router import set_catalog as set_template_catalog
 from akgentic.catalog.api.tool_router import set_catalog as set_tool_catalog
-from akgentic.infra.server.deps import CommunityServices
+from akgentic.infra.server.deps import TierServices
 from akgentic.infra.server.routes.frontend_adapter import load_frontend_adapter
 from akgentic.infra.server.routes.teams import router as teams_router
 from akgentic.infra.server.routes.webhook import router as webhook_router
@@ -25,41 +25,31 @@ from akgentic.infra.server.routes.ws import ConnectionManager
 from akgentic.infra.server.routes.ws import router as ws_router
 from akgentic.infra.server.services.team_service import TeamService
 from akgentic.infra.server.settings import ServerSettings
-from akgentic.infra.wiring import wire_community
 
 
-def create_app(settings: ServerSettings | None = None) -> FastAPI:
+def create_app(
+    services: TierServices,
+    settings: ServerSettings | None = None,
+) -> FastAPI:
     """Create and configure the FastAPI application.
 
-    Single entry-point factory: wires community services, constructs
-    ``TeamService``, completes deferred ``LocalIngestion`` wiring, and
-    mounts all routes.
+    Entry-point factory: constructs ``TeamService``, completes deferred
+    ``LocalIngestion`` wiring, and mounts all routes.
 
     Args:
+        services: Pre-wired tier services container.
         settings: Server settings. Defaults to ``ServerSettings()``.
 
     Returns:
         Configured FastAPI application instance.
     """
     settings = settings or ServerSettings()
-    services = wire_community(settings)
-    team_service = _build_team_service(services)
+    team_service = TeamService(services)
     _wire_ingestion(services, team_service)
     return _build_app(services, team_service, settings)
 
 
-def _build_team_service(services: CommunityServices) -> TeamService:
-    """Construct TeamService from wired community services."""
-    return TeamService(
-        services=services,
-        team_catalog=services.team_catalog,
-        agent_catalog=services.agent_catalog,
-        tool_catalog=services.tool_catalog,
-        template_catalog=services.template_catalog,
-    )
-
-
-def _wire_ingestion(services: CommunityServices, team_service: TeamService) -> None:
+def _wire_ingestion(services: TierServices, team_service: TeamService) -> None:
     """Complete deferred LocalIngestion wiring with the constructed TeamService."""
     from akgentic.infra.adapters.local_ingestion import LocalIngestion
 
@@ -68,7 +58,7 @@ def _wire_ingestion(services: CommunityServices, team_service: TeamService) -> N
 
 
 def _build_app(
-    services: CommunityServices,
+    services: TierServices,
     team_service: TeamService,
     settings: ServerSettings,
 ) -> FastAPI:
@@ -104,7 +94,7 @@ def _add_cors(app: FastAPI, cors_origins: list[str]) -> None:
 
 def _store_state(
     app: FastAPI,
-    services: CommunityServices,
+    services: TierServices,
     team_service: TeamService,
     settings: ServerSettings,
 ) -> None:
@@ -113,12 +103,12 @@ def _store_state(
     app.state.team_service = team_service
     app.state.settings = settings
     app.state.connection_manager = ConnectionManager()
-    app.state.channel_parser_registry = services.channel_parser_registry
+    app.state.channel_parser_registry = getattr(services, "channel_parser_registry", None)
     app.state.channel_registry = services.channel_registry
     app.state.ingestion = services.ingestion
 
 
-def _inject_catalogs(services: CommunityServices) -> None:
+def _inject_catalogs(services: TierServices) -> None:
     """Inject catalog service instances into akgentic-catalog router modules."""
     set_agent_catalog(services.agent_catalog)
     set_team_catalog(services.team_catalog)

--- a/src/akgentic/infra/server/deps.py
+++ b/src/akgentic/infra/server/deps.py
@@ -48,6 +48,12 @@ class TierServices(BaseModel):
     channel_registry: ChannelRegistry = Field(
         description="Registry mapping channel IDs to team IDs"
     )
+    team_catalog: TeamCatalog = Field(description="Catalog service for team entry resolution")
+    agent_catalog: AgentCatalog = Field(description="Catalog service for agent entry resolution")
+    tool_catalog: ToolCatalog = Field(description="Catalog service for tool entry resolution")
+    template_catalog: TemplateCatalog = Field(
+        description="Catalog service for template entry resolution"
+    )
 
 
 class CommunityServices(TierServices):
@@ -62,12 +68,6 @@ class CommunityServices(TierServices):
     )
     actor_system: ActorSystem = Field(description="Actor system for managing agent lifecycle")
     team_manager: TeamManager = Field(description="Team lifecycle manager (embedded, in-process)")
-    team_catalog: TeamCatalog = Field(description="Catalog service for team entry resolution")
-    agent_catalog: AgentCatalog = Field(description="Catalog service for agent entry resolution")
-    tool_catalog: ToolCatalog = Field(description="Catalog service for tool entry resolution")
-    template_catalog: TemplateCatalog = Field(
-        description="Catalog service for template entry resolution"
-    )
     channel_parser_registry: ChannelParserRegistry = Field(
         description="Registry of channel message parsers"
     )

--- a/src/akgentic/infra/server/routes/workspace.py
+++ b/src/akgentic/infra/server/routes/workspace.py
@@ -15,7 +15,7 @@ from akgentic.infra.server.models import (
     WorkspaceTreeResponse,
 )
 from akgentic.infra.server.services.team_service import TeamService
-from akgentic.infra.server.settings import ServerSettings
+from akgentic.infra.server.settings import CommunitySettings
 from akgentic.tool.workspace import Filesystem
 
 router = APIRouter(prefix="/workspace", tags=["workspace"])
@@ -23,7 +23,7 @@ router = APIRouter(prefix="/workspace", tags=["workspace"])
 _MAX_FILE_SIZE = 10_485_760  # 10 MB
 
 
-def _get_workspace(team_id: uuid.UUID, settings: ServerSettings) -> Filesystem:
+def _get_workspace(team_id: uuid.UUID, settings: CommunitySettings) -> Filesystem:
     """Instantiate a Filesystem scoped to a team's workspace directory."""
     return Filesystem(base_path=str(settings.workspaces_root), workspace_name=str(team_id))
 
@@ -43,7 +43,7 @@ def list_workspace_tree(
 ) -> WorkspaceTreeResponse:
     """List files in a team's workspace directory."""
     _validate_team(team_id, request)
-    settings = cast(ServerSettings, request.app.state.settings)
+    settings = cast(CommunitySettings, request.app.state.settings)
     ws = _get_workspace(team_id, settings)
     try:
         entries = ws.list(path)
@@ -66,7 +66,7 @@ def read_workspace_file(
 ) -> Response:
     """Read a file from a team's workspace."""
     _validate_team(team_id, request)
-    settings = cast(ServerSettings, request.app.state.settings)
+    settings = cast(CommunitySettings, request.app.state.settings)
     ws = _get_workspace(team_id, settings)
     try:
         data = ws.read(path)
@@ -93,7 +93,7 @@ async def upload_workspace_file(
 ) -> WorkspaceFileUploadResponse:
     """Upload a file to a team's workspace."""
     _validate_team(team_id, request)
-    settings = cast(ServerSettings, request.app.state.settings)
+    settings = cast(CommunitySettings, request.app.state.settings)
     ws = _get_workspace(team_id, settings)
     data = await file.read()
     if len(data) > _MAX_FILE_SIZE:

--- a/src/akgentic/infra/server/services/team_service.py
+++ b/src/akgentic/infra/server/services/team_service.py
@@ -1,20 +1,13 @@
-"""TeamService — orchestrates catalog resolution and TeamManager delegation."""
+"""TeamService — orchestrates catalog resolution and team lifecycle via protocols."""
 
 from __future__ import annotations
 
 import uuid
 
 from akgentic.catalog.models.errors import EntryNotFoundError
-from akgentic.catalog.services import (
-    AgentCatalog,
-    TeamCatalog,
-    TemplateCatalog,
-    ToolCatalog,
-)
 from akgentic.core.messages.message import Message
-from akgentic.infra.adapters.local_team_handle import LocalTeamHandle
 from akgentic.infra.protocols.team_handle import RuntimeCache, TeamHandle
-from akgentic.infra.server.deps import CommunityServices
+from akgentic.infra.server.deps import TierServices
 from akgentic.team.models import PersistedEvent, Process, TeamStatus
 
 
@@ -22,23 +15,13 @@ class TeamService:
     """Service layer bridging catalog resolution with team lifecycle management.
 
     Resolves catalog entry IDs to TeamCards, delegates lifecycle operations
-    to TeamManager, and queries EventStore for listing. Delegates runtime
-    interaction through RuntimeCache/TeamHandle protocols.
+    through PlacementStrategy and WorkerHandle protocols, and queries
+    EventStore for listing. Delegates runtime interaction through
+    RuntimeCache/TeamHandle protocols.
     """
 
-    def __init__(
-        self,
-        services: CommunityServices,
-        team_catalog: TeamCatalog,
-        agent_catalog: AgentCatalog,
-        tool_catalog: ToolCatalog | None = None,
-        template_catalog: TemplateCatalog | None = None,
-    ) -> None:
+    def __init__(self, services: TierServices) -> None:
         self._services = services
-        self._team_catalog = team_catalog
-        self._agent_catalog = agent_catalog
-        self._tool_catalog = tool_catalog
-        self._template_catalog = template_catalog
         self._cache: RuntimeCache = services.runtime_cache
 
     def create_team(self, catalog_entry_id: str, user_id: str) -> Process:
@@ -47,17 +30,19 @@ class TeamService:
         Raises:
             EntryNotFoundError: If catalog_entry_id is not found.
         """
-        entry = self._team_catalog.get(catalog_entry_id)
+        entry = self._services.team_catalog.get(catalog_entry_id)
         if entry is None:
             raise EntryNotFoundError(catalog_entry_id)
         team_card = entry.to_team_card(
-            self._agent_catalog, self._tool_catalog, self._template_catalog
+            self._services.agent_catalog,
+            self._services.tool_catalog,
+            self._services.template_catalog,
         )
-        runtime = self._services.team_manager.create_team(team_card, user_id)
-        self._cache.store(runtime.id, LocalTeamHandle(runtime))
-        process = self._services.team_manager.get_team(runtime.id)
+        handle = self._services.placement.create_team(team_card, user_id)
+        self._cache.store(handle.team_id, handle)
+        process = self._services.worker_handle.get_team(handle.team_id)
         if process is None:  # pragma: no cover
-            msg = f"Team {runtime.id} was created but not found in event store"
+            msg = f"Team {handle.team_id} was created but not found in event store"
             raise RuntimeError(msg)
         return process
 
@@ -68,7 +53,7 @@ class TeamService:
 
     def get_team(self, team_id: uuid.UUID) -> Process | None:
         """Get a single team by ID."""
-        return self._services.team_manager.get_team(team_id)
+        return self._services.worker_handle.get_team(team_id)
 
     def delete_team(self, team_id: uuid.UUID) -> None:
         """Stop (if running) and delete a team.
@@ -76,14 +61,14 @@ class TeamService:
         Raises:
             ValueError: If team not found or already deleted.
         """
-        process = self._services.team_manager.get_team(team_id)
+        process = self._services.worker_handle.get_team(team_id)
         if process is None:
             msg = f"Team {team_id} not found"
             raise ValueError(msg)
         if process.status == TeamStatus.RUNNING:
-            self._services.team_manager.stop_team(team_id)
+            self._services.worker_handle.stop_team(team_id)
         self._cache.remove(team_id)
-        self._services.team_manager.delete_team(team_id)
+        self._services.worker_handle.delete_team(team_id)
 
     def send_message(self, team_id: uuid.UUID, content: str) -> None:
         """Send a message to a running team.
@@ -95,7 +80,10 @@ class TeamService:
         handle.send(content)
 
     def process_human_input(
-        self, team_id: uuid.UUID, content: str, message_id: str,
+        self,
+        team_id: uuid.UUID,
+        content: str,
+        message_id: str,
     ) -> None:
         """Route human input to HumanProxy for a specific message.
 
@@ -112,7 +100,7 @@ class TeamService:
         Raises:
             ValueError: If team not found or not in a stoppable state.
         """
-        process = self._services.team_manager.get_team(team_id)
+        process = self._services.worker_handle.get_team(team_id)
         if process is None:
             msg = f"Team {team_id} not found"
             raise ValueError(msg)
@@ -122,7 +110,7 @@ class TeamService:
         if process.status == TeamStatus.DELETED:
             msg = f"Team {team_id} has been deleted"
             raise ValueError(msg)
-        self._services.team_manager.stop_team(team_id)
+        self._services.worker_handle.stop_team(team_id)
         self._cache.remove(team_id)
 
     def restore_team(self, team_id: uuid.UUID) -> Process:
@@ -131,7 +119,7 @@ class TeamService:
         Raises:
             ValueError: If team not found or not in a restorable state.
         """
-        process = self._services.team_manager.get_team(team_id)
+        process = self._services.worker_handle.get_team(team_id)
         if process is None:
             msg = f"Team {team_id} not found"
             raise ValueError(msg)
@@ -141,9 +129,9 @@ class TeamService:
         if process.status == TeamStatus.DELETED:
             msg = f"Team {team_id} has been deleted"
             raise ValueError(msg)
-        runtime = self._services.team_manager.resume_team(team_id)
-        self._cache.store(runtime.id, LocalTeamHandle(runtime))
-        updated = self._services.team_manager.get_team(team_id)
+        handle = self._services.worker_handle.resume_team(team_id)
+        self._cache.store(handle.team_id, handle)
+        updated = self._services.worker_handle.get_team(team_id)
         if updated is None:  # pragma: no cover
             msg = f"Team {team_id} was restored but not found in event store"
             raise RuntimeError(msg)
@@ -155,7 +143,7 @@ class TeamService:
         Raises:
             ValueError: If team not found.
         """
-        process = self._services.team_manager.get_team(team_id)
+        process = self._services.worker_handle.get_team(team_id)
         if process is None:
             msg = f"Team {team_id} not found"
             raise ValueError(msg)
@@ -178,7 +166,7 @@ class TeamService:
         Raises:
             ValueError: If team not found, not running, or handle not cached.
         """
-        process = self._services.team_manager.get_team(team_id)
+        process = self._services.worker_handle.get_team(team_id)
         if process is None:
             msg = f"Team {team_id} not found"
             raise ValueError(msg)

--- a/src/akgentic/infra/server/settings.py
+++ b/src/akgentic/infra/server/settings.py
@@ -3,17 +3,16 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Literal
 
 from pydantic import Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
 class ServerSettings(BaseSettings):
-    """Typed server configuration loaded from environment variables.
+    """Tier-agnostic server configuration loaded from environment variables.
 
+    Contains only settings common to all deployment tiers.
     All fields can be overridden via environment variables prefixed with ``AKGENTIC_``.
-    For example, ``AKGENTIC_HOST=127.0.0.1`` overrides the ``host`` field.
     """
 
     model_config = SettingsConfigDict(env_prefix="AKGENTIC_")
@@ -30,21 +29,22 @@ class ServerSettings(BaseSettings):
         default=None,
         description="FQDN for frontend adapter plugin class",
     )
-    workspaces_root: Path = Field(
-        default=Path("workspaces"),
-        description="Root directory for team workspace storage",
-    )
     cors_origins: list[str] = Field(
         default=["*"],
         description="Allowed CORS origins for the HTTP server",
     )
-    event_store: Literal["yaml"] = Field(
-        default="yaml",
-        description="Event store backend (only 'yaml' supported; 'memory' requires akgentic-team)",
-    )
-    catalog_backend: Literal["yaml"] = Field(
-        default="yaml",
-        description="Catalog backend: 'yaml'",
+
+
+class CommunitySettings(ServerSettings):
+    """Community-tier settings extending base ServerSettings.
+
+    Adds filesystem-backed workspace and catalog configuration
+    specific to the community (single-process) deployment tier.
+    """
+
+    workspaces_root: Path = Field(
+        default=Path("workspaces"),
+        description="Root directory for team workspace storage",
     )
     catalog_path: Path | None = Field(
         default=None,

--- a/src/akgentic/infra/wiring.py
+++ b/src/akgentic/infra/wiring.py
@@ -25,19 +25,19 @@ from akgentic.infra.adapters.no_auth import NoAuth
 from akgentic.infra.adapters.telemetry_subscriber import TelemetrySubscriber
 from akgentic.infra.adapters.yaml_channel_registry import YamlChannelRegistry
 from akgentic.infra.server.deps import CommunityServices
-from akgentic.infra.server.settings import ServerSettings
+from akgentic.infra.server.settings import CommunitySettings
 from akgentic.team.manager import TeamManager
 from akgentic.team.repositories.yaml import YamlEventStore
 
 
-def wire_community(settings: ServerSettings) -> CommunityServices:
+def wire_community(settings: CommunitySettings) -> CommunityServices:
     """Assemble community-tier services for single-process deployment.
 
     ``LocalIngestion`` is created with deferred ``team_service`` wiring —
     callers must set ``ingestion.team_service`` after constructing ``TeamService``.
 
     Args:
-        settings: Server configuration
+        settings: Community-tier configuration
 
     Returns:
         Fully wired CommunityServices container
@@ -89,7 +89,7 @@ def _build_actor_layer(
 
 
 def _build_catalogs(
-    settings: ServerSettings,
+    settings: CommunitySettings,
 ) -> tuple[TeamCatalog, AgentCatalog, ToolCatalog, TemplateCatalog]:
     """Build YAML-backed catalog services."""
     catalog_root = settings.catalog_path or settings.workspaces_root / "catalog"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,7 +14,7 @@ from fastapi.testclient import TestClient
 from akgentic.infra.server.app import create_app
 from akgentic.infra.server.deps import CommunityServices
 from akgentic.infra.server.services.team_service import TeamService
-from akgentic.infra.server.settings import ServerSettings
+from akgentic.infra.server.settings import CommunitySettings
 from akgentic.infra.wiring import wire_community
 
 
@@ -83,22 +83,22 @@ def _ensure_openai_key(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 @pytest.fixture()
-def server_settings(tmp_path: Path) -> ServerSettings:
+def server_settings(tmp_path: Path) -> CommunitySettings:
     """Server settings with tmp_path-based workspaces."""
-    return ServerSettings(workspaces_root=tmp_path / "workspaces")
+    return CommunitySettings(workspaces_root=tmp_path / "workspaces")
 
 
 @pytest.fixture()
-def seeded_settings(tmp_path: Path) -> ServerSettings:
+def seeded_settings(tmp_path: Path) -> CommunitySettings:
     """Server settings with pre-seeded catalog YAML files."""
-    settings = ServerSettings(workspaces_root=tmp_path / "workspaces")
+    settings = CommunitySettings(workspaces_root=tmp_path / "workspaces")
     _seed_catalog(settings.workspaces_root / "catalog")
     return settings
 
 
 @pytest.fixture()
 def community_services(
-    seeded_settings: ServerSettings,
+    seeded_settings: CommunitySettings,
 ) -> Generator[CommunityServices, None, None]:
     """Wired community services with seeded catalog data."""
     services = wire_community(seeded_settings)
@@ -109,19 +109,16 @@ def community_services(
 @pytest.fixture()
 def team_service(community_services: CommunityServices) -> TeamService:
     """TeamService wired to community services."""
-    return TeamService(
-        services=community_services,
-        team_catalog=community_services.team_catalog,
-        agent_catalog=community_services.agent_catalog,
-        tool_catalog=community_services.tool_catalog,
-        template_catalog=community_services.template_catalog,
-    )
+    return TeamService(services=community_services)
 
 
 @pytest.fixture()
-def app(seeded_settings: ServerSettings) -> Generator[FastAPI, None, None]:
-    """FastAPI app via the single-arg factory."""
-    application = create_app(seeded_settings)
+def app(
+    seeded_settings: CommunitySettings,
+    community_services: CommunityServices,
+) -> Generator[FastAPI, None, None]:
+    """FastAPI app via the two-arg factory."""
+    application = create_app(community_services, seeded_settings)
     yield application
     application.state.services.actor_system.shutdown()
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -19,7 +19,7 @@ from akgentic.infra.adapters.yaml_channel_registry import YamlChannelRegistry
 from akgentic.infra.server.app import _build_app, create_app
 from akgentic.infra.server.deps import CommunityServices
 from akgentic.infra.server.services.team_service import TeamService
-from akgentic.infra.server.settings import ServerSettings
+from akgentic.infra.server.settings import CommunitySettings
 from akgentic.infra.wiring import wire_community
 
 if TYPE_CHECKING:
@@ -125,16 +125,16 @@ def openai_api_key() -> str:
 
 
 @pytest.fixture()
-def integration_settings(tmp_path: Path) -> ServerSettings:
-    """ServerSettings backed by tmp_path with a seeded integration catalog."""
-    settings = ServerSettings(workspaces_root=tmp_path / "workspaces")
+def integration_settings(tmp_path: Path) -> CommunitySettings:
+    """CommunitySettings backed by tmp_path with a seeded integration catalog."""
+    settings = CommunitySettings(workspaces_root=tmp_path / "workspaces")
     _seed_integration_catalog(settings.workspaces_root / "catalog")
     return settings
 
 
 @pytest.fixture()
 def integration_services(
-    integration_settings: ServerSettings,
+    integration_settings: CommunitySettings,
 ) -> Generator[CommunityServices, None, None]:
     """Wired community services with real actor system — shuts down on teardown."""
     services = wire_community(integration_settings)
@@ -147,23 +147,17 @@ def integration_team_service(
     integration_services: CommunityServices,
 ) -> TeamService:
     """TeamService wired to integration services."""
-    return TeamService(
-        services=integration_services,
-        team_catalog=integration_services.team_catalog,
-        agent_catalog=integration_services.agent_catalog,
-        tool_catalog=integration_services.tool_catalog,
-        template_catalog=integration_services.template_catalog,
-    )
+    return TeamService(services=integration_services)
 
 
 @pytest.fixture()
 def integration_app(
-    integration_settings: ServerSettings,
+    integration_settings: CommunitySettings,
+    integration_services: CommunityServices,
 ) -> Generator[FastAPI, None, None]:
     """FastAPI app backed by real actors and real LLM."""
-    application = create_app(integration_settings)
+    application = create_app(integration_services, integration_settings)
     yield application
-    application.state.services.actor_system.shutdown()
 
 
 @pytest.fixture()
@@ -182,9 +176,9 @@ V1_ADAPTER_FQDN = (
 
 
 @pytest.fixture()
-def v1_adapter_settings(tmp_path: Path) -> ServerSettings:
-    """ServerSettings with V1 frontend adapter enabled."""
-    settings = ServerSettings(
+def v1_adapter_settings(tmp_path: Path) -> CommunitySettings:
+    """CommunitySettings with V1 frontend adapter enabled."""
+    settings = CommunitySettings(
         workspaces_root=tmp_path / "workspaces",
         frontend_adapter=V1_ADAPTER_FQDN,
     )
@@ -194,12 +188,13 @@ def v1_adapter_settings(tmp_path: Path) -> ServerSettings:
 
 @pytest.fixture()
 def v1_adapter_app(
-    v1_adapter_settings: ServerSettings,
+    v1_adapter_settings: CommunitySettings,
 ) -> Generator[FastAPI, None, None]:
     """FastAPI app with V1 frontend adapter loaded."""
-    application = create_app(v1_adapter_settings)
+    services = wire_community(v1_adapter_settings)
+    application = create_app(services, v1_adapter_settings)
     yield application
-    application.state.services.actor_system.shutdown()
+    services.actor_system.shutdown()
 
 
 @pytest.fixture()
@@ -253,7 +248,7 @@ def channel_ingestion(
 def channel_app(
     integration_services: CommunityServices,
     integration_team_service: TeamService,
-    integration_settings: ServerSettings,
+    integration_settings: CommunitySettings,
     channel_parser_registry: ChannelParserRegistry,
     channel_registry_instance: YamlChannelRegistry,
     channel_ingestion: LocalIngestion,

--- a/tests/integration/test_spec_compliance.py
+++ b/tests/integration/test_spec_compliance.py
@@ -14,7 +14,8 @@ from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
 from akgentic.infra.server.app import create_app
-from akgentic.infra.server.settings import ServerSettings
+from akgentic.infra.server.settings import CommunitySettings
+from akgentic.infra.wiring import wire_community
 
 from ._helpers import create_team
 
@@ -37,19 +38,20 @@ class TestAppFactory:
         assert resp.status_code == 200
 
     def test_two_line_fixture_pattern(self, tmp_path: Path) -> None:
-        """AC #1: Demonstrate the 2-line fixture pattern works end-to-end."""
+        """AC #1: Demonstrate the fixture pattern works end-to-end."""
         from tests.integration.conftest import _seed_integration_catalog
 
-        settings = ServerSettings(workspaces_root=tmp_path / "workspaces")
+        settings = CommunitySettings(workspaces_root=tmp_path / "workspaces")
         _seed_integration_catalog(settings.workspaces_root / "catalog")
-        app = create_app(settings)
+        services = wire_community(settings)
+        app = create_app(services, settings)
         client = TestClient(app)
 
         resp = client.get("/teams/")
         assert resp.status_code == 200
         assert "teams" in resp.json()
 
-        app.state.services.actor_system.shutdown()
+        services.actor_system.shutdown()
 
     def test_team_create_get_delete_via_test_client(
         self, integration_client: TestClient, integration_app: FastAPI,

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -2,35 +2,23 @@
 
 from __future__ import annotations
 
-from pathlib import Path
-
 from fastapi.testclient import TestClient
 
 from akgentic.infra.server.app import create_app
-from akgentic.infra.server.settings import ServerSettings
+from akgentic.infra.server.deps import CommunityServices
+from akgentic.infra.server.settings import CommunitySettings
 
 
-def test_create_app_defaults_settings_when_none(tmp_path: Path) -> None:
-    """create_app(None) defaults to ServerSettings() and returns a working app."""
-    import os
-
-    os.environ["AKGENTIC_WORKSPACES_ROOT"] = str(tmp_path / "ws")
-    try:
-        app = create_app(None)
-        assert app.title == "Akgentic Platform API"
-        app.state.services.actor_system.shutdown()
-    finally:
-        os.environ.pop("AKGENTIC_WORKSPACES_ROOT", None)
-
-
-def test_create_app_returns_fastapi(seeded_settings: ServerSettings) -> None:
+def test_create_app_returns_fastapi(
+    seeded_settings: CommunitySettings,
+    community_services: CommunityServices,
+) -> None:
     """create_app returns a FastAPI instance with routes mounted."""
-    app = create_app(seeded_settings)
+    app = create_app(community_services, seeded_settings)
     assert app.title == "Akgentic Platform API"
     route_paths = [r.path for r in app.routes]  # type: ignore[union-attr]
     assert "/teams/" in route_paths
     assert "/teams/{team_id}" in route_paths
-    app.state.services.actor_system.shutdown()
 
 
 def test_cors_headers_present(client: TestClient) -> None:
@@ -46,13 +34,16 @@ def test_cors_headers_present(client: TestClient) -> None:
     assert "access-control-allow-origin" in resp.headers
 
 
-def test_custom_cors_origins(seeded_settings: ServerSettings) -> None:
+def test_custom_cors_origins(
+    seeded_settings: CommunitySettings,
+    community_services: CommunityServices,
+) -> None:
     """create_app respects custom cors_origins from settings."""
-    settings = ServerSettings(
+    settings = CommunitySettings(
         workspaces_root=seeded_settings.workspaces_root,
         cors_origins=["http://example.com"],
     )
-    app = create_app(settings)
+    app = create_app(community_services, settings)
     test_client = TestClient(app)
     resp = test_client.options(
         "/teams/",
@@ -62,7 +53,6 @@ def test_custom_cors_origins(seeded_settings: ServerSettings) -> None:
         },
     )
     assert resp.headers.get("access-control-allow-origin") == "http://example.com"
-    app.state.services.actor_system.shutdown()
 
 
 # ---------------------------------------------------------------------------
@@ -70,9 +60,11 @@ def test_custom_cors_origins(seeded_settings: ServerSettings) -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_create_app_includes_webhook_routes(seeded_settings: ServerSettings) -> None:
+def test_create_app_includes_webhook_routes(
+    seeded_settings: CommunitySettings,
+    community_services: CommunityServices,
+) -> None:
     """create_app always includes /webhook routes (channel deps are auto-wired)."""
-    app = create_app(seeded_settings)
+    app = create_app(community_services, seeded_settings)
     route_paths = [r.path for r in app.routes]  # type: ignore[union-attr]
     assert "/webhook/{channel}" in route_paths
-    app.state.services.actor_system.shutdown()

--- a/tests/test_protocols.py
+++ b/tests/test_protocols.py
@@ -437,6 +437,15 @@ def test_team_handle_is_protocol() -> None:
     assert Protocol in inspect.getmro(TeamHandle)
 
 
+def test_team_handle_has_team_id_property() -> None:
+    """TeamHandle defines team_id property returning uuid.UUID."""
+    from akgentic.infra.protocols import TeamHandle
+
+    assert hasattr(TeamHandle, "team_id")
+    hints = get_type_hints(TeamHandle.team_id.fget)  # type: ignore[union-attr]
+    assert hints["return"] is uuid.UUID
+
+
 def test_team_handle_is_runtime_checkable() -> None:
     """TeamHandle has @runtime_checkable decorator."""
     from akgentic.infra.protocols import TeamHandle

--- a/tests/test_protocols.py
+++ b/tests/test_protocols.py
@@ -446,6 +446,11 @@ def test_team_handle_is_runtime_checkable() -> None:
     )
     # Verify isinstance works (runtime_checkable requirement)
     class FakeHandle:
+        @property
+        def team_id(self) -> object:
+            import uuid
+            return uuid.uuid4()
+
         def send(self, content: str) -> None:
             pass
 

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -46,10 +46,11 @@ def test_infra_all_includes_adapters() -> None:
 
 
 def test_infra_all_includes_server_models() -> None:
-    """akgentic.infra.__all__ includes ServerSettings, TierServices, CommunityServices."""
+    """akgentic.infra.__all__ includes ServerSettings, CommunitySettings, TierServices, CommunityServices."""
     from akgentic import infra
 
     assert "ServerSettings" in infra.__all__
+    assert "CommunitySettings" in infra.__all__
     assert "TierServices" in infra.__all__
     assert "CommunityServices" in infra.__all__
 

--- a/tests/test_server_settings.py
+++ b/tests/test_server_settings.py
@@ -1,15 +1,15 @@
-"""Tests for ServerSettings model."""
+"""Tests for ServerSettings and CommunitySettings models."""
 
 from __future__ import annotations
 
 import os
 from pathlib import Path
 
-from akgentic.infra.server.settings import ServerSettings
+from akgentic.infra.server.settings import CommunitySettings, ServerSettings
 
 
 class TestServerSettingsDefaults:
-    """AC4: ServerSettings provides typed configuration with defaults."""
+    """ServerSettings provides tier-agnostic configuration with defaults."""
 
     def test_default_host(self) -> None:
         """Default host is 0.0.0.0."""
@@ -26,14 +26,13 @@ class TestServerSettingsDefaults:
         settings = ServerSettings()
         assert settings.frontend_adapter is None
 
-    def test_default_workspaces_root(self) -> None:
-        """Default workspaces_root is Path('workspaces')."""
-        settings = ServerSettings()
-        assert settings.workspaces_root == Path("workspaces")
+    def test_no_workspaces_root_on_base(self) -> None:
+        """ServerSettings does not have workspaces_root (community-specific)."""
+        assert "workspaces_root" not in ServerSettings.model_fields
 
 
 class TestServerSettingsEnvOverride:
-    """AC4: ServerSettings loads from AKGENTIC_ prefixed env vars."""
+    """ServerSettings loads from AKGENTIC_ prefixed env vars."""
 
     def test_host_from_env(self) -> None:
         """AKGENTIC_HOST overrides host field."""
@@ -62,18 +61,9 @@ class TestServerSettingsEnvOverride:
         finally:
             del os.environ["AKGENTIC_FRONTEND_ADAPTER"]
 
-    def test_workspaces_root_from_env(self) -> None:
-        """AKGENTIC_WORKSPACES_ROOT overrides workspaces_root field."""
-        os.environ["AKGENTIC_WORKSPACES_ROOT"] = "/tmp/ws"
-        try:
-            settings = ServerSettings()
-            assert settings.workspaces_root == Path("/tmp/ws")
-        finally:
-            del os.environ["AKGENTIC_WORKSPACES_ROOT"]
-
 
 class TestServerSettingsModel:
-    """AC4: ServerSettings extends BaseSettings."""
+    """ServerSettings extends BaseSettings."""
 
     def test_is_base_settings_subclass(self) -> None:
         """ServerSettings is a pydantic_settings BaseSettings subclass."""
@@ -84,4 +74,43 @@ class TestServerSettingsModel:
     def test_field_descriptions_present(self) -> None:
         """All fields have descriptions."""
         for name, field_info in ServerSettings.model_fields.items():
+            assert field_info.description is not None, f"Field {name} missing description"
+
+
+class TestCommunitySettingsDefaults:
+    """CommunitySettings extends ServerSettings with community-specific fields."""
+
+    def test_inherits_server_settings(self) -> None:
+        """CommunitySettings is a subclass of ServerSettings."""
+        assert issubclass(CommunitySettings, ServerSettings)
+
+    def test_default_workspaces_root(self) -> None:
+        """Default workspaces_root is Path('workspaces')."""
+        settings = CommunitySettings()
+        assert settings.workspaces_root == Path("workspaces")
+
+    def test_default_catalog_path(self) -> None:
+        """Default catalog_path is None."""
+        settings = CommunitySettings()
+        assert settings.catalog_path is None
+
+    def test_inherits_base_fields(self) -> None:
+        """CommunitySettings inherits host, port, cors_origins from ServerSettings."""
+        settings = CommunitySettings()
+        assert settings.host == "0.0.0.0"
+        assert settings.port == 8000
+        assert settings.cors_origins == ["*"]
+
+    def test_workspaces_root_from_env(self) -> None:
+        """AKGENTIC_WORKSPACES_ROOT overrides workspaces_root field."""
+        os.environ["AKGENTIC_WORKSPACES_ROOT"] = "/tmp/ws"
+        try:
+            settings = CommunitySettings()
+            assert settings.workspaces_root == Path("/tmp/ws")
+        finally:
+            del os.environ["AKGENTIC_WORKSPACES_ROOT"]
+
+    def test_field_descriptions_present(self) -> None:
+        """All CommunitySettings fields have descriptions."""
+        for name, field_info in CommunitySettings.model_fields.items():
             assert field_info.description is not None, f"Field {name} missing description"

--- a/tests/test_team_service.py
+++ b/tests/test_team_service.py
@@ -69,7 +69,7 @@ def test_delete_team_stops_and_deletes(team_service: TeamService) -> None:
 def test_delete_stopped_team(team_service: TeamService) -> None:
     """delete_team handles an already-stopped team without calling stop_team."""
     process = team_service.create_team("test-team", user_id="anonymous")
-    team_service._services.team_manager.stop_team(process.team_id)
+    team_service._services.worker_handle.stop_team(process.team_id)
     team_service.delete_team(process.team_id)
     after = team_service.get_team(process.team_id)
     assert after is None

--- a/tests/test_wiring.py
+++ b/tests/test_wiring.py
@@ -14,7 +14,7 @@ from akgentic.infra.adapters.local_service_registry import LocalServiceRegistry
 from akgentic.infra.adapters.local_worker_handle import LocalWorkerHandle
 from akgentic.infra.adapters.no_auth import NoAuth
 from akgentic.infra.server.deps import CommunityServices
-from akgentic.infra.server.settings import ServerSettings
+from akgentic.infra.server.settings import CommunitySettings
 from akgentic.infra.wiring import wire_community
 
 
@@ -24,7 +24,7 @@ class TestWireCommunity:
     @pytest.fixture()
     def services(self, tmp_path: Path) -> Generator[CommunityServices, None, None]:
         """Wire community services with a temp workspace root and cleanup ActorSystem."""
-        settings = ServerSettings(workspaces_root=tmp_path)
+        settings = CommunitySettings(workspaces_root=tmp_path)
         svc = wire_community(settings)
         yield svc
         svc.team_manager._actor_system.shutdown(timeout=5)
@@ -59,7 +59,7 @@ class TestWireCommunity:
 
     def test_uses_settings_workspaces_root(self, tmp_path: Path) -> None:
         """wire_community passes settings.workspaces_root to YamlEventStore."""
-        settings = ServerSettings(workspaces_root=tmp_path)
+        settings = CommunitySettings(workspaces_root=tmp_path)
         services = wire_community(settings)
         try:
             assert isinstance(services.event_store, YamlEventStore)
@@ -85,7 +85,7 @@ class TestWireCommunity:
         custom_catalog.mkdir()
         for sub in ("teams", "agents", "tools", "templates"):
             (custom_catalog / sub).mkdir()
-        settings = ServerSettings(
+        settings = CommunitySettings(
             workspaces_root=tmp_path,
             catalog_path=custom_catalog,
         )


### PR DESCRIPTION
## Summary

- Move 4 catalog fields (team_catalog, agent_catalog, tool_catalog, template_catalog) from CommunityServices up to TierServices
- Split ServerSettings into tier-agnostic base and CommunitySettings subclass; remove Literal fields
- Refactor TeamService to accept TierServices only — all lifecycle ops via placement/worker_handle protocols, zero actor-internal imports
- Refactor create_app to take (services: TierServices, settings: ServerSettings | None) — no internal wire_community call
- Update wire_community to accept CommunitySettings
- Update all test fixtures and callers

Closes #73