### PR TITLE
Add auth stubs and fix response grouping

### DIFF
--- a/src/akgentic/infra/server/routes/frontend_adapter/__init__.py
+++ b/src/akgentic/infra/server/routes/frontend_adapter/__init__.py
@@ -17,6 +17,7 @@ from pydantic import BaseModel, Discriminator, Field, Tag
 from akgentic.team.models import PersistedEvent
 
 __all__ = [
+    "ErrorPayload",
     "FrontendAdapter",
     "LlmContextPayload",
     "MessagePayload",
@@ -29,7 +30,7 @@ __all__ = [
 ]
 
 # Keep in sync with WsEventPayload Tag annotations and payload Literal types below.
-_KNOWN_TYPES = {"message", "state", "tool_update", "llm_context"}
+_KNOWN_TYPES = {"message", "state", "tool_update", "llm_context", "error"}
 
 
 class MessagePayload(BaseModel):
@@ -68,6 +69,14 @@ class LlmContextPayload(BaseModel):
     timestamp: str
 
 
+class ErrorPayload(BaseModel):
+    """V1 ``type: "error"`` envelope payload."""
+
+    type: Literal["error"] = "error"
+    message: str
+    timestamp: str
+
+
 class UnknownPayload(BaseModel):
     """Catch-all payload for unrecognised event types."""
 
@@ -89,6 +98,7 @@ WsEventPayload = Annotated[
     | Annotated[StatePayload, Tag("state")]
     | Annotated[ToolUpdatePayload, Tag("tool_update")]
     | Annotated[LlmContextPayload, Tag("llm_context")]
+    | Annotated[ErrorPayload, Tag("error")]
     | Annotated[UnknownPayload, Tag("unknown")],
     Discriminator(_ws_event_discriminator),
 ]

--- a/src/akgentic/infra/server/routes/frontend_adapter/angular_v1/__init__.py
+++ b/src/akgentic/infra/server/routes/frontend_adapter/angular_v1/__init__.py
@@ -11,6 +11,7 @@ from fastapi import FastAPI
 
 from akgentic.infra.server.routes.frontend_adapter import WrappedWsEvent
 from akgentic.infra.server.routes.frontend_adapter.angular_v1.router import (
+    auth_router,
     config_router,
     feedback_router,
     human_input_router,
@@ -49,6 +50,7 @@ class AngularV1Adapter:
         app.include_router(feedback_router)
         app.include_router(relaunch_router)
         app.include_router(state_update_router)
+        app.include_router(auth_router)
 
     def wrap_ws_event(self, event: PersistedEvent) -> WrappedWsEvent:
         """Translate a V2 persisted event into a V1 WebSocket envelope."""

--- a/src/akgentic/infra/server/routes/frontend_adapter/angular_v1/router.py
+++ b/src/akgentic/infra/server/routes/frontend_adapter/angular_v1/router.py
@@ -5,6 +5,7 @@ Every route delegates to TeamService — zero business logic in the adapter.
 
 from __future__ import annotations
 
+import json
 import uuid
 from typing import Any, NoReturn, cast
 
@@ -25,10 +26,8 @@ from akgentic.infra.server.routes.frontend_adapter.angular_v1.models import (
     V1ConfigPutBody,
     V1DescriptionBody,
     V1FeedbackEntry,
-    V1LlmContextEntry,
     V1MessageEntry,
     V1ProcessContext,
-    V1StateEntry,
     V1StateUpdateBody,
     V1StatusResponse,
 )
@@ -46,6 +45,7 @@ team_configs_router = APIRouter(prefix="/team-configs", tags=["v1-compat"])
 feedback_router = APIRouter(tags=["v1-compat"])
 relaunch_router = APIRouter(prefix="/relaunch", tags=["v1-compat"])
 state_update_router = APIRouter(prefix="/state", tags=["v1-compat"])
+auth_router = APIRouter(prefix="/auth", tags=["v1-compat"])
 
 
 class V1MessageBody(BaseModel):
@@ -272,57 +272,55 @@ def get_messages(
 # --- LLM context route ---
 
 
-@llm_context_router.get("/{id}", response_model=list[V1LlmContextEntry])
+@llm_context_router.get("/{id}", response_model=dict[str, object])
 def get_llm_context(
     id: str,
     service: TeamService = Depends(get_team_service),
-) -> list[V1LlmContextEntry]:
-    """GET /llm_context/{id} -> LLM context events in V1 format."""
+) -> dict[str, object]:
+    """GET /llm_context/{id} -> LLM context grouped by agent ID."""
     team_id = _parse_uuid(id)
     try:
         events = service.get_events(team_id)
     except ValueError:
         raise HTTPException(status_code=404, detail="Team not found") from None
-    result: list[V1LlmContextEntry] = []
+    grouped: dict[str, list[dict[str, str]]] = {}
     for ev in events:
         content = extract_message_content(ev.event)
         if content is None:
             continue
-        result.append(
-            V1LlmContextEntry(
-                role=classify_message_type(ev.event),
-                content=content,
-                timestamp=ev.timestamp.isoformat(),
-            )
-        )
-    return result
+        agent_id = get_sender_name(ev.event)
+        grouped.setdefault(agent_id, [])
+        grouped[agent_id].append({
+            "role": classify_message_type(ev.event),
+            "content": content,
+            "timestamp": ev.timestamp.isoformat(),
+        })
+    return {agent_id: {"context": entries} for agent_id, entries in grouped.items()}
 
 
 # --- States route ---
 
 
-@states_router.get("/{id}", response_model=list[V1StateEntry])
+@states_router.get("/{id}", response_model=dict[str, object])
 def get_states(
     id: str,
     service: TeamService = Depends(get_team_service),
-) -> list[V1StateEntry]:
-    """GET /states/{id} -> state change events in V1 format."""
+) -> dict[str, object]:
+    """GET /states/{id} -> agent states grouped by agent ID, latest per agent."""
     team_id = _parse_uuid(id)
     try:
         events = service.get_events(team_id)
     except ValueError:
         raise HTTPException(status_code=404, detail="Team not found") from None
-    result: list[V1StateEntry] = []
+    latest: dict[str, object] = {}
     for ev in events:
         if isinstance(ev.event, StateChangedMessage):
-            result.append(
-                V1StateEntry(
-                    agent=get_sender_name(ev.event),
-                    state=ev.event.state.model_dump(mode="json"),
-                    timestamp=ev.timestamp.isoformat(),
-                )
-            )
-    return result
+            agent_name = get_sender_name(ev.event)
+            latest[agent_name] = {
+                "schema": {},
+                "state": ev.event.state.model_dump(mode="json"),
+            }
+    return latest
 
 
 # --- Description route (extends process_router) ---
@@ -467,19 +465,18 @@ def delete_config(
 # --- Team configs route ---
 
 
-@team_configs_router.get("/", response_model=list[V1ConfigEntry])
-def get_team_configs(request: Request) -> list[V1ConfigEntry]:
-    """GET /team-configs -> list all team catalog entries."""
+@team_configs_router.get("/", response_model=dict[str, object])
+def get_team_configs(request: Request) -> dict[str, object]:
+    """GET /team-configs -> dict keyed by team name for V1 frontend."""
     catalog = request.app.state.services.team_catalog
     entries = catalog.list()
-    return [
-        V1ConfigEntry(
-            id=entry.id,
-            type="team",
-            data=entry.model_dump(mode="json"),
-        )
+    return {
+        entry.id: {
+            "module": entry.id,
+            "setup": json.dumps(entry.model_dump(mode="json")),
+        }
         for entry in entries
-    ]
+    }
 
 
 # --- Feedback routes (stubs — no V2 feedback system) ---
@@ -495,3 +492,24 @@ def get_feedback() -> list[V1FeedbackEntry]:
 def set_feedback(body: V1FeedbackEntry) -> V1StatusResponse:
     """POST /set-feedback -> stub returning ok."""
     return V1StatusResponse(status="ok")
+
+
+# --- Auth stub routes (Community tier NoAuth) ---
+
+
+@auth_router.get("/me")
+def auth_me() -> dict[str, str]:
+    """GET /auth/me -> anonymous user stub for Community tier."""
+    return {"user_id": "anonymous", "email": "", "name": "Anonymous"}
+
+
+@auth_router.get("/ws-ticket")
+def auth_ws_ticket() -> dict[str, str]:
+    """GET /auth/ws-ticket -> noauth ticket stub for Community tier."""
+    return {"ticket": "noauth"}
+
+
+@auth_router.get("/logout")
+def auth_logout() -> dict[str, str]:
+    """GET /auth/logout -> no-op logout stub for Community tier."""
+    return {"auth_type": "none"}

--- a/src/akgentic/infra/server/routes/frontend_adapter/angular_v1/ws.py
+++ b/src/akgentic/infra/server/routes/frontend_adapter/angular_v1/ws.py
@@ -38,7 +38,8 @@ def _classify_envelope_type(event: Message) -> str:
         event: The V2 message from a persisted event.
 
     Returns:
-        One of ``"message"``, ``"state"``, ``"tool_update"``, or ``"llm_context"``.
+        One of ``"message"``, ``"state"``, ``"tool_update"``, ``"llm_context"``,
+        or ``"error"``.
     """
     if isinstance(event, StateChangedMessage):
         return "state"

--- a/src/akgentic/infra/server/routes/frontend_adapter/angular_v1/ws.py
+++ b/src/akgentic/infra/server/routes/frontend_adapter/angular_v1/ws.py
@@ -16,6 +16,7 @@ from akgentic.core.messages.orchestrator import (
     StateChangedMessage,
 )
 from akgentic.infra.server.routes.frontend_adapter import (
+    ErrorPayload,
     LlmContextPayload,
     MessagePayload,
     StatePayload,
@@ -45,6 +46,8 @@ def _classify_envelope_type(event: Message) -> str:
         return "tool_update"
     if type(event).__name__ == "ContextChangedMessage":
         return "llm_context"
+    if isinstance(event, ErrorMessage):
+        return "error"
     return "message"
 
 
@@ -160,6 +163,22 @@ def _build_llm_context_envelope(event: Message, timestamp: str) -> LlmContextPay
     )
 
 
+def _build_error_envelope(event: ErrorMessage, timestamp: str) -> ErrorPayload:
+    """Build a V1 ``type: "error"`` envelope.
+
+    Args:
+        event: The error message.
+        timestamp: ISO-formatted event timestamp.
+
+    Returns:
+        ErrorPayload with V1 error envelope fields.
+    """
+    return ErrorPayload(
+        message=event.exception_value,
+        timestamp=timestamp,
+    )
+
+
 def wrap_event(event: PersistedEvent) -> WrappedWsEvent:
     """Translate a V2 persisted event into a V1 WebSocket envelope.
 
@@ -175,13 +194,15 @@ def wrap_event(event: PersistedEvent) -> WrappedWsEvent:
     timestamp = event.timestamp.isoformat()
     envelope_type = _classify_envelope_type(msg)
 
-    payload: MessagePayload | StatePayload | ToolUpdatePayload | LlmContextPayload
+    payload: MessagePayload | StatePayload | ToolUpdatePayload | LlmContextPayload | ErrorPayload
     if envelope_type == "state" and isinstance(msg, StateChangedMessage):
         payload = _build_state_envelope(msg, timestamp)
     elif envelope_type == "tool_update" and isinstance(msg, EventMessage):
         payload = _build_tool_update_envelope(msg, timestamp)
     elif envelope_type == "llm_context":
         payload = _build_llm_context_envelope(msg, timestamp)
+    elif envelope_type == "error" and isinstance(msg, ErrorMessage):
+        payload = _build_error_envelope(msg, timestamp)
     else:
         payload = _build_message_envelope(msg, timestamp)
 

--- a/tests/test_angular_v1_adapter.py
+++ b/tests/test_angular_v1_adapter.py
@@ -561,10 +561,10 @@ class TestV1MessagesRoute:
 class TestV1LlmContextRoute:
     """Test V1 LLM context endpoint translation."""
 
-    def test_get_llm_context(
+    def test_get_llm_context_grouped(
         self, v1_client: TestClient, mock_service: MagicMock,
     ) -> None:
-        """AC #4: GET /llm_context/{id} returns LLM context in V1 format."""
+        """AC #5: GET /llm_context/{id} returns context grouped by agent ID."""
         user_msg = UserMessage(content="hello")
         mock_service.get_events.return_value = [
             _make_persisted_event(user_msg, sequence=1),
@@ -572,9 +572,13 @@ class TestV1LlmContextRoute:
         resp = v1_client.get(f"/llm_context/{_TEAM_ID}")
         assert resp.status_code == 200
         data = resp.json()
-        assert len(data) == 1
-        assert data[0]["role"] == "user"
-        assert data[0]["content"] == "hello"
+        assert isinstance(data, dict)
+        # UserMessage has no sender -> "system"
+        assert "system" in data
+        assert "context" in data["system"]
+        assert len(data["system"]["context"]) == 1
+        assert data["system"]["context"][0]["role"] == "user"
+        assert data["system"]["context"][0]["content"] == "hello"
 
     def test_get_llm_context_not_found(
         self, v1_client: TestClient, mock_service: MagicMock,
@@ -591,7 +595,7 @@ class TestV1StatesRoute:
     def test_get_states_not_found(
         self, v1_client: TestClient, mock_service: MagicMock,
     ) -> None:
-        """AC #5: GET /states/{id} returns 404 for unknown team."""
+        """AC #6: GET /states/{id} returns 404 for unknown team."""
         mock_service.get_events.side_effect = ValueError("not found")
         resp = v1_client.get(f"/states/{_TEAM_ID}")
         assert resp.status_code == 404
@@ -599,19 +603,19 @@ class TestV1StatesRoute:
     def test_get_states_empty(
         self, v1_client: TestClient, mock_service: MagicMock,
     ) -> None:
-        """GET /states/{id} returns empty list when no state events."""
+        """GET /states/{id} returns empty dict when no state events."""
         user_msg = UserMessage(content="hello")
         mock_service.get_events.return_value = [
             _make_persisted_event(user_msg, sequence=1),
         ]
         resp = v1_client.get(f"/states/{_TEAM_ID}")
         assert resp.status_code == 200
-        assert resp.json() == []
+        assert resp.json() == {}
 
-    def test_get_states_with_state_events(
+    def test_get_states_grouped(
         self, v1_client: TestClient, mock_service: MagicMock,
     ) -> None:
-        """AC #5: GET /states/{id} returns state changes in V1 format."""
+        """AC #6: GET /states/{id} returns states grouped by agent, latest wins."""
         sender = MagicMock()
         sender.name = "@Manager"
         state_msg = StateChangedMessage(state=BaseState())
@@ -622,10 +626,10 @@ class TestV1StatesRoute:
         resp = v1_client.get(f"/states/{_TEAM_ID}")
         assert resp.status_code == 200
         data = resp.json()
-        assert len(data) == 1
-        assert data[0]["agent"] == "@Manager"
-        assert isinstance(data[0]["state"], dict)
-        assert data[0]["timestamp"] == _NOW.isoformat()
+        assert isinstance(data, dict)
+        assert "@Manager" in data
+        assert data["@Manager"]["schema"] == {}
+        assert isinstance(data["@Manager"]["state"], dict)
 
 
 class TestV1MessageExtraction:
@@ -674,8 +678,10 @@ class TestV1MessageExtraction:
         resp = v1_client.get(f"/llm_context/{_TEAM_ID}")
         assert resp.status_code == 200
         data = resp.json()
+        # Only 1 agent group (system) with 1 context entry
         assert len(data) == 1
-        assert data[0]["content"] == "hello"
+        assert "system" in data
+        assert data["system"]["context"][0]["content"] == "hello"
 
 
 class TestV1StatusResponseModel:
@@ -1033,10 +1039,10 @@ class TestV1FeedbackEndpoints:
 class TestV1TeamConfigsEndpoint:
     """Test GET /team-configs endpoint."""
 
-    def test_get_team_configs(
+    def test_get_team_configs_dict(
         self, v1_client: TestClient, mock_service: MagicMock,
     ) -> None:
-        """AC3: GET /team-configs returns team catalog entries."""
+        """AC4: GET /team-configs returns dict keyed by team name."""
         mock_entry = MagicMock()
         mock_entry.id = "team-1"
         mock_entry.model_dump.return_value = {"id": "team-1", "name": "My Team"}
@@ -1044,18 +1050,23 @@ class TestV1TeamConfigsEndpoint:
         resp = v1_client.get("/team-configs/")
         assert resp.status_code == 200
         data = resp.json()
-        assert len(data) == 1
-        assert data[0]["id"] == "team-1"
-        assert data[0]["type"] == "team"
+        assert isinstance(data, dict)
+        assert "team-1" in data
+        assert data["team-1"]["module"] == "team-1"
+        assert isinstance(data["team-1"]["setup"], str)
+        import json
+
+        setup_parsed = json.loads(data["team-1"]["setup"])
+        assert setup_parsed["id"] == "team-1"
 
     def test_get_team_configs_empty(
         self, v1_client: TestClient, mock_service: MagicMock,
     ) -> None:
-        """GET /team-configs returns empty list when no entries."""
+        """GET /team-configs returns empty dict when no entries."""
         v1_client.app.state.services.team_catalog.list.return_value = []  # type: ignore[union-attr]
         resp = v1_client.get("/team-configs/")
         assert resp.status_code == 200
-        assert resp.json() == []
+        assert resp.json() == {}
 
 
 class TestV1ConfigEndpoints:
@@ -1167,3 +1178,148 @@ class TestV1AdapterNewRoutes:
         assert "/relaunch/{id}/message/{msg_id}" in paths
         assert "/state/{id}/of/{agent}" in paths
         assert "/process/{id}/description" in paths
+        assert "/auth/me" in paths
+        assert "/auth/ws-ticket" in paths
+        assert "/auth/logout" in paths
+
+
+# ---------------------------------------------------------------------------
+# Story 8.2: Auth stub endpoints (AC #1, #2, #3)
+# ---------------------------------------------------------------------------
+
+
+class TestV1AuthStubs:
+    """Test auth stub endpoints for Community tier NoAuth."""
+
+    def test_auth_me(self, v1_client: TestClient) -> None:
+        """AC1: GET /auth/me returns anonymous user stub."""
+        resp = v1_client.get("/auth/me")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data == {"user_id": "anonymous", "email": "", "name": "Anonymous"}
+
+    def test_auth_ws_ticket(self, v1_client: TestClient) -> None:
+        """AC2: GET /auth/ws-ticket returns noauth ticket stub."""
+        resp = v1_client.get("/auth/ws-ticket")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data == {"ticket": "noauth"}
+
+    def test_auth_logout(self, v1_client: TestClient) -> None:
+        """AC3: GET /auth/logout returns none auth_type stub."""
+        resp = v1_client.get("/auth/logout")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data == {"auth_type": "none"}
+
+
+# ---------------------------------------------------------------------------
+# Story 8.2: Grouped response shapes (AC #4, #5, #6)
+# ---------------------------------------------------------------------------
+
+
+class TestV1GroupedResponses:
+    """Test grouped dict response shapes for team-configs, llm_context, states."""
+
+    def test_llm_context_multi_agent_grouping(
+        self, v1_client: TestClient, mock_service: MagicMock,
+    ) -> None:
+        """AC5: llm_context groups entries by agent ID."""
+        sender_a = MagicMock()
+        sender_a.name = "@AgentA"
+        sender_b = MagicMock()
+        sender_b.name = "@AgentB"
+        msg_a = UserMessage(content="hello from A")
+        msg_a.sender = sender_a
+        msg_b = ResultMessage(content="hello from B")
+        msg_b.sender = sender_b
+        mock_service.get_events.return_value = [
+            _make_persisted_event(msg_a, sequence=1),
+            _make_persisted_event(msg_b, sequence=2),
+        ]
+        resp = v1_client.get(f"/llm_context/{_TEAM_ID}")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "@AgentA" in data
+        assert "@AgentB" in data
+        assert len(data["@AgentA"]["context"]) == 1
+        assert len(data["@AgentB"]["context"]) == 1
+        assert data["@AgentA"]["context"][0]["content"] == "hello from A"
+        assert data["@AgentB"]["context"][0]["content"] == "hello from B"
+
+    def test_states_latest_wins(
+        self, v1_client: TestClient, mock_service: MagicMock,
+    ) -> None:
+        """AC6: states returns only latest state per agent."""
+        sender = MagicMock()
+        sender.name = "@Manager"
+        state1 = StateChangedMessage(state=BaseState())
+        state1.sender = sender
+        state2 = StateChangedMessage(state=BaseState())
+        state2.sender = sender
+        mock_service.get_events.return_value = [
+            _make_persisted_event(state1, sequence=1),
+            _make_persisted_event(state2, sequence=2),
+        ]
+        resp = v1_client.get(f"/states/{_TEAM_ID}")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert isinstance(data, dict)
+        assert "@Manager" in data
+        # Only one entry per agent (latest wins)
+        assert data["@Manager"]["schema"] == {}
+        assert isinstance(data["@Manager"]["state"], dict)
+
+    def test_team_configs_multiple_entries(
+        self, v1_client: TestClient, mock_service: MagicMock,
+    ) -> None:
+        """AC4: team-configs dict has entry per team."""
+        entry_a = MagicMock()
+        entry_a.id = "alpha"
+        entry_a.model_dump.return_value = {"id": "alpha", "name": "Alpha Team"}
+        entry_b = MagicMock()
+        entry_b.id = "beta"
+        entry_b.model_dump.return_value = {"id": "beta", "name": "Beta Team"}
+        v1_client.app.state.services.team_catalog.list.return_value = [entry_a, entry_b]  # type: ignore[union-attr]
+        resp = v1_client.get("/team-configs/")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "alpha" in data
+        assert "beta" in data
+        assert data["alpha"]["module"] == "alpha"
+        assert data["beta"]["module"] == "beta"
+
+
+# ---------------------------------------------------------------------------
+# Story 8.2: WebSocket error envelope (AC #7)
+# ---------------------------------------------------------------------------
+
+
+class TestV1WsErrorEnvelope:
+    """Test WebSocket error envelope classification and wrapping."""
+
+    def test_classify_error_message(self) -> None:
+        """AC7: _classify_envelope_type returns 'error' for ErrorMessage."""
+        from akgentic.core.messages.orchestrator import ErrorMessage
+
+        from akgentic.infra.server.routes.frontend_adapter.angular_v1.ws import (
+            _classify_envelope_type,
+        )
+
+        err = ErrorMessage(exception_type="RuntimeError", exception_value="something broke")
+        assert _classify_envelope_type(err) == "error"
+
+    def test_wrap_event_error_envelope(self) -> None:
+        """AC7: wrap_event produces ErrorPayload with message field."""
+        from akgentic.core.messages.orchestrator import ErrorMessage
+
+        from akgentic.infra.server.routes.frontend_adapter import ErrorPayload
+        from akgentic.infra.server.routes.frontend_adapter.angular_v1.ws import wrap_event
+
+        err = ErrorMessage(exception_type="RuntimeError", exception_value="something broke")
+        event = _make_persisted_event(err)
+        result = wrap_event(event)
+        assert isinstance(result.payload, ErrorPayload)
+        assert result.payload.type == "error"
+        assert result.payload.message == "something broke"
+        assert result.payload.timestamp == _NOW.isoformat()

--- a/tests/test_angular_v1_adapter.py
+++ b/tests/test_angular_v1_adapter.py
@@ -1246,6 +1246,9 @@ class TestV1GroupedResponses:
         assert len(data["@AgentB"]["context"]) == 1
         assert data["@AgentA"]["context"][0]["content"] == "hello from A"
         assert data["@AgentB"]["context"][0]["content"] == "hello from B"
+        # Verify timestamp is present in context entries (AC5 shape requirement)
+        assert "timestamp" in data["@AgentA"]["context"][0]
+        assert "timestamp" in data["@AgentB"]["context"][0]
 
     def test_states_latest_wins(
         self, v1_client: TestClient, mock_service: MagicMock,
@@ -1269,6 +1272,32 @@ class TestV1GroupedResponses:
         # Only one entry per agent (latest wins)
         assert data["@Manager"]["schema"] == {}
         assert isinstance(data["@Manager"]["state"], dict)
+
+    def test_states_multi_agent_grouping(
+        self, v1_client: TestClient, mock_service: MagicMock,
+    ) -> None:
+        """AC6: states groups by agent ID with multiple agents."""
+        sender_a = MagicMock()
+        sender_a.name = "@AgentA"
+        sender_b = MagicMock()
+        sender_b.name = "@AgentB"
+        state_a = StateChangedMessage(state=BaseState())
+        state_a.sender = sender_a
+        state_b = StateChangedMessage(state=BaseState())
+        state_b.sender = sender_b
+        mock_service.get_events.return_value = [
+            _make_persisted_event(state_a, sequence=1),
+            _make_persisted_event(state_b, sequence=2),
+        ]
+        resp = v1_client.get(f"/states/{_TEAM_ID}")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "@AgentA" in data
+        assert "@AgentB" in data
+        assert data["@AgentA"]["schema"] == {}
+        assert data["@AgentB"]["schema"] == {}
+        assert isinstance(data["@AgentA"]["state"], dict)
+        assert isinstance(data["@AgentB"]["state"], dict)
 
     def test_team_configs_multiple_entries(
         self, v1_client: TestClient, mock_service: MagicMock,

--- a/tests/test_angular_v1_ws.py
+++ b/tests/test_angular_v1_ws.py
@@ -311,7 +311,7 @@ class TestWrapSentMessageNonContent:
 
 
 # ---------------------------------------------------------------------------
-# Task 4.9: ErrorMessage → type: "message", message_type: "system"
+# Task 4.9: ErrorMessage → type: "error" (Story 8.2 AC #7)
 # ---------------------------------------------------------------------------
 
 
@@ -319,25 +319,24 @@ class TestWrapErrorMessage:
     """Test ErrorMessage event wrapping."""
 
     def test_error_message_type(self) -> None:
-        """ErrorMessage produces type: 'message' envelope."""
+        """ErrorMessage produces type: 'error' envelope."""
         msg = ErrorMessage(
             exception_type="ValueError",
             exception_value="something went wrong",
         )
         event = _make_persisted_event(msg)
         result = wrap_event(event)
-        assert result.payload.type == "message"
+        assert result.payload.type == "error"
 
-    def test_error_message_classified_as_system(self) -> None:
-        """ErrorMessage message_type is 'system'."""
+    def test_error_message_has_message_field(self) -> None:
+        """ErrorMessage envelope has message field with exception_value."""
         msg = ErrorMessage(
             exception_type="ValueError",
             exception_value="something went wrong",
         )
         event = _make_persisted_event(msg)
         result = wrap_event(event)
-        assert result.payload.message_type == "system"
-        assert result.payload.content == "something went wrong"
+        assert result.payload.message == "something went wrong"
 
 
 # ---------------------------------------------------------------------------
@@ -412,7 +411,7 @@ class TestWrappedEventSerialization:
         event = _make_persisted_event(msg)
         result = wrap_event(event)
         json_str = result.model_dump_json()
-        assert '"type":"message"' in json_str
+        assert '"type":"error"' in json_str
         assert '"oops"' in json_str
 
     def test_tool_update_json_serializable(self) -> None:

--- a/tests/test_angular_v1_ws.py
+++ b/tests/test_angular_v1_ws.py
@@ -25,6 +25,7 @@ from akgentic.core.messages.orchestrator import (
 from akgentic.team.models import PersistedEvent
 
 from akgentic.infra.server.routes.frontend_adapter import (
+    ErrorPayload,
     LlmContextPayload,
     MessagePayload,
     StatePayload,
@@ -545,6 +546,16 @@ class TestDiscriminatedUnionDeserialization:
         assert isinstance(event.payload, LlmContextPayload)
         assert event.payload.context == {"tokens": 42}
 
+    def test_error_payload_from_json(self) -> None:
+        """JSON with type 'error' deserializes to ErrorPayload."""
+        json_str = (
+            '{"payload":{"type":"error","message":"something broke",'
+            '"timestamp":"2026-01-01T00:00:00"}}'
+        )
+        event = WrappedWsEvent.model_validate_json(json_str)
+        assert isinstance(event.payload, ErrorPayload)
+        assert event.payload.message == "something broke"
+
 
 class TestUnknownPayloadFallback:
     """Test UnknownPayload catch-all for unrecognised event types."""
@@ -632,6 +643,18 @@ class TestSerializationRoundTrip:
         restored = WrappedWsEvent.model_validate_json(original.model_dump_json())
         assert isinstance(restored.payload, LlmContextPayload)
         assert restored.payload.context == {"tokens": 99}
+
+    def test_error_round_trip(self) -> None:
+        """ErrorPayload survives serialization round-trip."""
+        original = WrappedWsEvent(
+            payload=ErrorPayload(
+                message="something broke",
+                timestamp="2026-01-01T00:00:00",
+            ),
+        )
+        restored = WrappedWsEvent.model_validate_json(original.model_dump_json())
+        assert isinstance(restored.payload, ErrorPayload)
+        assert restored.payload.message == "something broke"
 
     def test_unknown_round_trip(self) -> None:
         """UnknownPayload survives serialization round-trip."""


### PR DESCRIPTION
## Summary

- Added 3 auth stub routes (/me, /ws-ticket, /logout) for Community tier NoAuth
- Changed GET /team-configs from list to dict keyed by team name with module/setup keys
- Changed GET /llm_context/{id} from flat list to dict grouped by agent ID
- Changed GET /states/{id} from flat list to dict grouped by agent ID (latest state per agent)
- Added ErrorPayload model and WebSocket error envelope classification
- Code review: fixed docstring, added 3 missing tests, strengthened test assertions

## Verification

- 669 tests pass, 95.31% coverage
- ruff: clean
- mypy: clean

Closes #79