### PR TITLE
feat: implement community tier application logging

### DIFF
--- a/src/akgentic/__init__.py
+++ b/src/akgentic/__init__.py
@@ -1,2 +1,3 @@
 """Namespace package — allows akgentic.core, akgentic.infra, etc. to coexist."""
+
 __path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/src/akgentic/infra/adapters/channel_dispatcher.py
+++ b/src/akgentic/infra/adapters/channel_dispatcher.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 import uuid
 from typing import TYPE_CHECKING
 
@@ -10,6 +11,8 @@ from akgentic.core.messages import SentMessage
 if TYPE_CHECKING:
     from akgentic.core.messages import Message
     from akgentic.infra.protocols.channels import InteractionChannelAdapter
+
+logger = logging.getLogger(__name__)
 
 
 class InteractionChannelDispatcher:
@@ -24,9 +27,7 @@ class InteractionChannelDispatcher:
     message is silently skipped (web channel handles it via WebSocket).
     """
 
-    def __init__(
-        self, team_id: uuid.UUID, adapters: list[InteractionChannelAdapter]
-    ) -> None:
+    def __init__(self, team_id: uuid.UUID, adapters: list[InteractionChannelAdapter]) -> None:
         self._adapters = list(adapters)
         self._team_id = team_id
         self._restoring = False
@@ -50,11 +51,17 @@ class InteractionChannelDispatcher:
             return
         if not isinstance(msg, SentMessage):
             return
+        logger.debug(
+            "Dispatching SentMessage to %d adapter(s): team_id=%s",
+            len(self._adapters),
+            self._team_id,
+        )
         for adapter in self._adapters:
             if adapter.matches(msg):
                 adapter.deliver(msg)
 
     def on_stop(self) -> None:
         """Clean up all registered adapters when the team stops."""
+        logger.debug("ChannelDispatcher stopped: team_id=%s", self._team_id)
         for adapter in self._adapters:
             adapter.on_stop(self._team_id)

--- a/src/akgentic/infra/adapters/channel_parser_registry.py
+++ b/src/akgentic/infra/adapters/channel_parser_registry.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import importlib
+import logging
 
 from pydantic import BaseModel, Field
 
@@ -10,6 +11,8 @@ from akgentic.infra.protocols.channels import (
     ChannelParser,
     InteractionChannelAdapter,
 )
+
+logger = logging.getLogger(__name__)
 
 
 class ChannelConfig(BaseModel):
@@ -69,14 +72,18 @@ class ChannelParserRegistry:
     def _load(self, channels_config: dict[str, ChannelConfig]) -> None:
         """Resolve FQCNs and instantiate parsers and adapters."""
         for _channel_key, cfg in channels_config.items():
+            logger.info(
+                "Loading channel: %s (parser=%s, adapter=%s)",
+                _channel_key,
+                cfg.parser_fqcn,
+                cfg.adapter_fqcn,
+            )
             parser_cls = import_class(cfg.parser_fqcn)
             adapter_cls = import_class(cfg.adapter_fqcn)
 
             parser = parser_cls(**cfg.config)
             if not isinstance(parser, ChannelParser):
-                msg = (
-                    f"Class '{cfg.parser_fqcn}' does not satisfy ChannelParser protocol"
-                )
+                msg = f"Class '{cfg.parser_fqcn}' does not satisfy ChannelParser protocol"
                 raise TypeError(msg)
 
             adapter = adapter_cls(**cfg.config)
@@ -89,10 +96,13 @@ class ChannelParserRegistry:
 
             self._parsers[parser.channel_name] = parser
             self._adapters.append(adapter)
+        logger.debug("Channel parser registry loaded: %d channel(s)", len(self._parsers))
 
     def get_parser(self, channel_name: str) -> ChannelParser | None:
         """Return the parser for the given channel name, or None."""
-        return self._parsers.get(channel_name)
+        parser = self._parsers.get(channel_name)
+        logger.debug("Parser lookup: channel=%s, found=%s", channel_name, parser is not None)
+        return parser
 
     def get_adapters(self) -> list[InteractionChannelAdapter]:
         """Return all resolved adapters."""

--- a/src/akgentic/infra/adapters/local_ingestion.py
+++ b/src/akgentic/infra/adapters/local_ingestion.py
@@ -2,11 +2,14 @@
 
 from __future__ import annotations
 
+import logging
 import uuid
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from akgentic.infra.server.services.team_service import TeamService
+
+logger = logging.getLogger(__name__)
 
 
 class LocalIngestion:
@@ -63,6 +66,7 @@ class LocalIngestion:
             content: Message content from the human.
             original_message_id: Optional ID of the message being replied to.
         """
