### PR TITLE
fix: update CI workspace ref to master and fix coverage badge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: b12consulting/akgentic-quick-start
-          ref: feat/98-akgentic-infra-dev  # required until workspace PR merges akgentic-infra
+          ref: master
           submodules: recursive
           token: ${{ secrets.GH_PAT }}
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![Coverage](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/b12consulting/REPLACE_WITH_GIST_ID/raw/coverage.json)
+![Coverage](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/b12consulting/d0b84268aa19a7460fe186dbf23e500d/raw/coverage.json)
 
 # akgentic-infra
 


### PR DESCRIPTION
## Summary

- Update CI workspace checkout ref from hardcoded `feat/98-akgentic-infra-dev` to `master`
- Fix README coverage badge URL with actual Gist ID

Relates to #83