+        logger.info("Inbound reply: team_id=%s", team_id)
         self._require_team_service().send_message(team_id, content)
 
     async def initiate_team(
@@ -81,7 +85,10 @@ class LocalIngestion:
         Returns:
             The newly created team's ID.
         """
+        logger.info("Inbound initiation: catalog=%s", catalog_entry_id)
+        logger.debug("Initiation user: %s", channel_user_id)
         ts = self._require_team_service()
         process = ts.create_team(catalog_entry_id, user_id=channel_user_id)
         ts.send_message(process.team_id, content)
+        logger.debug("Team initiated: team_id=%s", process.team_id)
         return process.team_id

--- a/src/akgentic/infra/adapters/local_placement.py
+++ b/src/akgentic/infra/adapters/local_placement.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 import uuid
 from typing import TYPE_CHECKING
 
@@ -12,6 +13,9 @@ from akgentic.team.ports import ServiceRegistry
 if TYPE_CHECKING:
     from akgentic.infra.protocols.team_handle import TeamHandle
     from akgentic.team.models import TeamCard
+
+
+logger = logging.getLogger(__name__)
 
 
 class LocalPlacement:
@@ -46,5 +50,7 @@ class LocalPlacement:
         Returns:
             A LocalTeamHandle for interacting with the newly created team.
         """
+        logger.debug("LocalPlacement creating team: user_id=%s", user_id)
         runtime = self._team_manager.create_team(team_card, user_id)
+        logger.debug("Team created locally: team_id=%s", runtime.id)
         return LocalTeamHandle(runtime)

--- a/src/akgentic/infra/adapters/local_runtime_cache.py
+++ b/src/akgentic/infra/adapters/local_runtime_cache.py
@@ -2,9 +2,12 @@
 
 from __future__ import annotations
 
+import logging
 import uuid
 
 from akgentic.infra.protocols.team_handle import TeamHandle
+
+logger = logging.getLogger(__name__)
 
 
 class LocalRuntimeCache:
@@ -22,6 +25,7 @@ class LocalRuntimeCache:
 
     def store(self, team_id: uuid.UUID, handle: TeamHandle) -> None:
         """Store a team handle in the cache."""
+        logger.debug("Cache store: team_id=%s", team_id)
         self._handles[team_id] = handle
 
     def get(self, team_id: uuid.UUID) -> TeamHandle | None:
@@ -30,4 +34,5 @@ class LocalRuntimeCache:
 
     def remove(self, team_id: uuid.UUID) -> None:
         """Remove a team handle from the cache (no-op if absent)."""
+        logger.debug("Cache remove: team_id=%s", team_id)
         self._handles.pop(team_id, None)

--- a/src/akgentic/infra/adapters/local_worker_handle.py
+++ b/src/akgentic/infra/adapters/local_worker_handle.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 import uuid
 from typing import TYPE_CHECKING
 
@@ -12,6 +13,9 @@ from akgentic.team.ports import ServiceRegistry
 if TYPE_CHECKING:
     from akgentic.infra.protocols.team_handle import TeamHandle
     from akgentic.team.models import Process
+
+
+logger = logging.getLogger(__name__)
 
 
 class LocalWorkerHandle:
@@ -31,14 +35,17 @@ class LocalWorkerHandle:
 
     def stop_team(self, team_id: uuid.UUID) -> None:
         """Stop a running team by delegating to TeamManager."""
+        logger.debug("Stopping team: %s", team_id)
         self._team_manager.stop_team(team_id)
 
     def delete_team(self, team_id: uuid.UUID) -> None:
         """Delete a team by delegating to TeamManager."""
+        logger.debug("Deleting team: %s", team_id)
         self._team_manager.delete_team(team_id)
 
     def resume_team(self, team_id: uuid.UUID) -> TeamHandle:
         """Resume a stopped team and return a LocalTeamHandle."""
+        logger.debug("Resuming team: %s", team_id)
         runtime = self._team_manager.resume_team(team_id)
         return LocalTeamHandle(runtime)
 

--- a/src/akgentic/infra/adapters/null_channel_registry.py
+++ b/src/akgentic/infra/adapters/null_channel_registry.py
@@ -12,14 +12,10 @@ class NullChannelRegistry:
     disabled but the ``ChannelRegistry`` protocol contract is satisfied.
     """
 
-    async def register(
-        self, channel: str, channel_user_id: str, team_id: uuid.UUID
-    ) -> None:
+    async def register(self, channel: str, channel_user_id: str, team_id: uuid.UUID) -> None:
         """No-op — registration is not supported when channels are disabled."""
 
-    async def find_team(
-        self, channel: str, channel_user_id: str
-    ) -> uuid.UUID | None:
+    async def find_team(self, channel: str, channel_user_id: str) -> uuid.UUID | None:
         """Always returns None — no channel mappings exist."""
         return None
 

--- a/src/akgentic/infra/adapters/telegram_adapter.py
+++ b/src/akgentic/infra/adapters/telegram_adapter.py
@@ -77,6 +77,7 @@ class TelegramChannelAdapter:
         """
         chat_id = msg.recipient.name
         text = getattr(msg.message, "content", None) or str(msg.message)
+        logger.debug("Delivering message to Telegram chat %s", chat_id)
 
         try:
             response = self._client.post(
@@ -98,4 +99,5 @@ class TelegramChannelAdapter:
         Args:
             team_id: The team being stopped.
         """
+        logger.debug("TelegramAdapter stopped: team_id=%s", team_id)
         self._client.close()

--- a/src/akgentic/infra/adapters/telegram_parser.py
+++ b/src/akgentic/infra/adapters/telegram_parser.py
@@ -27,9 +27,7 @@ class TelegramChannelParser:
         default_catalog_entry: Catalog entry ID for initiating new teams.
     """
 
-    def __init__(
-        self, default_catalog_entry: str = "default", **_kwargs: str
-    ) -> None:
+    def __init__(self, default_catalog_entry: str = "default", **_kwargs: str) -> None:
         self._default_catalog_entry = default_catalog_entry
 
     @property
@@ -85,6 +83,7 @@ class TelegramChannelParser:
 
         message_id = message.get("message_id")
 
+        logger.debug("Parsing Telegram update: chat_id=%s", chat_id)
         return ChannelMessage(
             content=text,
             channel_user_id=str(chat_id),

--- a/src/akgentic/infra/adapters/telemetry_subscriber.py
+++ b/src/akgentic/infra/adapters/telemetry_subscriber.py
@@ -22,6 +22,7 @@ class TelemetrySubscriber:
     """
 
     def __init__(self) -> None:
+        logger.debug("TelemetrySubscriber initialized")
         self._restoring = False
 
     def set_restoring(self, restoring: bool) -> None:
@@ -41,6 +42,7 @@ class TelemetrySubscriber:
             "orchestrator event: {msg_type}",
             msg_type=msg_type,
         )
+        logger.debug("Telemetry event: %s", msg_type)
 
     def on_stop(self) -> None:
         """Cleanup hook — logs shutdown."""

--- a/src/akgentic/infra/adapters/websocket_subscriber.py
+++ b/src/akgentic/infra/adapters/websocket_subscriber.py
@@ -2,11 +2,14 @@
 
 from __future__ import annotations
 
+import logging
 import queue
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from akgentic.core.messages import Message
+
+logger = logging.getLogger(__name__)
 
 
 class WebSocketEventSubscriber:
@@ -31,9 +34,11 @@ class WebSocketEventSubscriber:
         """
         json_str: str = msg.model_dump_json()
         self._queue.put(json_str)
+        logger.debug("Event queued: %s", type(msg).__name__)
 
     def on_stop(self) -> None:
         """Signal connection closure by enqueuing a sentinel None."""
+        logger.debug("WebSocketEventSubscriber stopped, sentinel queued")
         self._queue.put(None)
 
     def get_queue(self) -> queue.Queue[str | None]:

--- a/src/akgentic/infra/adapters/yaml_channel_registry.py
+++ b/src/akgentic/infra/adapters/yaml_channel_registry.py
@@ -2,10 +2,13 @@
 
 from __future__ import annotations
 
+import logging
 import uuid
 from pathlib import Path
 
 import yaml
+
+logger = logging.getLogger(__name__)
 
 
 class YamlChannelRegistry:
@@ -34,23 +37,23 @@ class YamlChannelRegistry:
     def _save(self, data: dict[str, dict[str, str]]) -> None:
         """Write registry data to YAML."""
         self._path.parent.mkdir(parents=True, exist_ok=True)
-        self._path.write_text(
-            yaml.safe_dump(data, default_flow_style=False), encoding="utf-8"
-        )
+        self._path.write_text(yaml.safe_dump(data, default_flow_style=False), encoding="utf-8")
 
-    async def register(
-        self, channel: str, channel_user_id: str, team_id: uuid.UUID
-    ) -> None:
+    async def register(self, channel: str, channel_user_id: str, team_id: uuid.UUID) -> None:
         """Add a channel-user → team mapping."""
         data = self._load()
         if channel not in data:
             data[channel] = {}
         data[channel][channel_user_id] = str(team_id)
         self._save(data)
+        logger.debug(
+            "Channel registry: registered %s/%s → team %s",
+            channel,
+            channel_user_id,
+            team_id,
+        )
 
-    async def find_team(
-        self, channel: str, channel_user_id: str
-    ) -> uuid.UUID | None:
+    async def find_team(self, channel: str, channel_user_id: str) -> uuid.UUID | None:
         """Look up the team for a channel user, or return None."""
         data = self._load()
         channel_data = data.get(channel)
@@ -58,7 +61,9 @@ class YamlChannelRegistry:
             return None
         team_str = channel_data.get(channel_user_id)
         if team_str is None:
+            logger.debug("Channel registry: lookup %s/%s → None", channel, channel_user_id)
             return None
+        logger.debug("Channel registry: lookup %s/%s → %s", channel, channel_user_id, team_str)
         return uuid.UUID(team_str)
 
     async def deregister(self, channel: str, channel_user_id: str) -> None:
@@ -71,3 +76,4 @@ class YamlChannelRegistry:
         if not channel_data:
             del data[channel]
         self._save(data)
+        logger.debug("Channel registry: deregistered %s/%s", channel, channel_user_id)

--- a/src/akgentic/infra/cli/client.py
+++ b/src/akgentic/infra/cli/client.py
@@ -146,9 +146,7 @@ class ApiClient:
 
     def restore_team(self, team_id: str) -> TeamInfo:
         """POST /teams/{team_id}/restore → restored TeamInfo model."""
-        return TeamInfo.model_validate(
-            self._request("POST", f"/teams/{team_id}/restore").json()
-        )
+        return TeamInfo.model_validate(self._request("POST", f"/teams/{team_id}/restore").json())
 
     def get_events(self, team_id: str) -> list[EventInfo]:
         """GET /teams/{team_id}/events → list of EventInfo models."""

--- a/src/akgentic/infra/protocols/channels.py
+++ b/src/akgentic/infra/protocols/channels.py
@@ -168,9 +168,7 @@ class ChannelRegistry(Protocol):
       multi-instance deployments.
     """
 
-    async def register(
-        self, channel: str, channel_user_id: str, team_id: uuid.UUID
-    ) -> None:
+    async def register(self, channel: str, channel_user_id: str, team_id: uuid.UUID) -> None:
         """Register a mapping from a channel user to a team.
 
         Args:
@@ -180,9 +178,7 @@ class ChannelRegistry(Protocol):
         """
         ...
 
-    async def find_team(
-        self, channel: str, channel_user_id: str
-    ) -> uuid.UUID | None:
+    async def find_team(self, channel: str, channel_user_id: str) -> uuid.UUID | None:
         """Find the team associated with a channel user.
 
         Args:

--- a/src/akgentic/infra/server/app.py
+++ b/src/akgentic/infra/server/app.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import logging
+
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
@@ -17,6 +19,7 @@ from akgentic.catalog.api.team_router import set_catalog as set_team_catalog
 from akgentic.catalog.api.template_router import set_catalog as set_template_catalog
 from akgentic.catalog.api.tool_router import set_catalog as set_tool_catalog
 from akgentic.infra.server.deps import TierServices
+from akgentic.infra.server.logging_config import configure_logging
 from akgentic.infra.server.routes.frontend_adapter import load_frontend_adapter
 from akgentic.infra.server.routes.teams import router as teams_router
 from akgentic.infra.server.routes.webhook import router as webhook_router
@@ -25,6 +28,8 @@ from akgentic.infra.server.routes.ws import ConnectionManager
 from akgentic.infra.server.routes.ws import router as ws_router
 from akgentic.infra.server.services.team_service import TeamService
 from akgentic.infra.server.settings import ServerSettings
+
+logger = logging.getLogger(__name__)
 
 
 def create_app(
@@ -44,6 +49,8 @@ def create_app(
         Configured FastAPI application instance.
     """
     settings = settings or ServerSettings()
+    configure_logging(settings.log_level)
+    logger.info("Logging configured: level=%s", settings.log_level)
     team_service = TeamService(services)
     _wire_ingestion(services, team_service)
     return _build_app(services, team_service, settings)
@@ -86,6 +93,7 @@ def _build_app(
     _inject_catalogs(services)
     _mount_routes(app, settings)
     add_exception_handlers(app)
+    logger.info("Building app: routes mounted, CORS origins=%s", settings.cors_origins)
     return app
 
 
@@ -139,3 +147,4 @@ def _mount_routes(app: FastAPI, settings: ServerSettings) -> None:
         adapter = load_frontend_adapter(settings.frontend_adapter)
         adapter.register_routes(app)
         app.state.frontend_adapter = adapter
+        logger.debug("Frontend adapter loaded: %s", settings.frontend_adapter)

--- a/src/akgentic/infra/server/logging_config.py
+++ b/src/akgentic/infra/server/logging_config.py
@@ -1,0 +1,37 @@
+"""Logging configuration — explicit root logger setup for the akgentic-infra server."""
+
+from __future__ import annotations
+
+import logging
+
+_THIRD_PARTY_LOGGERS = (
+    "uvicorn",
+    "uvicorn.access",
+    "uvicorn.error",
+    "httpx",
+    "httpcore",
+    "pydantic_ai",
+)
+
+_FORMAT = "%(asctime)s %(levelname)-8s [%(name)s] %(message)s"
+_DATEFMT = "%Y-%m-%d %H:%M:%S"
+
+
+def configure_logging(level: str) -> None:
+    """Configure the root logger with a human-readable StreamHandler.
+
+    Uses explicit handler assignment (not ``basicConfig``) to guarantee
+    deterministic behaviour regardless of import order.
+
+    Args:
+        level: Log level name (e.g. "DEBUG", "INFO").
+    """
+    handler = logging.StreamHandler()
+    handler.setFormatter(logging.Formatter(fmt=_FORMAT, datefmt=_DATEFMT))
+
+    root = logging.getLogger()
+    root.setLevel(level)
+    root.handlers = [handler]
+
+    for name in _THIRD_PARTY_LOGGERS:
+        logging.getLogger(name).setLevel(logging.WARNING)

--- a/src/akgentic/infra/server/routes/frontend_adapter/__init__.py
+++ b/src/akgentic/infra/server/routes/frontend_adapter/__init__.py
@@ -176,9 +176,7 @@ def load_frontend_adapter(fqdn: str) -> FrontendAdapter:
     try:
         instance = cls()
     except TypeError as exc:
-        raise TypeError(
-            f"Cannot instantiate frontend adapter '{fqdn}': {exc}"
-        ) from exc
+        raise TypeError(f"Cannot instantiate frontend adapter '{fqdn}': {exc}") from exc
     if not isinstance(instance, FrontendAdapter):
         raise TypeError(f"Class '{fqdn}' does not implement FrontendAdapter protocol")
 

--- a/src/akgentic/infra/server/routes/frontend_adapter/angular_v1/router.py
+++ b/src/akgentic/infra/server/routes/frontend_adapter/angular_v1/router.py
@@ -290,11 +290,13 @@ def get_llm_context(
             continue
         agent_id = get_sender_name(ev.event)
         grouped.setdefault(agent_id, [])
-        grouped[agent_id].append({
-            "role": classify_message_type(ev.event),
-            "content": content,
-            "timestamp": ev.timestamp.isoformat(),
-        })
+        grouped[agent_id].append(
+            {
+                "role": classify_message_type(ev.event),
+                "content": content,
+                "timestamp": ev.timestamp.isoformat(),
+            }
+        )
     return {agent_id: {"context": entries} for agent_id, entries in grouped.items()}
 
 
@@ -327,7 +329,9 @@ def get_states(
 
 
 @process_router.patch(
-    "/{id}/description", status_code=200, response_model=V1StatusResponse,
+    "/{id}/description",
+    status_code=200,
+    response_model=V1StatusResponse,
 )
 def update_description(
     id: str,
@@ -346,7 +350,9 @@ def update_description(
 
 
 @relaunch_router.post(
-    "/{id}/message/{msg_id}", status_code=200, response_model=V1StatusResponse,
+    "/{id}/message/{msg_id}",
+    status_code=200,
+    response_model=V1StatusResponse,
 )
 def relaunch_message(
     id: str,
@@ -377,7 +383,9 @@ def relaunch_message(
 
 
 @state_update_router.patch(
-    "/{id}/of/{agent}", status_code=200, response_model=V1StatusResponse,
+    "/{id}/of/{agent}",
+    status_code=200,
+    response_model=V1StatusResponse,
 )
 def update_agent_state(
     id: str,
@@ -409,7 +417,8 @@ def _get_catalog_for_type(request: Request, config_type: str) -> Any:
     catalog = catalogs.get(config_type)
     if catalog is None:
         raise HTTPException(
-            status_code=400, detail=f"Unknown config type: {config_type}",
+            status_code=400,
+            detail=f"Unknown config type: {config_type}",
         )
     return catalog
 
@@ -431,7 +440,9 @@ def get_config(config_type: str, request: Request) -> list[V1ConfigEntry]:
 
 @config_router.put("/{config_type}", status_code=200, response_model=V1StatusResponse)
 def put_config(
-    config_type: str, body: V1ConfigPutBody, request: Request,
+    config_type: str,
+    body: V1ConfigPutBody,
+    request: Request,
 ) -> V1StatusResponse:
     """PUT /config/{config_type} -> create or update a catalog entry."""
     catalog = _get_catalog_for_type(request, config_type)
@@ -448,10 +459,14 @@ def put_config(
 
 
 @config_router.delete(
-    "/{config_type}/{config_id}", status_code=200, response_model=V1StatusResponse,
+    "/{config_type}/{config_id}",
+    status_code=200,
+    response_model=V1StatusResponse,
 )
 def delete_config(
-    config_type: str, config_id: str, request: Request,
+    config_type: str,
+    config_id: str,
+    request: Request,
 ) -> V1StatusResponse:
     """DELETE /config/{config_type}/{config_id} -> delete a catalog entry."""
     catalog = _get_catalog_for_type(request, config_type)

--- a/src/akgentic/infra/server/routes/teams.py
+++ b/src/akgentic/infra/server/routes/teams.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 import uuid
 from typing import NoReturn, cast
 
@@ -19,6 +20,8 @@ from akgentic.infra.server.models import (
 )
 from akgentic.infra.server.services.team_service import TeamService
 from akgentic.team.models import Process
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/teams", tags=["teams"])
 
@@ -46,6 +49,7 @@ def create_team(
     service: TeamService = Depends(get_team_service),
 ) -> TeamResponse:
     """Create a new team from a catalog entry."""
+    logger.info("POST /teams — catalog_entry=%s", body.catalog_entry_id)
     try:
         # Community-tier hardcoded identity. Department/enterprise tiers must
         # replace with authenticated user identity from auth middleware.
@@ -54,6 +58,7 @@ def create_team(
             user_id="anonymous",
         )
     except EntryNotFoundError:
+        logger.warning("Team creation failed: catalog entry %s not found", body.catalog_entry_id)
         raise HTTPException(status_code=404, detail="Catalog entry not found") from None
     return _process_to_response(process)
 
@@ -63,6 +68,7 @@ def list_teams(
     service: TeamService = Depends(get_team_service),
 ) -> TeamListResponse:
     """List all teams for the current user."""
+    logger.debug("GET /teams")
     # Community-tier hardcoded identity (see create_team comment above).
     processes = service.list_teams(user_id="anonymous")
     return TeamListResponse(teams=[_process_to_response(p) for p in processes])
@@ -74,6 +80,7 @@ def get_team(
     service: TeamService = Depends(get_team_service),
 ) -> TeamResponse:
     """Get a single team by ID."""
+    logger.debug("GET /teams/%s", team_id)
     process = service.get_team(team_id)
     if process is None:
         raise HTTPException(status_code=404, detail="Team not found")
@@ -86,6 +93,7 @@ def delete_team(
     service: TeamService = Depends(get_team_service),
 ) -> None:
     """Stop and delete a team."""
+    logger.info("DELETE /teams/%s", team_id)
     try:
         service.delete_team(team_id)
     except ValueError:
@@ -102,6 +110,7 @@ def send_message(
     service: TeamService = Depends(get_team_service),
 ) -> None:
     """Send a message to a running team."""
+    logger.info("POST /teams/%s/message", team_id)
     try:
         service.send_message(team_id, body.content)
     except ValueError as exc:
@@ -115,6 +124,7 @@ def human_input(
     service: TeamService = Depends(get_team_service),
 ) -> None:
     """Provide human input in response to an agent request."""
+    logger.info("POST /teams/%s/human-input", team_id)
     try:
         service.process_human_input(team_id, body.content, body.message_id)
     except ValueError as exc:
@@ -127,6 +137,7 @@ def stop_team(
     service: TeamService = Depends(get_team_service),
 ) -> None:
     """Stop a running team without deleting persisted data."""
+    logger.info("POST /teams/%s/stop", team_id)
     try:
         service.stop_team(team_id)
     except ValueError as exc:
@@ -140,6 +151,7 @@ def restore_team(
     service: TeamService = Depends(get_team_service),
 ) -> TeamResponse:
     """Restore a stopped team and notify waiting WebSocket connections."""
+    logger.info("POST /teams/%s/restore", team_id)
     try:
         process = service.restore_team(team_id)
     except ValueError as exc:
@@ -160,6 +172,7 @@ def get_events(
     service: TeamService = Depends(get_team_service),
 ) -> EventListResponse:
     """Get all persisted events for a team."""
+    logger.debug("GET /teams/%s/events", team_id)
     try:
         events = service.get_events(team_id)
     except ValueError:
@@ -190,5 +203,7 @@ def _raise_action_error(exc: ValueError) -> NoReturn:
     """
     detail = str(exc)
     if "not found" in detail or "deleted" in detail:
+        logger.debug("Action error (not found): %s", detail)
         raise HTTPException(status_code=404, detail=detail) from None
+    logger.warning("Action error: %s", detail)
     raise HTTPException(status_code=409, detail=detail) from None

--- a/src/akgentic/infra/server/routes/webhook.py
+++ b/src/akgentic/infra/server/routes/webhook.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from typing import cast
 
 from fastapi import APIRouter, Depends, HTTPException, Request
@@ -12,6 +13,8 @@ from akgentic.infra.protocols.channels import (
     InteractionChannelIngestion,
     JsonValue,
 )
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/webhook", tags=["webhook"])
 
@@ -46,31 +49,38 @@ async def webhook(
     2. Continuation: no team_id but existing team found → route_reply
     3. Initiation: no existing team → initiate_team + register
     """
+    content_type = request.headers.get("content-type", "")
+    logger.info("POST /webhook/%s — content_type=%s", channel, content_type)
+
     parser = parser_registry.get_parser(channel)
     if parser is None:
+        logger.warning("Unknown channel: %s", channel)
         raise HTTPException(status_code=404, detail=f"Unknown channel: {channel}")
 
-    content_type = request.headers.get("content-type", "")
     if "application/json" in content_type:
         payload: dict[str, JsonValue] = await request.json()
     elif "application/x-www-form-urlencoded" in content_type:
         form_data = await request.form()
         payload = {k: str(v) for k, v in form_data.items()}
     else:
+        logger.warning("Unsupported content type: %s", content_type)
         raise HTTPException(status_code=415, detail="Unsupported content type")
     message = await parser.parse(payload)
 
     if message.team_id is not None:
         # Reply flow
-        await ingestion.route_reply(
-            message.team_id, message.content, message.message_id
-        )
+        logger.debug("Webhook reply: channel=%s, team_id=%s", channel, message.team_id)
+        await ingestion.route_reply(message.team_id, message.content, message.message_id)
     else:
-        existing_team = await channel_registry.find_team(
-            channel, message.channel_user_id
-        )
+        existing_team = await channel_registry.find_team(channel, message.channel_user_id)
         if existing_team is not None:
             # Continuation flow
+            logger.debug(
+                "Webhook continuation: channel=%s, user=%s, team_id=%s",
+                channel,
+                message.channel_user_id,
+                existing_team,
+            )
             await ingestion.route_reply(existing_team, message.content)
         else:
             # Initiation flow
@@ -79,6 +89,10 @@ async def webhook(
                 message.channel_user_id,
                 parser.default_catalog_entry,
             )
-            await channel_registry.register(
-                channel, message.channel_user_id, new_team_id
+            logger.debug(
+                "Webhook initiation: channel=%s, user=%s, new_team=%s",
+                channel,
+                message.channel_user_id,
+                new_team_id,
             )
+            await channel_registry.register(channel, message.channel_user_id, new_team_id)

--- a/src/akgentic/infra/server/routes/workspace.py
+++ b/src/akgentic/infra/server/routes/workspace.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 import uuid
 from pathlib import PurePosixPath
 from typing import Annotated, cast
@@ -17,6 +18,8 @@ from akgentic.infra.server.models import (
 from akgentic.infra.server.services.team_service import TeamService
 from akgentic.infra.server.settings import CommunitySettings
 from akgentic.tool.workspace import Filesystem
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/workspace", tags=["workspace"])
 
@@ -42,6 +45,7 @@ def list_workspace_tree(
     path: str = "",
 ) -> WorkspaceTreeResponse:
     """List files in a team's workspace directory."""
+    logger.debug("GET /workspace/%s/tree path=%s", team_id, path)
     _validate_team(team_id, request)
     settings = cast(CommunitySettings, request.app.state.settings)
     ws = _get_workspace(team_id, settings)
@@ -52,9 +56,7 @@ def list_workspace_tree(
     return WorkspaceTreeResponse(
         team_id=str(team_id),
         path=path,
-        entries=[
-            WorkspaceFileEntry(name=e.name, is_dir=e.is_dir, size=e.size) for e in entries
-        ],
+        entries=[WorkspaceFileEntry(name=e.name, is_dir=e.is_dir, size=e.size) for e in entries],
     )
 
 
@@ -65,6 +67,7 @@ def read_workspace_file(
     path: str,
 ) -> Response:
     """Read a file from a team's workspace."""
+    logger.debug("GET /workspace/%s/file path=%s", team_id, path)
     _validate_team(team_id, request)
     settings = cast(CommunitySettings, request.app.state.settings)
     ws = _get_workspace(team_id, settings)
@@ -98,6 +101,7 @@ async def upload_workspace_file(
     data = await file.read()
     if len(data) > _MAX_FILE_SIZE:
         raise HTTPException(status_code=413, detail="File exceeds 10 MB size limit")
+    logger.info("POST /workspace/%s/file path=%s, size=%d", team_id, path, len(data))
     try:
         ws.write(path, data)
     except PermissionError:

--- a/src/akgentic/infra/server/routes/ws.py
+++ b/src/akgentic/infra/server/routes/ws.py
@@ -88,10 +88,12 @@ async def websocket_events(websocket: WebSocket, team_id: uuid.UUID) -> None:
 
     process = service.get_team(team_id)
     if process is None:
+        logger.info("WebSocket rejected: team_id=%s (not found)", team_id)
         await websocket.close(code=4004, reason="Team not found")
         return
 
     await websocket.accept()
+    logger.info("WebSocket connected: team_id=%s", team_id)
 
     adapter: FrontendAdapter | None = getattr(websocket.app.state, "frontend_adapter", None)
 
@@ -109,8 +111,10 @@ async def _run_streaming_loop(
     adapter: FrontendAdapter | None = None,
 ) -> None:
     """Subscribe to orchestrator events and forward them over WebSocket."""
+    logger.debug("Streaming loop started: team_id=%s", team_id)
     handle = service.get_handle(team_id)
     if handle is None:
+        logger.debug("Runtime not available for team %s, closing WebSocket", team_id)
         await websocket.close(code=1011, reason="Runtime not available")
         return
 
@@ -120,7 +124,7 @@ async def _run_streaming_loop(
     try:
         await _send_loop(websocket, subscriber, team_id, adapter)
     except WebSocketDisconnect:
-        pass
+        logger.info("WebSocket disconnected: team_id=%s", team_id)
     finally:
         try:
             handle.unsubscribe(subscriber)
@@ -161,17 +165,21 @@ async def _send_loop(
                 logger.warning("Malformed JSON in event queue, sending raw text")
                 await websocket.send_text(item)
                 continue
-            event = PersistedEvent.model_validate({
-                "team_id": str(team_id),
-                "sequence": seq,
-                "event": msg_data,
-                "timestamp": datetime.now(tz=UTC).isoformat(),
-            })
+            event = PersistedEvent.model_validate(
+                {
+                    "team_id": str(team_id),
+                    "sequence": seq,
+                    "event": msg_data,
+                    "timestamp": datetime.now(tz=UTC).isoformat(),
+                }
+            )
             seq += 1
             wrapped = adapter.wrap_ws_event(event)
             await websocket.send_text(wrapped.model_dump_json())
+            logger.debug("Event forwarded to client: %s", item[:80])
         else:
             await websocket.send_text(item)
+            logger.debug("Event forwarded to client: %s", item[:80])
 
 
 async def _run_idle_loop(
@@ -189,6 +197,7 @@ async def _run_idle_loop(
     iteration. Direct signaling is not used because there is no safe
     way to interrupt a blocking ``receive_text()`` from another thread.
     """
+    logger.debug("WebSocket idle, waiting for restore: team_id=%s", team_id)
     conn_mgr.add_waiting(team_id, websocket)
     try:
         while True:
@@ -218,6 +227,8 @@ def notify_restore(
     waiting = conn_mgr.pop_waiting(team_id)
     if not waiting:
         return
+
+    logger.info("Notifying %d waiting WebSocket(s) for team %s", len(waiting), team_id)
 
     handle = service.get_handle(team_id)
     if handle is None:

--- a/src/akgentic/infra/server/services/team_service.py
+++ b/src/akgentic/infra/server/services/team_service.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 import uuid
 
 from akgentic.catalog.models.errors import EntryNotFoundError
@@ -9,6 +10,8 @@ from akgentic.core.messages.message import Message
 from akgentic.infra.protocols.team_handle import RuntimeCache, TeamHandle
 from akgentic.infra.server.deps import TierServices
 from akgentic.team.models import PersistedEvent, Process, TeamStatus
+
+logger = logging.getLogger(__name__)
 
 
 class TeamService:
@@ -30,6 +33,7 @@ class TeamService:
         Raises:
             EntryNotFoundError: If catalog_entry_id is not found.
         """
+        logger.debug("Resolving catalog entry: %s", catalog_entry_id)
         entry = self._services.team_catalog.get(catalog_entry_id)
         if entry is None:
             raise EntryNotFoundError(catalog_entry_id)
@@ -47,6 +51,7 @@ class TeamService:
         if process is None:  # pragma: no cover
             msg = f"Team {handle.team_id} was created but not found in event store"
             raise RuntimeError(msg)
+        logger.info("Team created: team_id=%s, catalog_entry=%s", process.team_id, catalog_entry_id)
         return process
 
     def list_teams(self, user_id: str) -> list[Process]:
@@ -72,6 +77,7 @@ class TeamService:
             self._services.worker_handle.stop_team(team_id)
         self._cache.remove(team_id)
         self._services.worker_handle.delete_team(team_id)
+        logger.info("Team deleted: team_id=%s", team_id)
 
     def send_message(self, team_id: uuid.UUID, content: str) -> None:
         """Send a message to a running team.
@@ -81,6 +87,7 @@ class TeamService:
         """
         handle = self._get_running_handle(team_id)
         handle.send(content)
+        logger.debug("Message sent to team %s", team_id)
 
     def process_human_input(
         self,
@@ -96,6 +103,7 @@ class TeamService:
         handle = self._get_running_handle(team_id)
         original_message = self._find_message(team_id, message_id)
         handle.process_human_input(content, original_message)
+        logger.debug("Human input routed to team %s, message_id=%s", team_id, message_id)
 
     def stop_team(self, team_id: uuid.UUID) -> None:
         """Stop a running team without deleting persisted data.
@@ -115,6 +123,7 @@ class TeamService:
             raise ValueError(msg)
         self._services.worker_handle.stop_team(team_id)
         self._cache.remove(team_id)
+        logger.info("Team stopped: team_id=%s", team_id)
 
     def restore_team(self, team_id: uuid.UUID) -> Process:
         """Restore a stopped team.
@@ -138,6 +147,7 @@ class TeamService:
         if updated is None:  # pragma: no cover
             msg = f"Team {team_id} was restored but not found in event store"
             raise RuntimeError(msg)
+        logger.info("Team restored: team_id=%s", team_id)
         return updated
 
     def get_events(self, team_id: uuid.UUID) -> list[PersistedEvent]:
@@ -150,6 +160,7 @@ class TeamService:
         if process is None:
             msg = f"Team {team_id} not found"
             raise ValueError(msg)
+        logger.debug("Loading events for team %s", team_id)
         return self._services.event_store.load_events(team_id)
 
     def get_handle(self, team_id: uuid.UUID) -> TeamHandle | None:
@@ -176,6 +187,7 @@ class TeamService:
         if process.status != TeamStatus.RUNNING:
             msg = f"Team {team_id} is not running"
             raise ValueError(msg)
+        logger.debug("Resolving running handle for team %s", team_id)
         handle = self._cache.get(team_id)
         if handle is None:
             msg = f"Team {team_id} handle not cached"

--- a/src/akgentic/infra/server/settings.py
+++ b/src/akgentic/infra/server/settings.py
@@ -2,10 +2,13 @@
 
 from __future__ import annotations
 
+import warnings
 from pathlib import Path
 
-from pydantic import Field
+from pydantic import Field, field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
+
+_VALID_LOG_LEVELS = frozenset({"DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"})
 
 
 class ServerSettings(BaseSettings):
@@ -25,6 +28,25 @@ class ServerSettings(BaseSettings):
         default=8000,
         description="Port number for the HTTP server",
     )
+    log_level: str = Field(
+        default="INFO",
+        description="Application log level (DEBUG, INFO, WARNING, ERROR, CRITICAL)",
+    )
+
+    @field_validator("log_level", mode="before")
+    @classmethod
+    def _normalize_log_level(cls, v: str) -> str:
+        """Normalize to uppercase and fall back to INFO for invalid values."""
+        upper = str(v).upper()
+        if upper not in _VALID_LOG_LEVELS:
+            warnings.warn(
+                f"Invalid AKGENTIC_LOG_LEVEL '{v}', falling back to INFO",
+                UserWarning,
+                stacklevel=1,
+            )
+            return "INFO"
+        return upper
+
     frontend_adapter: str | None = Field(
         default=None,
         description="FQDN for frontend adapter plugin class",

--- a/src/akgentic/infra/wiring.py
+++ b/src/akgentic/infra/wiring.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import logging
+
 from akgentic.catalog.repositories.yaml import (
     YamlAgentCatalogRepository,
     YamlTeamCatalogRepository,
@@ -30,6 +32,8 @@ from akgentic.team.manager import TeamManager
 from akgentic.team.ports import NullServiceRegistry, ServiceRegistry
 from akgentic.team.repositories.yaml import YamlEventStore
 
+logger = logging.getLogger(__name__)
+
 
 def wire_community(settings: CommunitySettings) -> CommunityServices:
     """Assemble community-tier services for single-process deployment.
@@ -43,6 +47,7 @@ def wire_community(settings: CommunitySettings) -> CommunityServices:
     Returns:
         Fully wired CommunityServices container
     """
+    logger.info("Wiring community services")
     event_store = YamlEventStore(data_dir=settings.workspaces_root)
     service_registry = NullServiceRegistry()
     actor_system, team_manager = _build_actor_layer(event_store, service_registry)
@@ -51,6 +56,11 @@ def wire_community(settings: CommunitySettings) -> CommunityServices:
     local_placement = LocalPlacement(team_manager, service_registry)
     local_worker_handle = LocalWorkerHandle(team_manager, service_registry)
 
+    logger.info(
+        "Community services wired: placement=%s, worker=%s",
+        type(local_placement).__name__,
+        type(local_worker_handle).__name__,
+    )
     return CommunityServices(
         placement=local_placement,
         worker_handle=local_worker_handle,
@@ -79,6 +89,7 @@ def _build_actor_layer(
     service_registry: ServiceRegistry,
 ) -> tuple[ActorSystem, TeamManager]:
     """Build ActorSystem and TeamManager."""
+    logger.debug("Building actor layer: event_store=%s", type(event_store).__name__)
     shared_subscribers: list[EventSubscriber] = [TelemetrySubscriber()]
     actor_system = ActorSystem()
     team_manager = TeamManager(
@@ -86,6 +97,10 @@ def _build_actor_layer(
         event_store=event_store,
         service_registry=service_registry,
         subscribers=shared_subscribers,
+    )
+    logger.debug(
+        "Actor system created, team manager initialized with %d shared subscribers",
+        len(shared_subscribers),
     )
     return actor_system, team_manager
 
@@ -95,6 +110,7 @@ def _build_catalogs(
 ) -> tuple[TeamCatalog, AgentCatalog, ToolCatalog, TemplateCatalog]:
     """Build YAML-backed catalog services."""
     catalog_root = settings.catalog_path or settings.workspaces_root / "catalog"
+    logger.debug("Building catalogs from %s", catalog_root)
     template_catalog = TemplateCatalog(
         repository=YamlTemplateCatalogRepository(catalog_dir=catalog_root / "templates"),
     )

--- a/tests/integration/_helpers.py
+++ b/tests/integration/_helpers.py
@@ -85,8 +85,7 @@ def seed_integration_catalog(catalog_root: Path) -> None:
                     "role": "Manager",
                     "prompt": {
                         "template": (
-                            "You are a helpful assistant. "
-                            "Reply concisely in one or two sentences."
+                            "You are a helpful assistant. Reply concisely in one or two sentences."
                         ),
                     },
                     "model_cfg": {
@@ -134,10 +133,6 @@ def has_llm_content(events: list[dict[str, object]]) -> bool:
         sender = ev.get("sender")
         if not isinstance(sender, dict):
             continue
-        if (
-            isinstance(content, str)
-            and len(content) > 0
-            and sender.get("name") == "@Manager"
-        ):
+        if isinstance(content, str) and len(content) > 0 and sender.get("name") == "@Manager":
             return True
     return False

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -98,9 +98,7 @@ def integration_client(integration_app: FastAPI) -> TestClient:
 # V1 Adapter Fixtures
 # ---------------------------------------------------------------------------
 
-V1_ADAPTER_FQDN = (
-    "akgentic.infra.server.routes.frontend_adapter.angular_v1.AngularV1Adapter"
-)
+V1_ADAPTER_FQDN = "akgentic.infra.server.routes.frontend_adapter.angular_v1.AngularV1Adapter"
 
 
 @pytest.fixture()

--- a/tests/integration/test_adr003_tier_agnostic.py
+++ b/tests/integration/test_adr003_tier_agnostic.py
@@ -259,9 +259,9 @@ class TestTeamServiceProtocolRouting:
         assert len(events) >= 1
         # Verify at least one event contains the sent message content
         event_strs = [str(ev) for ev in events]
-        assert any(
-            "Hello from integration test" in s for s in event_strs
-        ), f"Expected sent message content in events, got: {events}"
+        assert any("Hello from integration test" in s for s in event_strs), (
+            f"Expected sent message content in events, got: {events}"
+        )
 
         # Cleanup
         integration_client.post(f"/teams/{team_id}/stop")

--- a/tests/integration/test_adr004_v1_compat.py
+++ b/tests/integration/test_adr004_v1_compat.py
@@ -86,7 +86,8 @@ class TestProcessEndpoint:
     """Test GET /processes returns flat list with V1ActorAddress orchestrator."""
 
     def test_get_processes_returns_flat_list(
-        self, v1_adapter_client: TestClient,
+        self,
+        v1_adapter_client: TestClient,
     ) -> None:
         """AC1: GET /processes returns 200 with flat list response."""
         team_id = _create_v1_team(v1_adapter_client)
@@ -101,7 +102,8 @@ class TestProcessEndpoint:
         time.sleep(0.5)
 
     def test_orchestrator_v1_actor_address_fields(
-        self, v1_adapter_client: TestClient,
+        self,
+        v1_adapter_client: TestClient,
     ) -> None:
         """AC1: orchestrator is V1ActorAddress with name, role, and string defaults."""
         team_id = _create_v1_team(v1_adapter_client)
@@ -129,7 +131,8 @@ class TestProcessEndpoint:
         time.sleep(0.5)
 
     def test_params_workspace_and_knowledge_graph(
-        self, v1_adapter_client: TestClient,
+        self,
+        v1_adapter_client: TestClient,
     ) -> None:
         """AC1: params contains workspace and knowledge_graph keys."""
         team_id = _create_v1_team(v1_adapter_client)
@@ -149,7 +152,8 @@ class TestProcessEndpoint:
         time.sleep(0.5)
 
     def test_processes_alias_matches_process_list(
-        self, v1_adapter_client: TestClient,
+        self,
+        v1_adapter_client: TestClient,
     ) -> None:
         """AC1: GET /process/ returns same data as GET /processes."""
         team_id = _create_v1_team(v1_adapter_client)
@@ -176,7 +180,8 @@ class TestConfigEndpoint:
     """Test PUT /config/{config_type} and DELETE /config/{config_type}/{config_id}."""
 
     def test_put_config_new_url_shape(
-        self, v1_adapter_client: TestClient,
+        self,
+        v1_adapter_client: TestClient,
     ) -> None:
         """AC2: PUT /config/team with V1ConfigPutBody succeeds."""
         # Get existing entry to build a valid config
@@ -198,7 +203,8 @@ class TestConfigEndpoint:
         v1_adapter_client.delete("/config/team/adr004-put-test")
 
     def test_delete_config_new_url_shape(
-        self, v1_adapter_client: TestClient,
+        self,
+        v1_adapter_client: TestClient,
     ) -> None:
         """AC2: DELETE /config/team/{config_id} with URL params succeeds."""
         # Create an entry first
@@ -229,7 +235,8 @@ class TestHumanInput:
     """Test POST /process_human_input/{id}/human/{proxy} with message dict."""
 
     def test_human_input_with_message_body(
-        self, v1_adapter_client: TestClient,
+        self,
+        v1_adapter_client: TestClient,
     ) -> None:
         """AC3: human input with message dict containing id field succeeds."""
         team_id = _create_v1_team(v1_adapter_client)
@@ -300,7 +307,8 @@ class TestTeamConfigs:
     """Test GET /team-configs/ returns dict keyed by team name."""
 
     def test_team_configs_returns_dict(
-        self, v1_adapter_client: TestClient,
+        self,
+        v1_adapter_client: TestClient,
     ) -> None:
         """AC5: GET /team-configs/ returns a dict (not a list)."""
         resp = v1_adapter_client.get("/team-configs/")
@@ -309,7 +317,8 @@ class TestTeamConfigs:
         assert isinstance(data, dict)
 
     def test_team_configs_has_seeded_entry(
-        self, v1_adapter_client: TestClient,
+        self,
+        v1_adapter_client: TestClient,
     ) -> None:
         """AC5: at least one entry exists from seeded catalog."""
         resp = v1_adapter_client.get("/team-configs/")
@@ -318,7 +327,8 @@ class TestTeamConfigs:
         assert len(data) >= 1
 
     def test_team_configs_entry_shape(
-        self, v1_adapter_client: TestClient,
+        self,
+        v1_adapter_client: TestClient,
     ) -> None:
         """AC5: each value has module (str) and setup (str, parseable as JSON) keys."""
         resp = v1_adapter_client.get("/team-configs/")
@@ -345,7 +355,8 @@ class TestLlmContextGrouped:
     """Test GET /llm_context/{id} returns dict keyed by agent ID."""
 
     def test_llm_context_grouped_response(
-        self, v1_adapter_client: TestClient,
+        self,
+        v1_adapter_client: TestClient,
     ) -> None:
         """AC6: GET /llm_context/{id} returns dict with agent keys and context lists."""
         team_id = _create_v1_team(v1_adapter_client)
@@ -382,7 +393,8 @@ class TestStatesGrouped:
     """Test GET /states/{id} returns dict keyed by agent ID."""
 
     def test_states_grouped_response(
-        self, v1_adapter_client: TestClient,
+        self,
+        v1_adapter_client: TestClient,
     ) -> None:
         """AC7: GET /states/{id} returns dict."""
         team_id = _create_v1_team(v1_adapter_client)

--- a/tests/integration/test_catalog.py
+++ b/tests/integration/test_catalog.py
@@ -16,7 +16,8 @@ class TestCatalogIntegration:
     """Integration tests for catalog browsing with real YAML catalog."""
 
     def test_list_teams_returns_seeded_entry(
-        self, integration_client: TestClient,
+        self,
+        integration_client: TestClient,
     ) -> None:
         """AC #3: GET /catalog/api/teams returns at least the seeded test-team."""
         resp = integration_client.get("/catalog/api/teams")
@@ -27,7 +28,8 @@ class TestCatalogIntegration:
         assert "test-team" in ids, f"Expected 'test-team' in catalog, got: {ids}"
 
     def test_get_team_details(
-        self, integration_client: TestClient,
+        self,
+        integration_client: TestClient,
     ) -> None:
         """AC #3: GET /catalog/api/teams/test-team returns full details."""
         resp = integration_client.get("/catalog/api/teams/test-team")
@@ -41,7 +43,8 @@ class TestCatalogIntegration:
         assert isinstance(body["profiles"], list)
 
     def test_get_nonexistent_team_returns_404(
-        self, integration_client: TestClient,
+        self,
+        integration_client: TestClient,
     ) -> None:
         """AC #3: GET /catalog/api/teams/nonexistent returns 404."""
         resp = integration_client.get("/catalog/api/teams/nonexistent")

--- a/tests/integration/test_channels.py
+++ b/tests/integration/test_channels.py
@@ -47,22 +47,15 @@ class StubChannelParser:
         return "test-team"
 
     async def parse(
-        self, payload: dict[str, JsonValue],
+        self,
+        payload: dict[str, JsonValue],
     ) -> ChannelMessage:
         """Parse test payload into ChannelMessage."""
         content = str(payload.get("content", ""))
         channel_user_id = str(payload.get("channel_user_id", ""))
         raw_team_id = payload.get("team_id")
-        team_id = (
-            uuid.UUID(str(raw_team_id))
-            if raw_team_id is not None
-            else None
-        )
-        message_id = (
-            str(payload["message_id"])
-            if payload.get("message_id")
-            else None
-        )
+        team_id = uuid.UUID(str(raw_team_id)) if raw_team_id is not None else None
+        message_id = str(payload["message_id"]) if payload.get("message_id") else None
         return ChannelMessage(
             content=content,
             channel_user_id=channel_user_id,
@@ -127,19 +120,21 @@ class TestChannelInitiation:
             "channel_user_id": "ext-user-1",
         }
         resp = channel_client.post(
-            "/webhook/test-channel", json=payload,
+            "/webhook/test-channel",
+            json=payload,
         )
         assert resp.status_code == 204
 
         team_id = _find_team_via_registry(
-            channel_registry_instance, "test-channel", "ext-user-1",
+            channel_registry_instance,
+            "test-channel",
+            "ext-user-1",
         )
-        assert team_id is not None, (
-            "Channel registry should map ext-user-1 after initiation"
-        )
+        assert team_id is not None, "Channel registry should map ext-user-1 after initiation"
 
         events = wait_for_llm_response(
-            channel_client, str(team_id),
+            channel_client,
+            str(team_id),
         )
         assert has_llm_content(events)
 
@@ -151,10 +146,12 @@ class TestChannelReply:
     """AC #2: Webhook with team_id routes to the correct team."""
 
     def test_reply_routes_to_existing_team(
-        self, channel_client: TestClient,
+        self,
+        channel_client: TestClient,
     ) -> None:
         create_resp = channel_client.post(
-            "/teams/", json={"catalog_entry_id": "test-team"},
+            "/teams/",
+            json={"catalog_entry_id": "test-team"},
         )
         assert create_resp.status_code == 201
         team_id = create_resp.json()["team_id"]
@@ -190,7 +187,8 @@ class TestChannelContinuation:
             "channel_user_id": "ext-user-cont",
         }
         resp = channel_client.post(
-            "/webhook/test-channel", json=payload,
+            "/webhook/test-channel",
+            json=payload,
         )
         assert resp.status_code == 204
 
@@ -199,9 +197,7 @@ class TestChannelContinuation:
             "test-channel",
             "ext-user-cont",
         )
-        assert team_id is not None, (
-            "Channel registry should have mapping after initiation"
-        )
+        assert team_id is not None, "Channel registry should have mapping after initiation"
 
         # Wait for LLM to process first message before sending follow-up
         wait_for_llm_response(channel_client, str(team_id))
@@ -234,10 +230,7 @@ class TestChannelContinuation:
                     found_followup = True
                     break
                 msg = ev.get("message")
-                if (
-                    isinstance(msg, dict)
-                    and msg.get("content") == FOLLOWUP_CONTENT
-                ):
+                if isinstance(msg, dict) and msg.get("content") == FOLLOWUP_CONTENT:
                     found_followup = True
                     break
             if found_followup:
@@ -267,7 +260,8 @@ class TestDispatcherRestoreSuppression:
     ) -> None:
         # Create team via REST (no LLM call needed)
         create_resp = channel_client.post(
-            "/teams/", json={"catalog_entry_id": "test-team"},
+            "/teams/",
+            json={"catalog_entry_id": "test-team"},
         )
         assert create_resp.status_code == 201
         team_id = create_resp.json()["team_id"]

--- a/tests/integration/test_cli.py
+++ b/tests/integration/test_cli.py
@@ -398,6 +398,7 @@ class TestCliChat:
                 return "/quit"
             # After /quit: block until cancelled (session should have exited)
             import threading
+
             threading.Event().wait(timeout=30)
             return "/quit"
 

--- a/tests/integration/test_events.py
+++ b/tests/integration/test_events.py
@@ -21,7 +21,8 @@ class TestEventPersistence:
     """Integration tests for event persistence after team lifecycle operations."""
 
     def test_events_persisted_after_stop(
-        self, integration_client: TestClient,
+        self,
+        integration_client: TestClient,
     ) -> None:
         """AC #2: Create team, send message, wait for LLM, stop, verify events via REST."""
         team_id = create_team(integration_client)
@@ -56,7 +57,8 @@ class TestEventPersistence:
         )
 
     def test_event_count_after_send_and_respond(
-        self, integration_client: TestClient,
+        self,
+        integration_client: TestClient,
     ) -> None:
         """AC #2: Verify event count >= 3 after a full send-and-respond cycle."""
         team_id = create_team(integration_client)
@@ -75,7 +77,8 @@ class TestEventPersistence:
         time.sleep(0.5)
 
     def test_events_survive_stop_restore_cycle(
-        self, integration_client: TestClient,
+        self,
+        integration_client: TestClient,
     ) -> None:
         """AC #2: Events from before stop are still accessible after restore."""
         team_id = create_team(integration_client)

--- a/tests/integration/test_frontend_adapter.py
+++ b/tests/integration/test_frontend_adapter.py
@@ -165,7 +165,8 @@ class TestV1FrontendAdapter:
 
         # Verify V1MessageEntry shape on the LLM response
         llm_messages = [
-            m for m in messages
+            m
+            for m in messages
             if isinstance(m.get("sender"), str)
             and "@Manager" in str(m.get("sender"))
             and isinstance(m.get("content"), str)

--- a/tests/integration/test_spec_catalog.py
+++ b/tests/integration/test_spec_catalog.py
@@ -37,7 +37,8 @@ class TestCatalogTeamCrud:
         assert body["name"] == "Integration Test Team"
 
     def test_create_update_delete_team(
-        self, integration_client: TestClient,
+        self,
+        integration_client: TestClient,
     ) -> None:
         """AC #6: POST/PUT/DELETE /catalog/api/teams for full CRUD."""
         new_entry = {
@@ -62,7 +63,8 @@ class TestCatalogTeamCrud:
         # Update
         new_entry["name"] = "Updated CRUD Team"
         resp = integration_client.put(
-            "/catalog/api/teams/crud-test-team", json=new_entry,
+            "/catalog/api/teams/crud-test-team",
+            json=new_entry,
         )
         assert resp.status_code == 200
         assert resp.json()["name"] == "Updated CRUD Team"
@@ -72,7 +74,8 @@ class TestCatalogTeamCrud:
         assert resp.status_code == 204
 
     def test_get_nonexistent_team_404(
-        self, integration_client: TestClient,
+        self,
+        integration_client: TestClient,
     ) -> None:
         """AC #6: GET /catalog/api/teams/nonexistent returns 404."""
         resp = integration_client.get("/catalog/api/teams/nonexistent-xyz")
@@ -104,7 +107,8 @@ class TestCatalogAgentCrud:
         assert resp.json()["id"] == "manager"
 
     def test_get_nonexistent_agent_404(
-        self, integration_client: TestClient,
+        self,
+        integration_client: TestClient,
     ) -> None:
         """AC #6: GET /catalog/api/agents/nonexistent returns 404."""
         resp = integration_client.get("/catalog/api/agents/nonexistent-xyz")

--- a/tests/integration/test_spec_channels.py
+++ b/tests/integration/test_spec_channels.py
@@ -73,7 +73,8 @@ class TestFormEncodedWebhook:
     """Verify form-encoded webhook payloads are parsed correctly."""
 
     def test_form_encoded_webhook_returns_204(
-        self, channel_client: TestClient,
+        self,
+        channel_client: TestClient,
     ) -> None:
         """AC #3: POST form-encoded to /webhook/{channel} returns 204.
 
@@ -84,7 +85,8 @@ class TestFormEncodedWebhook:
 
         # Create a team first so we can use reply flow (no LLM initiation)
         create_resp = channel_client.post(
-            "/teams/", json={"catalog_entry_id": "test-team"},
+            "/teams/",
+            json={"catalog_entry_id": "test-team"},
         )
         assert create_resp.status_code == 201
         team_id = create_resp.json()["team_id"]
@@ -156,11 +158,7 @@ class TestChannelConfigPassthrough:
         # Monkeypatch import_class to return our stubs
         monkeypatch.setattr(
             "akgentic.infra.adapters.channel_parser_registry.import_class",
-            lambda fqcn: (
-                StubParserWithConfig
-                if "Parser" in fqcn
-                else StubAdapterWithConfig
-            ),
+            lambda fqcn: StubParserWithConfig if "Parser" in fqcn else StubAdapterWithConfig,
         )
 
         config = {

--- a/tests/integration/test_spec_compliance.py
+++ b/tests/integration/test_spec_compliance.py
@@ -31,7 +31,8 @@ class TestAppFactory:
     """Verify the 2-line fixture pattern: settings -> create_app -> TestClient."""
 
     def test_app_starts_and_teams_returns_200(
-        self, integration_client: TestClient,
+        self,
+        integration_client: TestClient,
     ) -> None:
         """AC #1: App created via create_app(settings) serves /teams/ correctly."""
         resp = integration_client.get("/teams/")
@@ -54,7 +55,9 @@ class TestAppFactory:
         services.actor_system.shutdown()
 
     def test_team_create_get_delete_via_test_client(
-        self, integration_client: TestClient, integration_app: FastAPI,
+        self,
+        integration_client: TestClient,
+        integration_app: FastAPI,
     ) -> None:
         """AC #1: Team create/get/delete work through TestClient."""
         team_id = create_team(integration_client)
@@ -88,7 +91,9 @@ class TestRuntimeCacheLifecycle:
     """Verify RuntimeCache store/get/remove through team lifecycle operations."""
 
     def test_cache_lifecycle_create_stop_restore_delete(
-        self, integration_client: TestClient, integration_app: FastAPI,
+        self,
+        integration_client: TestClient,
+        integration_app: FastAPI,
     ) -> None:
         """AC #2: Full RuntimeCache lifecycle — create, stop, restore, delete."""
         cache = integration_app.state.services.runtime_cache
@@ -96,16 +101,12 @@ class TestRuntimeCacheLifecycle:
         # 1. Create team -> cache.get(team_id) is not None
         team_id_str = create_team(integration_client)
         team_id = uuid.UUID(team_id_str)
-        assert cache.get(team_id) is not None, (
-            "RuntimeCache should hold handle after create"
-        )
+        assert cache.get(team_id) is not None, "RuntimeCache should hold handle after create"
 
         # 2. Stop team -> cache.get(team_id) returns None
         resp = integration_client.post(f"/teams/{team_id_str}/stop")
         assert resp.status_code == 204
-        assert cache.get(team_id) is None, (
-            "RuntimeCache should be empty after stop"
-        )
+        assert cache.get(team_id) is None, "RuntimeCache should be empty after stop"
 
         # 3. Verify events still accessible (event store preserved)
         resp = integration_client.get(f"/teams/{team_id_str}/events")
@@ -117,18 +118,14 @@ class TestRuntimeCacheLifecycle:
         resp = integration_client.post(f"/teams/{team_id_str}/restore")
         assert resp.status_code == 200
         assert resp.json()["status"] == "running"
-        assert cache.get(team_id) is not None, (
-            "RuntimeCache should hold handle after restore"
-        )
+        assert cache.get(team_id) is not None, "RuntimeCache should hold handle after restore"
 
         # 5. Delete team -> team gone
         resp = integration_client.post(f"/teams/{team_id_str}/stop")
         assert resp.status_code == 204
         resp = integration_client.delete(f"/teams/{team_id_str}")
         assert resp.status_code == 204
-        assert cache.get(team_id) is None, (
-            "RuntimeCache should be empty after delete"
-        )
+        assert cache.get(team_id) is None, "RuntimeCache should be empty after delete"
 
 
 # ---------------------------------------------------------------------------
@@ -140,7 +137,8 @@ class TestWebSocketTeamHandle:
     """Verify WebSocket events flow through TeamHandle.subscribe/unsubscribe."""
 
     def test_ws_events_arrive_via_team_handle(
-        self, integration_client: TestClient,
+        self,
+        integration_client: TestClient,
     ) -> None:
         """AC #4: Create team, open WS, verify events arrive via TeamHandle."""
         team_id = create_team(integration_client)
@@ -165,7 +163,8 @@ class TestWebSocketTeamHandle:
         time.sleep(0.5)
 
     def test_ws_send_message_via_rest_receive_via_ws(
-        self, integration_client: TestClient,
+        self,
+        integration_client: TestClient,
     ) -> None:
         """AC #4: Send message via REST, verify WS receives events, close cleanly."""
         team_id = create_team(integration_client)

--- a/tests/integration/test_team_lifecycle.py
+++ b/tests/integration/test_team_lifecycle.py
@@ -53,11 +53,7 @@ def _has_llm_content(events: list[dict[str, object]]) -> bool:
         sender = ev.get("sender")
         if not isinstance(sender, dict):
             continue
-        if (
-            isinstance(content, str)
-            and len(content) > 0
-            and sender.get("name") == "@Manager"
-        ):
+        if isinstance(content, str) and len(content) > 0 and sender.get("name") == "@Manager":
             return True
     return False
 
@@ -80,7 +76,8 @@ class TestTeamLifecycle:
     """Integration tests exercising the full team lifecycle via HTTP."""
 
     def test_create_team_send_message_receive_response(
-        self, integration_client: TestClient,
+        self,
+        integration_client: TestClient,
     ) -> None:
         """AC #1, #2: Create a team and verify it is running."""
         team_id = _create_team(integration_client)
@@ -90,7 +87,8 @@ class TestTeamLifecycle:
         assert resp.json()["status"] == "running"
 
     def test_send_message_and_receive_llm_response(
-        self, integration_client: TestClient,
+        self,
+        integration_client: TestClient,
     ) -> None:
         """AC #5 (partial): Send a message and verify LLM responds."""
         team_id = _create_team(integration_client)
@@ -105,7 +103,8 @@ class TestTeamLifecycle:
         assert _has_llm_content(events)
 
     def test_stop_and_restore_team(
-        self, integration_client: TestClient,
+        self,
+        integration_client: TestClient,
     ) -> None:
         """AC #5 (partial): Stop and restore a team."""
         team_id = _create_team(integration_client)
@@ -124,7 +123,8 @@ class TestTeamLifecycle:
         assert resp.json()["status"] == "running"
 
     def test_events_persisted_after_stop(
-        self, integration_client: TestClient,
+        self,
+        integration_client: TestClient,
     ) -> None:
         """AC #5 (partial): Events persist after stop."""
         team_id = _create_team(integration_client)
@@ -147,7 +147,8 @@ class TestTeamLifecycle:
         assert len(events) >= 3
 
     def test_full_lifecycle_round_trip(
-        self, integration_client: TestClient,
+        self,
+        integration_client: TestClient,
     ) -> None:
         """AC #5: Full round-trip — create, message, LLM, stop, restore."""
         # 1. Create

--- a/tests/integration/test_websocket.py
+++ b/tests/integration/test_websocket.py
@@ -21,7 +21,8 @@ class TestWebSocketIntegration:
     """Integration tests for WebSocket event streaming (AC #1)."""
 
     def test_ws_create_team_send_message_receive_events(
-        self, integration_client: TestClient,
+        self,
+        integration_client: TestClient,
     ) -> None:
         """AC #1: Create team, open WS, send message, verify events delivered via WS."""
         team_id = create_team(integration_client)
@@ -47,7 +48,8 @@ class TestWebSocketIntegration:
         time.sleep(0.5)
 
     def test_ws_full_round_trip_with_llm(
-        self, integration_client: TestClient,
+        self,
+        integration_client: TestClient,
     ) -> None:
         """AC #1: Send message via HTTP, verify LLM response arrives, open WS for new events."""
         team_id = create_team(integration_client)
@@ -82,7 +84,8 @@ class TestWebSocketIntegration:
         time.sleep(0.5)
 
     def test_ws_restore_receives_events(
-        self, integration_client: TestClient,
+        self,
+        integration_client: TestClient,
     ) -> None:
         """AC #1: Connect WS to stopped team, restore, verify events flow after restore."""
         team_id = create_team(integration_client)

--- a/tests/test_angular_v1_adapter.py
+++ b/tests/test_angular_v1_adapter.py
@@ -203,8 +203,10 @@ class TestV1Models:
     def test_v1_config_put_body_serialization(self) -> None:
         """V1ConfigPutBody serializes correctly."""
         body = V1ConfigPutBody(
-            id="cfg-1", name="my-config",
-            config={"key": "value"}, dry_run=True,
+            id="cfg-1",
+            name="my-config",
+            config={"key": "value"},
+            dry_run=True,
         )
         data = body.model_dump()
         restored = V1ConfigPutBody.model_validate(data)
@@ -296,7 +298,9 @@ class TestV1ProcessRoutes:
     """Test V1 process endpoint translations."""
 
     def test_create_process(
-        self, v1_client: TestClient, mock_service: MagicMock,
+        self,
+        v1_client: TestClient,
+        mock_service: MagicMock,
     ) -> None:
         """AC #1: POST /process/{type} creates team via V2 service."""
         mock_service.create_team.return_value = _make_process()
@@ -308,11 +312,14 @@ class TestV1ProcessRoutes:
         assert data["status"] == "running"
         assert data["params"] == {"workspace": "false", "knowledge_graph": "false"}
         mock_service.create_team.assert_called_once_with(
-            catalog_entry_id="test-team", user_id="anonymous",
+            catalog_entry_id="test-team",
+            user_id="anonymous",
         )
 
     def test_create_process_not_found(
-        self, v1_client: TestClient, mock_service: MagicMock,
+        self,
+        v1_client: TestClient,
+        mock_service: MagicMock,
     ) -> None:
         """POST /process/{type} with unknown type returns 404."""
         from akgentic.catalog.models.errors import EntryNotFoundError
@@ -322,7 +329,9 @@ class TestV1ProcessRoutes:
         assert resp.status_code == 404
 
     def test_list_processes(
-        self, v1_client: TestClient, mock_service: MagicMock,
+        self,
+        v1_client: TestClient,
+        mock_service: MagicMock,
     ) -> None:
         """AC #2: GET /process/ returns flat list of V1ProcessContext."""
         mock_service.list_teams.return_value = [_make_process()]
@@ -334,7 +343,9 @@ class TestV1ProcessRoutes:
         assert data[0]["type"] == "Test Team"
 
     def test_list_processes_empty(
-        self, v1_client: TestClient, mock_service: MagicMock,
+        self,
+        v1_client: TestClient,
+        mock_service: MagicMock,
     ) -> None:
         """GET /process/ returns empty flat list when no teams."""
         mock_service.list_teams.return_value = []
@@ -343,7 +354,9 @@ class TestV1ProcessRoutes:
         assert resp.json() == []
 
     def test_list_processes_alias(
-        self, v1_client: TestClient, mock_service: MagicMock,
+        self,
+        v1_client: TestClient,
+        mock_service: MagicMock,
     ) -> None:
         """AC #1: GET /processes returns same flat list as GET /process/."""
         mock_service.list_teams.return_value = [_make_process()]
@@ -355,7 +368,9 @@ class TestV1ProcessRoutes:
         assert data[0]["type"] == "Test Team"
 
     def test_get_process(
-        self, v1_client: TestClient, mock_service: MagicMock,
+        self,
+        v1_client: TestClient,
+        mock_service: MagicMock,
     ) -> None:
         """AC #7: GET /process/{id} gets team with V1 response shape."""
         mock_service.get_team.return_value = _make_process()
@@ -364,7 +379,9 @@ class TestV1ProcessRoutes:
         assert resp.json()["id"] == str(_TEAM_ID)
 
     def test_get_process_not_found(
-        self, v1_client: TestClient, mock_service: MagicMock,
+        self,
+        v1_client: TestClient,
+        mock_service: MagicMock,
     ) -> None:
         """GET /process/{id} returns 404 for unknown team."""
         mock_service.get_team.return_value = None
@@ -372,7 +389,9 @@ class TestV1ProcessRoutes:
         assert resp.status_code == 404
 
     def test_send_message(
-        self, v1_client: TestClient, mock_service: MagicMock,
+        self,
+        v1_client: TestClient,
+        mock_service: MagicMock,
     ) -> None:
         """AC #2: PATCH /process/{id} sends message via V2 service."""
         mock_service.send_message.return_value = None
@@ -384,7 +403,9 @@ class TestV1ProcessRoutes:
         mock_service.send_message.assert_called_once_with(_TEAM_ID, "hello")
 
     def test_send_message_not_found(
-        self, v1_client: TestClient, mock_service: MagicMock,
+        self,
+        v1_client: TestClient,
+        mock_service: MagicMock,
     ) -> None:
         """PATCH /process/{id} returns 404 for unknown team."""
         mock_service.send_message.side_effect = ValueError("Team not found")
@@ -395,7 +416,9 @@ class TestV1ProcessRoutes:
         assert resp.status_code == 404
 
     def test_send_message_not_running(
-        self, v1_client: TestClient, mock_service: MagicMock,
+        self,
+        v1_client: TestClient,
+        mock_service: MagicMock,
     ) -> None:
         """PATCH /process/{id} returns 409 when team is not running."""
         mock_service.send_message.side_effect = ValueError("Team is not running")
@@ -406,7 +429,9 @@ class TestV1ProcessRoutes:
         assert resp.status_code == 409
 
     def test_delete_process(
-        self, v1_client: TestClient, mock_service: MagicMock,
+        self,
+        v1_client: TestClient,
+        mock_service: MagicMock,
     ) -> None:
         """AC #7: DELETE /process/{id} deletes team via V2 service."""
         mock_service.delete_team.return_value = None
@@ -415,7 +440,9 @@ class TestV1ProcessRoutes:
         mock_service.delete_team.assert_called_once_with(_TEAM_ID)
 
     def test_delete_process_not_found(
-        self, v1_client: TestClient, mock_service: MagicMock,
+        self,
+        v1_client: TestClient,
+        mock_service: MagicMock,
     ) -> None:
         """DELETE /process/{id} returns 404 for unknown team."""
         mock_service.delete_team.side_effect = ValueError("not found")
@@ -423,7 +450,9 @@ class TestV1ProcessRoutes:
         assert resp.status_code == 404
 
     def test_archive_process(
-        self, v1_client: TestClient, mock_service: MagicMock,
+        self,
+        v1_client: TestClient,
+        mock_service: MagicMock,
     ) -> None:
         """AC #6: DELETE /process/{id}/archive stops team via V2 service."""
         mock_service.stop_team.return_value = None
@@ -432,7 +461,9 @@ class TestV1ProcessRoutes:
         mock_service.stop_team.assert_called_once_with(_TEAM_ID)
 
     def test_archive_process_not_found(
-        self, v1_client: TestClient, mock_service: MagicMock,
+        self,
+        v1_client: TestClient,
+        mock_service: MagicMock,
     ) -> None:
         """DELETE /process/{id}/archive returns 404 for unknown team."""
         mock_service.stop_team.side_effect = ValueError("not found")
@@ -440,7 +471,9 @@ class TestV1ProcessRoutes:
         assert resp.status_code == 404
 
     def test_archive_process_conflict(
-        self, v1_client: TestClient, mock_service: MagicMock,
+        self,
+        v1_client: TestClient,
+        mock_service: MagicMock,
     ) -> None:
         """DELETE /process/{id}/archive returns 409 for already stopped team."""
         mock_service.stop_team.side_effect = ValueError("already stopped")
@@ -448,7 +481,9 @@ class TestV1ProcessRoutes:
         assert resp.status_code == 409
 
     def test_restore_process(
-        self, v1_client: TestClient, mock_service: MagicMock,
+        self,
+        v1_client: TestClient,
+        mock_service: MagicMock,
     ) -> None:
         """AC #7: POST /process/{id}/restore restores team via V2 service."""
         mock_service.restore_team.return_value = _make_process()
@@ -459,7 +494,9 @@ class TestV1ProcessRoutes:
         mock_service.restore_team.assert_called_once_with(_TEAM_ID)
 
     def test_restore_process_not_found(
-        self, v1_client: TestClient, mock_service: MagicMock,
+        self,
+        v1_client: TestClient,
+        mock_service: MagicMock,
     ) -> None:
         """POST /process/{id}/restore returns 404 for unknown team."""
         mock_service.restore_team.side_effect = ValueError("not found")
@@ -467,7 +504,9 @@ class TestV1ProcessRoutes:
         assert resp.status_code == 404
 
     def test_restore_process_conflict(
-        self, v1_client: TestClient, mock_service: MagicMock,
+        self,
+        v1_client: TestClient,
+        mock_service: MagicMock,
     ) -> None:
         """POST /process/{id}/restore returns 409 when already running."""
         mock_service.restore_team.side_effect = ValueError("already running")
@@ -479,7 +518,9 @@ class TestV1HumanInputRoute:
     """Test V1 human input endpoint translation."""
 
     def test_process_human_input(
-        self, v1_client: TestClient, mock_service: MagicMock,
+        self,
+        v1_client: TestClient,
+        mock_service: MagicMock,
     ) -> None:
         """AC #6: POST /process_human_input/{id}/human/{proxy} routes human input."""
         mock_service.process_human_input.return_value = None
@@ -489,11 +530,15 @@ class TestV1HumanInputRoute:
         )
         assert resp.status_code == 200
         mock_service.process_human_input.assert_called_once_with(
-            _TEAM_ID, "yes", "msg-123",
+            _TEAM_ID,
+            "yes",
+            "msg-123",
         )
 
     def test_process_human_input_not_found(
-        self, v1_client: TestClient, mock_service: MagicMock,
+        self,
+        v1_client: TestClient,
+        mock_service: MagicMock,
     ) -> None:
         """POST /process_human_input returns 404 for unknown team."""
         mock_service.process_human_input.side_effect = ValueError("not found")
@@ -503,9 +548,10 @@ class TestV1HumanInputRoute:
         )
         assert resp.status_code == 404
 
-
     def test_process_human_input_missing_message_id(
-        self, v1_client: TestClient, mock_service: MagicMock,
+        self,
+        v1_client: TestClient,
+        mock_service: MagicMock,
     ) -> None:
         """POST /process_human_input returns 422 when message has no 'id' field."""
         resp = v1_client.post(
@@ -519,7 +565,9 @@ class TestV1MessagesRoute:
     """Test V1 messages endpoint translation."""
 
     def test_get_messages(
-        self, v1_client: TestClient, mock_service: MagicMock,
+        self,
+        v1_client: TestClient,
+        mock_service: MagicMock,
     ) -> None:
         """AC #3: GET /messages/{id} returns event-sourced messages in V1 format."""
         user_msg = UserMessage(content="hello")
@@ -534,7 +582,9 @@ class TestV1MessagesRoute:
         assert data[0]["type"] == "user"
 
     def test_get_messages_not_found(
-        self, v1_client: TestClient, mock_service: MagicMock,
+        self,
+        v1_client: TestClient,
+        mock_service: MagicMock,
     ) -> None:
         """GET /messages/{id} returns 404 for unknown team."""
         mock_service.get_events.side_effect = ValueError("not found")
@@ -542,7 +592,9 @@ class TestV1MessagesRoute:
         assert resp.status_code == 404
 
     def test_get_messages_filters_non_content_events(
-        self, v1_client: TestClient, mock_service: MagicMock,
+        self,
+        v1_client: TestClient,
+        mock_service: MagicMock,
     ) -> None:
         """GET /messages/{id} filters out events without content."""
         user_msg = UserMessage(content="hello")
@@ -562,7 +614,9 @@ class TestV1LlmContextRoute:
     """Test V1 LLM context endpoint translation."""
 
     def test_get_llm_context_grouped(
-        self, v1_client: TestClient, mock_service: MagicMock,
+        self,
+        v1_client: TestClient,
+        mock_service: MagicMock,
     ) -> None:
         """AC #5: GET /llm_context/{id} returns context grouped by agent ID."""
         user_msg = UserMessage(content="hello")
@@ -581,7 +635,9 @@ class TestV1LlmContextRoute:
         assert data["system"]["context"][0]["content"] == "hello"
 
     def test_get_llm_context_not_found(
-        self, v1_client: TestClient, mock_service: MagicMock,
+        self,
+        v1_client: TestClient,
+        mock_service: MagicMock,
     ) -> None:
         """GET /llm_context/{id} returns 404 for unknown team."""
         mock_service.get_events.side_effect = ValueError("not found")
@@ -593,7 +649,9 @@ class TestV1StatesRoute:
     """Test V1 states endpoint translation."""
 
     def test_get_states_not_found(
-        self, v1_client: TestClient, mock_service: MagicMock,
+        self,
+        v1_client: TestClient,
+        mock_service: MagicMock,
     ) -> None:
         """AC #6: GET /states/{id} returns 404 for unknown team."""
         mock_service.get_events.side_effect = ValueError("not found")
@@ -601,7 +659,9 @@ class TestV1StatesRoute:
         assert resp.status_code == 404
 
     def test_get_states_empty(
-        self, v1_client: TestClient, mock_service: MagicMock,
+        self,
+        v1_client: TestClient,
+        mock_service: MagicMock,
     ) -> None:
         """GET /states/{id} returns empty dict when no state events."""
         user_msg = UserMessage(content="hello")
@@ -613,7 +673,9 @@ class TestV1StatesRoute:
         assert resp.json() == {}
 
     def test_get_states_grouped(
-        self, v1_client: TestClient, mock_service: MagicMock,
+        self,
+        v1_client: TestClient,
+        mock_service: MagicMock,
     ) -> None:
         """AC #6: GET /states/{id} returns states grouped by agent, latest wins."""
         sender = MagicMock()
@@ -636,7 +698,9 @@ class TestV1MessageExtraction:
     """Test message content extraction and classification helper coverage."""
 
     def test_sent_message_content_extraction(
-        self, v1_client: TestClient, mock_service: MagicMock,
+        self,
+        v1_client: TestClient,
+        mock_service: MagicMock,
     ) -> None:
         """SentMessage.message.content is extracted when outer has no content."""
         inner = UserMessage(content="inner content")
@@ -652,7 +716,9 @@ class TestV1MessageExtraction:
         assert len(data) >= 1
 
     def test_result_message_classified_as_agent(
-        self, v1_client: TestClient, mock_service: MagicMock,
+        self,
+        v1_client: TestClient,
+        mock_service: MagicMock,
     ) -> None:
         """ResultMessage events are classified as 'agent' type."""
         result_msg = ResultMessage(content="AI response")
@@ -666,7 +732,9 @@ class TestV1MessageExtraction:
         assert data[0]["type"] == "agent"
 
     def test_llm_context_filters_non_content_events(
-        self, v1_client: TestClient, mock_service: MagicMock,
+        self,
+        v1_client: TestClient,
+        mock_service: MagicMock,
     ) -> None:
         """GET /llm_context/{id} filters out events without displayable content."""
         user_msg = UserMessage(content="hello")
@@ -785,7 +853,9 @@ class TestV1ProcessContextNewFields:
         assert restored == ctx
 
     def test_to_v1_process_context_populates_new_fields(
-        self, v1_client: TestClient, mock_service: MagicMock,
+        self,
+        v1_client: TestClient,
+        mock_service: MagicMock,
     ) -> None:
         """AC #3: GET /process/{id} orchestrator is V1ActorAddress."""
         process = _make_process()
@@ -803,7 +873,9 @@ class TestV1ProcessContextNewFields:
         assert data["user_email"] == ""
 
     def test_to_v1_process_context_populates_params(
-        self, v1_client: TestClient, mock_service: MagicMock,
+        self,
+        v1_client: TestClient,
+        mock_service: MagicMock,
     ) -> None:
         """AC #7: GET /process/{id} params has workspace and knowledge_graph."""
         process = _make_process()
@@ -814,7 +886,9 @@ class TestV1ProcessContextNewFields:
         assert data["params"] == {"workspace": "false", "knowledge_graph": "false"}
 
     def test_running_false_when_stopped(
-        self, v1_client: TestClient, mock_service: MagicMock,
+        self,
+        v1_client: TestClient,
+        mock_service: MagicMock,
     ) -> None:
         """Running field is False when team is stopped."""
         process = _make_process(status=TeamStatus.STOPPED)
@@ -931,7 +1005,9 @@ class TestV1DescriptionEndpoint:
     """Test PATCH /process/{id}/description endpoint."""
 
     def test_update_description_ok(
-        self, v1_client: TestClient, mock_service: MagicMock,
+        self,
+        v1_client: TestClient,
+        mock_service: MagicMock,
     ) -> None:
         """AC3: PATCH /process/{id}/description returns ok."""
         mock_service.get_team.return_value = _make_process()
@@ -943,7 +1019,9 @@ class TestV1DescriptionEndpoint:
         assert resp.json()["status"] == "ok"
 
     def test_update_description_not_found(
-        self, v1_client: TestClient, mock_service: MagicMock,
+        self,
+        v1_client: TestClient,
+        mock_service: MagicMock,
     ) -> None:
         """PATCH /process/{id}/description returns 404 for missing team."""
         mock_service.get_team.return_value = None
@@ -958,7 +1036,9 @@ class TestV1RelaunchEndpoint:
     """Test POST /relaunch/{id}/message/{msgId} endpoint."""
 
     def test_relaunch_message_ok(
-        self, v1_client: TestClient, mock_service: MagicMock,
+        self,
+        v1_client: TestClient,
+        mock_service: MagicMock,
     ) -> None:
         """AC3: POST /relaunch/{id}/message/{msgId} re-sends message."""
         msg = UserMessage(content="original message")
@@ -972,7 +1052,9 @@ class TestV1RelaunchEndpoint:
         mock_service.send_message.assert_called_once_with(_TEAM_ID, "original message")
 
     def test_relaunch_message_not_found_team(
-        self, v1_client: TestClient, mock_service: MagicMock,
+        self,
+        v1_client: TestClient,
+        mock_service: MagicMock,
     ) -> None:
         """POST /relaunch/{id}/message/{msgId} returns 404 for unknown team."""
         mock_service.get_events.side_effect = ValueError("not found")
@@ -980,7 +1062,9 @@ class TestV1RelaunchEndpoint:
         assert resp.status_code == 404
 
     def test_relaunch_message_not_found_msg(
-        self, v1_client: TestClient, mock_service: MagicMock,
+        self,
+        v1_client: TestClient,
+        mock_service: MagicMock,
     ) -> None:
         """POST /relaunch/{id}/message/{msgId} returns 404 for unknown msg."""
         mock_service.get_events.return_value = []
@@ -992,7 +1076,9 @@ class TestV1StateUpdateEndpoint:
     """Test PATCH /state/{id}/of/{agent} endpoint."""
 
     def test_update_agent_state_ok(
-        self, v1_client: TestClient, mock_service: MagicMock,
+        self,
+        v1_client: TestClient,
+        mock_service: MagicMock,
     ) -> None:
         """AC3: PATCH /state/{id}/of/{agent} sends to agent."""
         mock_handle = MagicMock()
@@ -1006,7 +1092,9 @@ class TestV1StateUpdateEndpoint:
         mock_handle.send_to.assert_called_once_with("@Worker", "update state")
 
     def test_update_agent_state_not_found(
-        self, v1_client: TestClient, mock_service: MagicMock,
+        self,
+        v1_client: TestClient,
+        mock_service: MagicMock,
     ) -> None:
         """PATCH /state/{id}/of/{agent} returns 404 when no handle."""
         mock_service.get_handle.return_value = None
@@ -1040,7 +1128,9 @@ class TestV1TeamConfigsEndpoint:
     """Test GET /team-configs endpoint."""
 
     def test_get_team_configs_dict(
-        self, v1_client: TestClient, mock_service: MagicMock,
+        self,
+        v1_client: TestClient,
+        mock_service: MagicMock,
     ) -> None:
         """AC4: GET /team-configs returns dict keyed by team name."""
         mock_entry = MagicMock()
@@ -1060,7 +1150,9 @@ class TestV1TeamConfigsEndpoint:
         assert setup_parsed["id"] == "team-1"
 
     def test_get_team_configs_empty(
-        self, v1_client: TestClient, mock_service: MagicMock,
+        self,
+        v1_client: TestClient,
+        mock_service: MagicMock,
     ) -> None:
         """GET /team-configs returns empty dict when no entries."""
         v1_client.app.state.services.team_catalog.list.return_value = []  # type: ignore[union-attr]
@@ -1073,7 +1165,9 @@ class TestV1ConfigEndpoints:
     """Test config CRUD endpoints."""
 
     def test_get_config_by_type(
-        self, v1_client: TestClient, mock_service: MagicMock,
+        self,
+        v1_client: TestClient,
+        mock_service: MagicMock,
     ) -> None:
         """AC3: GET /config/{type} returns catalog entries."""
         mock_entry = MagicMock()
@@ -1093,7 +1187,9 @@ class TestV1ConfigEndpoints:
         assert resp.status_code == 400
 
     def test_delete_config_ok(
-        self, v1_client: TestClient, mock_service: MagicMock,
+        self,
+        v1_client: TestClient,
+        mock_service: MagicMock,
     ) -> None:
         """AC #5: DELETE /config/{type}/{id} deletes catalog entry."""
         mock_entry = MagicMock()
@@ -1103,7 +1199,9 @@ class TestV1ConfigEndpoints:
         assert resp.json()["status"] == "ok"
 
     def test_delete_config_not_found(
-        self, v1_client: TestClient, mock_service: MagicMock,
+        self,
+        v1_client: TestClient,
+        mock_service: MagicMock,
     ) -> None:
         """DELETE /config/{type}/{id} returns 404 for missing entry."""
         v1_client.app.state.services.tool_catalog.get.return_value = None  # type: ignore[union-attr]
@@ -1115,7 +1213,9 @@ class TestV1PutConfigEndpoint:
     """Test PUT /config endpoint."""
 
     def test_put_config_update_existing(
-        self, v1_client: TestClient, mock_service: MagicMock,
+        self,
+        v1_client: TestClient,
+        mock_service: MagicMock,
     ) -> None:
         """AC #4: PUT /config/{type} updates existing catalog entry."""
         mock_existing = MagicMock()
@@ -1131,7 +1231,9 @@ class TestV1PutConfigEndpoint:
         v1_client.app.state.services.agent_catalog.update.assert_called_once()  # type: ignore[union-attr]
 
     def test_put_config_create_new(
-        self, v1_client: TestClient, mock_service: MagicMock,
+        self,
+        v1_client: TestClient,
+        mock_service: MagicMock,
     ) -> None:
         """AC #4: PUT /config/{type} creates new catalog entry when not found."""
         mock_entry = MagicMock()
@@ -1148,7 +1250,9 @@ class TestV1PutConfigEndpoint:
         v1_client.app.state.services.agent_catalog.create.assert_called_once()  # type: ignore[union-attr]
 
     def test_put_config_empty_catalog_returns_400(
-        self, v1_client: TestClient, mock_service: MagicMock,
+        self,
+        v1_client: TestClient,
+        mock_service: MagicMock,
     ) -> None:
         """PUT /config/{type} returns 400 when catalog is empty."""
         v1_client.app.state.services.agent_catalog.get.return_value = None  # type: ignore[union-attr]
@@ -1222,7 +1326,9 @@ class TestV1GroupedResponses:
     """Test grouped dict response shapes for team-configs, llm_context, states."""
 
     def test_llm_context_multi_agent_grouping(
-        self, v1_client: TestClient, mock_service: MagicMock,
+        self,
+        v1_client: TestClient,
+        mock_service: MagicMock,
     ) -> None:
         """AC5: llm_context groups entries by agent ID."""
         sender_a = MagicMock()
@@ -1251,7 +1357,9 @@ class TestV1GroupedResponses:
         assert "timestamp" in data["@AgentB"]["context"][0]
 
     def test_states_latest_wins(
-        self, v1_client: TestClient, mock_service: MagicMock,
+        self,
+        v1_client: TestClient,
+        mock_service: MagicMock,
     ) -> None:
         """AC6: states returns only latest state per agent."""
         sender = MagicMock()
@@ -1274,7 +1382,9 @@ class TestV1GroupedResponses:
         assert isinstance(data["@Manager"]["state"], dict)
 
     def test_states_multi_agent_grouping(
-        self, v1_client: TestClient, mock_service: MagicMock,
+        self,
+        v1_client: TestClient,
+        mock_service: MagicMock,
     ) -> None:
         """AC6: states groups by agent ID with multiple agents."""
         sender_a = MagicMock()
@@ -1300,7 +1410,9 @@ class TestV1GroupedResponses:
         assert isinstance(data["@AgentB"]["state"], dict)
 
     def test_team_configs_multiple_entries(
-        self, v1_client: TestClient, mock_service: MagicMock,
+        self,
+        v1_client: TestClient,
+        mock_service: MagicMock,
     ) -> None:
         """AC4: team-configs dict has entry per team."""
         entry_a = MagicMock()

--- a/tests/test_channel_dispatcher.py
+++ b/tests/test_channel_dispatcher.py
@@ -14,6 +14,7 @@ from akgentic.infra.adapters.channel_dispatcher import InteractionChannelDispatc
 # Stub adapters satisfying InteractionChannelAdapter protocol (structural)
 # ---------------------------------------------------------------------------
 
+
 class _MatchingAdapter:
     """Adapter stub that always matches."""
 
@@ -64,17 +65,20 @@ class _NonMatchingAdapter:
 # Helpers
 # ---------------------------------------------------------------------------
 
+
 def _make_addr() -> ActorAddressProxy:
-    return ActorAddressProxy({
-        "__actor_address__": True,
-        "__actor_type__": "akgentic.core.actor_address_impl.ActorAddressProxy",
-        "agent_id": str(uuid.uuid4()),
-        "name": "test-agent",
-        "role": "tester",
-        "team_id": str(uuid.uuid4()),
-        "squad_id": str(uuid.uuid4()),
-        "user_message": False,
-    })
+    return ActorAddressProxy(
+        {
+            "__actor_address__": True,
+            "__actor_type__": "akgentic.core.actor_address_impl.ActorAddressProxy",
+            "agent_id": str(uuid.uuid4()),
+            "name": "test-agent",
+            "role": "tester",
+            "team_id": str(uuid.uuid4()),
+            "squad_id": str(uuid.uuid4()),
+            "user_message": False,
+        }
+    )
 
 
 def _make_sent_message() -> SentMessage:
@@ -89,6 +93,7 @@ TEAM_ID = uuid.uuid4()
 # ---------------------------------------------------------------------------
 # AC #1: matches() then deliver() on matching adapter
 # ---------------------------------------------------------------------------
+
 
 class TestDispatchToMatchingAdapter:
     """AC #1: Dispatcher calls matches() then deliver() on matching adapters."""
@@ -108,6 +113,7 @@ class TestDispatchToMatchingAdapter:
 # ---------------------------------------------------------------------------
 # AC #2: non-SentMessage events are skipped
 # ---------------------------------------------------------------------------
+
 
 class TestSkipsNonSentMessage:
     """Dispatcher ignores non-SentMessage events."""
@@ -135,6 +141,7 @@ class TestSkipsNonSentMessage:
 # AC #2: no adapter matches → silently skip
 # ---------------------------------------------------------------------------
 
+
 class TestNoAdapterMatch:
     """When no adapter matches, message is silently skipped."""
 
@@ -151,15 +158,14 @@ class TestNoAdapterMatch:
 # AC #2: multi-channel delivery — ALL matching adapters get deliver()
 # ---------------------------------------------------------------------------
 
+
 class TestMultiChannelDelivery:
     """With multiple adapters, ALL matching adapters receive deliver()."""
 
     def test_all_matching_adapters_deliver(self) -> None:
         first = _MatchingAdapter()
         second = _MatchingAdapter()
-        dispatcher = InteractionChannelDispatcher(
-            team_id=TEAM_ID, adapters=[first, second]
-        )
+        dispatcher = InteractionChannelDispatcher(team_id=TEAM_ID, adapters=[first, second])
         sent = _make_sent_message()
         dispatcher.on_message(sent)
 
@@ -173,9 +179,7 @@ class TestMultiChannelDelivery:
     def test_skips_non_matching_then_delivers_to_match(self) -> None:
         non_match = _NonMatchingAdapter()
         match = _MatchingAdapter()
-        dispatcher = InteractionChannelDispatcher(
-            team_id=TEAM_ID, adapters=[non_match, match]
-        )
+        dispatcher = InteractionChannelDispatcher(team_id=TEAM_ID, adapters=[non_match, match])
         dispatcher.on_message(_make_sent_message())
 
         assert non_match.matches_called
@@ -205,6 +209,7 @@ class TestMultiChannelDelivery:
 # AC #3: set_restoring(True) causes all events to be skipped
 # ---------------------------------------------------------------------------
 
+
 class TestRestoreMode:
     """set_restoring suppresses delivery during event replay."""
 
@@ -233,15 +238,14 @@ class TestRestoreMode:
 # AC #4: on_stop() calls adapter.on_stop(team_id) on ALL adapters
 # ---------------------------------------------------------------------------
 
+
 class TestOnStop:
     """on_stop() propagates to all registered adapters."""
 
     def test_on_stop_calls_all_adapters(self) -> None:
         a1 = _MatchingAdapter()
         a2 = _NonMatchingAdapter()
-        dispatcher = InteractionChannelDispatcher(
-            team_id=TEAM_ID, adapters=[a1, a2]
-        )
+        dispatcher = InteractionChannelDispatcher(team_id=TEAM_ID, adapters=[a1, a2])
         dispatcher.on_stop()
 
         assert a1.stop_called
@@ -257,6 +261,7 @@ class TestOnStop:
 # ---------------------------------------------------------------------------
 # Edge case: empty adapter list with SentMessage
 # ---------------------------------------------------------------------------
+
 
 class TestEmptyAdapterList:
     """Dispatcher with empty adapter list handles messages without error."""

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -35,26 +35,44 @@ def _mock_client(**overrides: Any) -> MagicMock:
     mock = MagicMock()
     mock.list_teams.return_value = [
         TeamInfo(
-            team_id="t1", name="Team 1", status="running",
-            user_id="u1", created_at="2025-01-01", updated_at="2025-01-01",
+            team_id="t1",
+            name="Team 1",
+            status="running",
+            user_id="u1",
+            created_at="2025-01-01",
+            updated_at="2025-01-01",
         ),
     ]
     mock.get_team.return_value = TeamInfo(
-        team_id="t1", name="Team 1", status="running",
-        user_id="u1", created_at="2025-01-01", updated_at="2025-01-02",
+        team_id="t1",
+        name="Team 1",
+        status="running",
+        user_id="u1",
+        created_at="2025-01-01",
+        updated_at="2025-01-02",
     )
     mock.create_team.return_value = TeamInfo(
-        team_id="new", name="New Team", status="created",
-        user_id="u1", created_at="2025-01-01", updated_at="2025-01-01",
+        team_id="new",
+        name="New Team",
+        status="created",
+        user_id="u1",
+        created_at="2025-01-01",
+        updated_at="2025-01-01",
     )
     mock.delete_team.return_value = None
     mock.restore_team.return_value = TeamInfo(
-        team_id="t1", name="Team 1", status="running",
-        user_id="u1", created_at="2025-01-01", updated_at="2025-01-03",
+        team_id="t1",
+        name="Team 1",
+        status="running",
+        user_id="u1",
+        created_at="2025-01-01",
+        updated_at="2025-01-03",
     )
     mock.get_events.return_value = [
         EventInfo(
-            team_id="t1", sequence=1, timestamp="2025-01-01T00:00:00",
+            team_id="t1",
+            sequence=1,
+            timestamp="2025-01-01T00:00:00",
             event={"type": "started"},
         ),
     ]

--- a/tests/test_cli_commands_insession.py
+++ b/tests/test_cli_commands_insession.py
@@ -374,9 +374,7 @@ class TestFilesHandler:
 
     async def test_empty_workspace(self, capsys: pytest.CaptureFixture[str]) -> None:
         client = _mock_client()
-        client.workspace_tree.return_value = WorkspaceTreeInfo(
-            team_id="t1", path="/", entries=[]
-        )
+        client.workspace_tree.return_value = WorkspaceTreeInfo(team_id="t1", path="/", entries=[])
         session = _make_session(client=client)
 
         await _files_handler("", session)

--- a/tests/test_frontend_adapter.py
+++ b/tests/test_frontend_adapter.py
@@ -37,7 +37,8 @@ class _StubAdapter:
     def wrap_ws_event(self, event: PersistedEvent) -> WrappedWsEvent:
         return WrappedWsEvent(
             payload=UnknownPayload(
-                type="stub", data={"wrapped": True, "sequence": event.sequence},
+                type="stub",
+                data={"wrapped": True, "sequence": event.sequence},
             ),
         )
 
@@ -133,7 +134,8 @@ class TestLoadFrontendAdapter:
             return_value=mod,
         ):
             with pytest.raises(
-                TypeError, match="does not implement FrontendAdapter protocol",
+                TypeError,
+                match="does not implement FrontendAdapter protocol",
             ):
                 load_frontend_adapter("fake_adapter_module._NotAnAdapter")
 
@@ -293,11 +295,13 @@ class TestWebSocketAdapterIntegration:
             assert "__model__" in data
 
     def test_ws_calls_wrap_ws_event_when_adapter_present(
-        self, client_with_adapter: TestClient,
+        self,
+        client_with_adapter: TestClient,
     ) -> None:
         """AC #1: Adapter present — wrap_ws_event is called."""
         resp = client_with_adapter.post(
-            "/teams/", json={"catalog_entry_id": "test-team"},
+            "/teams/",
+            json={"catalog_entry_id": "test-team"},
         )
         assert resp.status_code == 201
         team_id = resp.json()["team_id"]

--- a/tests/test_local_ingestion.py
+++ b/tests/test_local_ingestion.py
@@ -63,9 +63,7 @@ async def test_initiate_team_creates_and_sends() -> None:
 
     result = await ingestion.initiate_team("first message", "user-42", "catalog-entry-1")
 
-    mock_service.create_team.assert_called_once_with(
-        "catalog-entry-1", user_id="user-42"
-    )
+    mock_service.create_team.assert_called_once_with("catalog-entry-1", user_id="user-42")
     mock_service.send_message.assert_called_once_with(new_team_id, "first message")
     assert result == new_team_id
 

--- a/tests/test_local_team_handle.py
+++ b/tests/test_local_team_handle.py
@@ -98,7 +98,9 @@ class TestLocalTeamHandleProcessHumanInput:
 
         handle = LocalTeamHandle(runtime)
         message = MagicMock()
-        with pytest.raises(ValueError, match="HumanProxy 'human' found but has no resolved address"):
+        with pytest.raises(
+            ValueError, match="HumanProxy 'human' found but has no resolved address"
+        ):
             handle.process_human_input("input", message)
 
     def test_process_human_input_raises_for_empty_agent_cards(self) -> None:
@@ -152,7 +154,8 @@ class TestLocalTeamHandleSubscribe:
         handle.subscribe(subscriber)
 
         runtime.actor_system.proxy_ask.assert_called_once_with(
-            runtime.orchestrator_addr, Orchestrator,
+            runtime.orchestrator_addr,
+            Orchestrator,
         )
         mock_orch_proxy.subscribe.assert_called_once_with(subscriber)
 
@@ -173,6 +176,7 @@ class TestLocalTeamHandleUnsubscribe:
         handle.unsubscribe(subscriber)
 
         runtime.actor_system.proxy_ask.assert_called_once_with(
-            runtime.orchestrator_addr, Orchestrator,
+            runtime.orchestrator_addr,
+            Orchestrator,
         )
         mock_orch_proxy.unsubscribe.assert_called_once_with(subscriber)

--- a/tests/test_logging_config.py
+++ b/tests/test_logging_config.py
@@ -1,0 +1,69 @@
+"""Tests for configure_logging() utility."""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Generator
+
+import pytest
+
+from akgentic.infra.server.logging_config import configure_logging
+
+
+class TestConfigureLogging:
+    """configure_logging() sets up root logger deterministically."""
+
+    @pytest.fixture(autouse=True)
+    def _reset_root_logger(self) -> Generator[None, None, None]:
+        """Save and restore root logger state around each test."""
+        root = logging.getLogger()
+        original_level = root.level
+        original_handlers = list(root.handlers)
+        yield
+        root.setLevel(original_level)
+        root.handlers = original_handlers
+
+    def test_sets_root_level_debug(self) -> None:
+        """configure_logging('DEBUG') sets root logger to DEBUG."""
+        configure_logging("DEBUG")
+        assert logging.getLogger().level == logging.DEBUG
+
+    def test_sets_root_level_info(self) -> None:
+        """configure_logging('INFO') sets root logger to INFO."""
+        configure_logging("INFO")
+        assert logging.getLogger().level == logging.INFO
+
+    def test_sets_format(self) -> None:
+        """Handler format matches the expected pattern."""
+        configure_logging("INFO")
+        root = logging.getLogger()
+        assert len(root.handlers) == 1
+        formatter = root.handlers[0].formatter
+        assert formatter is not None
+        assert "%(asctime)s" in formatter._fmt
+        assert "%(levelname)" in formatter._fmt
+        assert "%(name)s" in formatter._fmt
+        assert "%(message)s" in formatter._fmt
+
+    def test_suppresses_third_party_loggers(self) -> None:
+        """Third-party loggers are set to WARNING."""
+        configure_logging("DEBUG")
+        for name in (
+            "uvicorn",
+            "uvicorn.access",
+            "uvicorn.error",
+            "httpx",
+            "httpcore",
+            "pydantic_ai",
+        ):
+            assert logging.getLogger(name).level == logging.WARNING
+
+    def test_replaces_existing_handlers(self) -> None:
+        """configure_logging replaces existing handlers, not appends."""
+        root = logging.getLogger()
+        root.addHandler(logging.StreamHandler())
+        root.addHandler(logging.StreamHandler())
+        assert len(root.handlers) >= 2
+
+        configure_logging("INFO")
+        assert len(root.handlers) == 1

--- a/tests/test_protocols.py
+++ b/tests/test_protocols.py
@@ -360,14 +360,10 @@ def test_channel_registry_structural_subtyping() -> None:
     from akgentic.infra.protocols import ChannelRegistry
 
     class FakeRegistry:
-        async def register(
-            self, channel: str, channel_user_id: str, team_id: uuid.UUID
-        ) -> None:
+        async def register(self, channel: str, channel_user_id: str, team_id: uuid.UUID) -> None:
             pass
 
-        async def find_team(
-            self, channel: str, channel_user_id: str
-        ) -> uuid.UUID | None:
+        async def find_team(self, channel: str, channel_user_id: str) -> uuid.UUID | None:
             return None
 
         async def deregister(self, channel: str, channel_user_id: str) -> None:
@@ -453,11 +449,13 @@ def test_team_handle_is_runtime_checkable() -> None:
     assert getattr(TeamHandle, "__protocol_attrs__", None) is not None or hasattr(
         TeamHandle, "_is_runtime_protocol"
     )
+
     # Verify isinstance works (runtime_checkable requirement)
     class FakeHandle:
         @property
         def team_id(self) -> object:
             import uuid
+
             return uuid.uuid4()
 
         def send(self, content: str) -> None:
@@ -530,9 +528,7 @@ def test_team_handle_method_count() -> None:
     from akgentic.infra.protocols import TeamHandle
 
     public_methods = [
-        m
-        for m in dir(TeamHandle)
-        if not m.startswith("_") and callable(getattr(TeamHandle, m))
+        m for m in dir(TeamHandle) if not m.startswith("_") and callable(getattr(TeamHandle, m))
     ]
     assert len(public_methods) == 5
 
@@ -629,9 +625,7 @@ def test_runtime_cache_method_count() -> None:
     from akgentic.infra.protocols import RuntimeCache
 
     public_methods = [
-        m
-        for m in dir(RuntimeCache)
-        if not m.startswith("_") and callable(getattr(RuntimeCache, m))
+        m for m in dir(RuntimeCache) if not m.startswith("_") and callable(getattr(RuntimeCache, m))
     ]
     assert len(public_methods) == 3
 
@@ -786,8 +780,6 @@ def test_worker_handle_method_count() -> None:
     from akgentic.infra.protocols import WorkerHandle
 
     public_methods = [
-        m
-        for m in dir(WorkerHandle)
-        if not m.startswith("_") and callable(getattr(WorkerHandle, m))
+        m for m in dir(WorkerHandle) if not m.startswith("_") and callable(getattr(WorkerHandle, m))
     ]
     assert len(public_methods) == 4

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -67,10 +67,15 @@ def test_infra_all_includes_server_app_and_models() -> None:
     from akgentic import infra
 
     expected = (
-        "create_app", "CreateTeamRequest", "TeamResponse",
-        "TeamListResponse", "TeamService",
-        "SendMessageRequest", "HumanInputRequest",
-        "EventResponse", "EventListResponse",
+        "create_app",
+        "CreateTeamRequest",
+        "TeamResponse",
+        "TeamListResponse",
+        "TeamService",
+        "SendMessageRequest",
+        "HumanInputRequest",
+        "EventResponse",
+        "EventListResponse",
     )
     for name in expected:
         assert name in infra.__all__, f"Missing export: {name}"

--- a/tests/test_server_settings.py
+++ b/tests/test_server_settings.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+import warnings
 from pathlib import Path
 
 from akgentic.infra.server.settings import CommunitySettings, ServerSettings
@@ -60,6 +61,47 @@ class TestServerSettingsEnvOverride:
             assert settings.frontend_adapter == "my.adapter.Class"
         finally:
             del os.environ["AKGENTIC_FRONTEND_ADAPTER"]
+
+
+class TestServerSettingsLogLevel:
+    """ServerSettings log_level field — validation and env override."""
+
+    def test_default_log_level(self) -> None:
+        """Default log_level is INFO."""
+        settings = ServerSettings()
+        assert settings.log_level == "INFO"
+
+    def test_log_level_from_env(self) -> None:
+        """AKGENTIC_LOG_LEVEL overrides log_level field."""
+        os.environ["AKGENTIC_LOG_LEVEL"] = "DEBUG"
+        try:
+            settings = ServerSettings()
+            assert settings.log_level == "DEBUG"
+        finally:
+            del os.environ["AKGENTIC_LOG_LEVEL"]
+
+    def test_log_level_case_insensitive(self) -> None:
+        """AKGENTIC_LOG_LEVEL is normalized to uppercase."""
+        os.environ["AKGENTIC_LOG_LEVEL"] = "debug"
+        try:
+            settings = ServerSettings()
+            assert settings.log_level == "DEBUG"
+        finally:
+            del os.environ["AKGENTIC_LOG_LEVEL"]
+
+    def test_invalid_log_level_falls_back(self) -> None:
+        """Invalid AKGENTIC_LOG_LEVEL falls back to INFO with a warning."""
+
+        os.environ["AKGENTIC_LOG_LEVEL"] = "TRACE"
+        try:
+            with warnings.catch_warnings(record=True) as w:
+                warnings.simplefilter("always")
+                settings = ServerSettings()
+                assert settings.log_level == "INFO"
+                assert len(w) == 1
+                assert "TRACE" in str(w[0].message)
+        finally:
+            del os.environ["AKGENTIC_LOG_LEVEL"]
 
 
 class TestServerSettingsModel:

--- a/tests/test_team_action_routes.py
+++ b/tests/test_team_action_routes.py
@@ -18,7 +18,8 @@ def test_send_message_success(client: TestClient) -> None:
 def test_send_message_not_found(client: TestClient) -> None:
     """POST /teams/{id}/message on non-existent team returns 404."""
     resp = client.post(
-        f"/teams/{uuid.uuid4()}/message", json={"content": "hello"},
+        f"/teams/{uuid.uuid4()}/message",
+        json={"content": "hello"},
     )
     assert resp.status_code == 404
 

--- a/tests/test_team_service.py
+++ b/tests/test_team_service.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 import uuid
 
 import pytest
@@ -79,3 +80,29 @@ def test_delete_team_not_found_raises(team_service: TeamService) -> None:
     """delete_team raises ValueError for a nonexistent team ID."""
     with pytest.raises(ValueError, match="not found"):
         team_service.delete_team(uuid.uuid4())
+
+
+class TestTeamServiceLogging:
+    """TeamService emits expected log messages."""
+
+    def test_create_team_emits_info_log(
+        self,
+        team_service: TeamService,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """create_team() emits INFO log with team_id and catalog_entry."""
+        with caplog.at_level(logging.INFO, logger="akgentic.infra.server.services.team_service"):
+            team_service.create_team("test-team", user_id="anonymous")
+        assert any("Team created" in r.message for r in caplog.records)
+
+    def test_delete_team_emits_info_log(
+        self,
+        team_service: TeamService,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """delete_team() emits INFO log with team_id."""
+        process = team_service.create_team("test-team", user_id="anonymous")
+        caplog.clear()
+        with caplog.at_level(logging.INFO, logger="akgentic.infra.server.services.team_service"):
+            team_service.delete_team(process.team_id)
+        assert any("Team deleted" in r.message for r in caplog.records)

--- a/tests/test_telegram_adapter.py
+++ b/tests/test_telegram_adapter.py
@@ -17,17 +17,20 @@ from akgentic.infra.adapters.telegram_adapter import TelegramChannelAdapter
 # Helpers (following test_channel_dispatcher.py patterns)
 # ---------------------------------------------------------------------------
 
+
 def _make_addr(role: str = "UserProxy", name: str = "987654321") -> ActorAddressProxy:
-    return ActorAddressProxy({
-        "__actor_address__": True,
-        "__actor_type__": "akgentic.core.actor_address_impl.ActorAddressProxy",
-        "agent_id": str(uuid.uuid4()),
-        "name": name,
-        "role": role,
-        "team_id": str(uuid.uuid4()),
-        "squad_id": str(uuid.uuid4()),
-        "user_message": False,
-    })
+    return ActorAddressProxy(
+        {
+            "__actor_address__": True,
+            "__actor_type__": "akgentic.core.actor_address_impl.ActorAddressProxy",
+            "agent_id": str(uuid.uuid4()),
+            "name": name,
+            "role": role,
+            "team_id": str(uuid.uuid4()),
+            "squad_id": str(uuid.uuid4()),
+            "user_message": False,
+        }
+    )
 
 
 def _make_sent_message(
@@ -46,6 +49,7 @@ def _make_sent_message(
 # ---------------------------------------------------------------------------
 # Mock transport for httpx
 # ---------------------------------------------------------------------------
+
 
 class _CaptureTransport(httpx.BaseTransport):
     """Captures requests and returns configurable responses."""
@@ -80,6 +84,7 @@ def _make_adapter(
 # AC 3: matches() returns True for UserProxy
 # ---------------------------------------------------------------------------
 
+
 class TestMatchesUserProxy:
     """AC 3: SentMessage targeting UserProxy → matches() returns True."""
 
@@ -92,6 +97,7 @@ class TestMatchesUserProxy:
 # ---------------------------------------------------------------------------
 # AC 4: matches() returns False for non-UserProxy
 # ---------------------------------------------------------------------------
+
 
 class TestMatchesNonUserProxy:
     """AC 4: SentMessage targeting non-UserProxy → matches() returns False."""
@@ -110,6 +116,7 @@ class TestMatchesNonUserProxy:
 # ---------------------------------------------------------------------------
 # AC 5: deliver() POSTs to Telegram API
 # ---------------------------------------------------------------------------
+
 
 class TestDeliver:
     """AC 5: deliver() sends correct POST to Telegram sendMessage."""
@@ -133,6 +140,7 @@ class TestDeliver:
 # AC 6: deliver() handles errors without raising
 # ---------------------------------------------------------------------------
 
+
 class TestDeliverError:
     """AC 6: Telegram API error → logged, no exception raised."""
 
@@ -151,6 +159,7 @@ class TestDeliverError:
 # ---------------------------------------------------------------------------
 # on_stop() cleanup
 # ---------------------------------------------------------------------------
+
 
 class TestOnStop:
     """on_stop() closes the httpx client without error."""

--- a/tests/test_telegram_integration.py
+++ b/tests/test_telegram_integration.py
@@ -110,12 +110,17 @@ class _StubChannelRegistry:
         self.registrations: list[tuple] = []
 
     async def register(
-        self, channel: str, channel_user_id: str, team_id: uuid.UUID,
+        self,
+        channel: str,
+        channel_user_id: str,
+        team_id: uuid.UUID,
     ) -> None:
         self.registrations.append((channel, channel_user_id, team_id))
 
     async def find_team(
-        self, channel: str, channel_user_id: str,
+        self,
+        channel: str,
+        channel_user_id: str,
     ) -> uuid.UUID | None:
         return None
 
@@ -130,7 +135,8 @@ class TestWebhookWithTelegramParser:
         from akgentic.infra.server.routes.webhook import router
 
         parser = TelegramChannelParser(
-            bot_token="test-token", default_catalog_entry="test-team",
+            bot_token="test-token",
+            default_catalog_entry="test-team",
         )
         registry = ChannelParserRegistry(channels_config={})
         registry._parsers[parser.channel_name] = parser

--- a/tests/test_telegram_parser.py
+++ b/tests/test_telegram_parser.py
@@ -50,6 +50,7 @@ PHOTO_MESSAGE_UPDATE: dict = {
 # Properties
 # ---------------------------------------------------------------------------
 
+
 class TestChannelName:
     """channel_name property returns 'telegram'."""
 
@@ -73,6 +74,7 @@ class TestDefaultCatalogEntry:
 # ---------------------------------------------------------------------------
 # parse() — happy path
 # ---------------------------------------------------------------------------
+
 
 class TestParseValidTextMessage:
     """AC 1: Valid Telegram text Update → correct ChannelMessage."""
@@ -105,6 +107,7 @@ class TestParseValidTextMessage:
 # ---------------------------------------------------------------------------
 # parse() — error cases
 # ---------------------------------------------------------------------------
+
 
 class TestParseNoMessage:
     """AC 2: Update with no 'message' key raises ValueError."""

--- a/tests/test_webhook_route.py
+++ b/tests/test_webhook_route.py
@@ -17,6 +17,7 @@ from akgentic.infra.server.routes.webhook import router as webhook_router
 # Stub classes satisfying protocols via structural subtyping
 # ---------------------------------------------------------------------------
 
+
 class StubParser:
     """Stub ChannelParser that returns a configurable ChannelMessage."""
 
@@ -83,6 +84,7 @@ class StubIngestion:
 # Fixtures / helpers
 # ---------------------------------------------------------------------------
 
+
 def _build_parser_registry(parser: StubParser) -> ChannelParserRegistry:
     """Build a ChannelParserRegistry with a pre-registered stub parser.
 
@@ -113,6 +115,7 @@ def _build_app(
 # ---------------------------------------------------------------------------
 # Tests
 # ---------------------------------------------------------------------------
+
 
 class TestWebhookReplyFlow:
     """AC #3: team_id in parsed message → route_reply."""
@@ -195,13 +198,9 @@ class TestWebhookInitiationFlow:
         assert call[1] == "user-3"
         assert call[2] == "my-catalog-entry"
 
-    async def test_initiation_registers_in_channel_registry(
-        self, tmp_path: Path
-    ) -> None:
+    async def test_initiation_registers_in_channel_registry(self, tmp_path: Path) -> None:
         parser = StubParser()
-        parser.set_next_message(
-            ChannelMessage(content="hello", channel_user_id="user-4")
-        )
+        parser.set_next_message(ChannelMessage(content="hello", channel_user_id="user-4"))
         new_team_id = uuid.uuid4()
         ingestion = StubIngestion()
         ingestion.set_next_team_id(new_team_id)
@@ -251,9 +250,7 @@ class TestWebhookStatusCode:
 
     def test_initiation_returns_204(self, tmp_path: Path) -> None:
         parser = StubParser()
-        parser.set_next_message(
-            ChannelMessage(content="msg", channel_user_id="u")
-        )
+        parser.set_next_message(ChannelMessage(content="msg", channel_user_id="u"))
         ingestion = StubIngestion()
         registry = YamlChannelRegistry(tmp_path / "registry.yaml")
         client = TestClient(_build_app(parser, ingestion, registry))
@@ -265,6 +262,7 @@ class TestWebhookStatusCode:
 # ---------------------------------------------------------------------------
 # AC #4: Form-data and unsupported content-type handling
 # ---------------------------------------------------------------------------
+
 
 class TestWebhookFormData:
     """AC #4: webhook handles application/x-www-form-urlencoded."""

--- a/tests/test_websocket_route.py
+++ b/tests/test_websocket_route.py
@@ -40,7 +40,8 @@ class TestWebSocketRoute:
     """Unit tests for WebSocket endpoint (AC #1, #2, #3, #4, #6)."""
 
     def test_ws_connect_nonexistent_team_receives_4004(
-        self, client: TestClient,
+        self,
+        client: TestClient,
     ) -> None:
         """AC #1: Non-existent team gets close code 4004."""
         from starlette.websockets import WebSocketDisconnect
@@ -52,7 +53,8 @@ class TestWebSocketRoute:
         assert exc_info.value.code == 4004
 
     def test_ws_connect_running_team_receives_events(
-        self, client: TestClient,
+        self,
+        client: TestClient,
     ) -> None:
         """AC #1, #2: Running team pushes events via subscriber."""
         resp = client.post("/teams/", json={"catalog_entry_id": "test-team"})
@@ -66,7 +68,8 @@ class TestWebSocketRoute:
             assert "__model__" in data
 
     def test_ws_connect_stopped_team_accepts_connection(
-        self, client: TestClient,
+        self,
+        client: TestClient,
     ) -> None:
         """AC #3: Stopped team accepts connection (idle)."""
         resp = client.post("/teams/", json={"catalog_entry_id": "test-team"})
@@ -78,7 +81,8 @@ class TestWebSocketRoute:
             pass
 
     def test_ws_event_json_contains_model_field(
-        self, client: TestClient,
+        self,
+        client: TestClient,
     ) -> None:
         """AC #1: __model__ discriminator in event JSON."""
         resp = client.post("/teams/", json={"catalog_entry_id": "test-team"})
@@ -90,7 +94,8 @@ class TestWebSocketRoute:
             assert "__model__" in data
 
     def test_ws_client_disconnect_triggers_cleanup(
-        self, client: TestClient,
+        self,
+        client: TestClient,
     ) -> None:
         """AC: Client disconnect unsubscribes from orchestrator."""
         resp = client.post("/teams/", json={"catalog_entry_id": "test-team"})
@@ -99,7 +104,6 @@ class TestWebSocketRoute:
         # Connect and immediately disconnect — should not raise
         with client.websocket_connect(f"/ws/{team_id}"):
             pass
-
 
     def test_ws_restore_scenario(self, client: TestClient) -> None:
         """AC #4: Idle connection starts receiving events after restore."""

--- a/tests/test_websocket_subscriber.py
+++ b/tests/test_websocket_subscriber.py
@@ -91,15 +91,17 @@ def _make_message() -> Message:
 
     from akgentic.core.actor_address_impl import ActorAddressProxy
 
-    addr = ActorAddressProxy({
-        "__actor_address__": True,
-        "__actor_type__": "akgentic.core.actor_address_impl.ActorAddressProxy",
-        "agent_id": str(uuid.uuid4()),
-        "name": "test-agent",
-        "role": "tester",
-        "team_id": str(uuid.uuid4()),
-        "squad_id": str(uuid.uuid4()),
-        "user_message": False,
-    })
+    addr = ActorAddressProxy(
+        {
+            "__actor_address__": True,
+            "__actor_type__": "akgentic.core.actor_address_impl.ActorAddressProxy",
+            "agent_id": str(uuid.uuid4()),
+            "name": "test-agent",
+            "role": "tester",
+            "team_id": str(uuid.uuid4()),
+            "squad_id": str(uuid.uuid4()),
+            "user_message": False,
+        }
+    )
     inner = Message(sender=addr)
     return SentMessage(message=inner, recipient=addr, sender=addr)

--- a/tests/test_wiring.py
+++ b/tests/test_wiring.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from collections.abc import Generator
 from pathlib import Path
 
@@ -18,6 +19,24 @@ from akgentic.infra.adapters.yaml_channel_registry import YamlChannelRegistry
 from akgentic.infra.server.deps import CommunityServices
 from akgentic.infra.server.settings import CommunitySettings
 from akgentic.infra.wiring import wire_community
+
+
+class TestWireCommunityLogging:
+    """wire_community() emits expected log messages."""
+
+    def test_emits_wiring_info_log(
+        self,
+        tmp_path: Path,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """wire_community() emits 'Wiring community services' INFO log."""
+        settings = CommunitySettings(workspaces_root=tmp_path)
+        with caplog.at_level(logging.INFO, logger="akgentic.infra.wiring"):
+            services = wire_community(settings)
+        try:
+            assert any("Wiring community services" in r.message for r in caplog.records)
+        finally:
+            services.team_manager._actor_system.shutdown(timeout=5)
 
 
 class TestWireCommunity:
@@ -73,7 +92,8 @@ class TestWireCommunity:
         assert services.service_registry is services.team_manager._service_registry
 
     def test_service_registry_satisfies_protocol(
-        self, services: CommunityServices,
+        self,
+        services: CommunityServices,
     ) -> None:
         """Service registry satisfies the ServiceRegistry protocol."""
         assert isinstance(services.service_registry, ServiceRegistry)
@@ -95,7 +115,8 @@ class TestWireCommunity:
             services.team_manager._actor_system.shutdown(timeout=5)
 
     def test_default_channel_registry_is_null(
-        self, services: CommunityServices,
+        self,
+        services: CommunityServices,
     ) -> None:
         """When channel_registry_path is None (default), uses NullChannelRegistry."""
         assert isinstance(services.channel_registry, NullChannelRegistry)

--- a/tests/test_workspace_routes.py
+++ b/tests/test_workspace_routes.py
@@ -81,9 +81,7 @@ def test_workspace_file_traversal_attack(
     client: TestClient, team_with_workspace: uuid.UUID
 ) -> None:
     """GET /workspace/{team_id}/file rejects path traversal attempts with 403."""
-    resp = client.get(
-        f"/workspace/{team_with_workspace}/file", params={"path": "../../etc/passwd"}
-    )
+    resp = client.get(f"/workspace/{team_with_workspace}/file", params={"path": "../../etc/passwd"})
     assert resp.status_code == 403
 
 

--- a/tests/test_yaml_channel_registry.py
+++ b/tests/test_yaml_channel_registry.py
@@ -29,9 +29,7 @@ async def test_satisfies_channel_registry_protocol() -> None:
     assert isinstance(YamlChannelRegistry(Path("/tmp/fake.yaml")), ChannelRegistry)
 
 
-async def test_register_creates_mapping(
-    registry: YamlChannelRegistry, registry_path: Path
-) -> None:
+async def test_register_creates_mapping(registry: YamlChannelRegistry, registry_path: Path) -> None:
     """register() persists a channel-user → team mapping to YAML."""
     team_id = uuid.uuid4()
     await registry.register("whatsapp", "+1234567890", team_id)


### PR DESCRIPTION
## Summary
- Add `AKGENTIC_LOG_LEVEL` field to `ServerSettings` with Pydantic validation and env var support
- Create `configure_logging()` utility with explicit root logger setup and third-party suppression
- Instrument all 6 layers per ADR-001 inventory: startup/wiring, HTTP routes, TeamService, WebSocket, adapters, channel ingestion
- Add 12 new tests covering settings, logging config, wiring logs, and team service logs
- Apply ruff format across the codebase

Relates to #92

## Test plan
- [x] All 698 existing tests pass
- [x] 12 new tests cover added functionality
- [x] Ruff lint and format checks pass