### PR TITLE
fix: CLI follow redirects, REPL rendering, and autocomplete

### DIFF
--- a/src/akgentic/infra/cli/client.py
+++ b/src/akgentic/infra/cli/client.py
@@ -74,7 +74,7 @@ class ApiClient:
         headers: dict[str, str] = {}
         if api_key:
             headers["Authorization"] = f"Bearer {api_key}"
-        self._client = httpx.Client(base_url=base_url, headers=headers)
+        self._client = httpx.Client(base_url=base_url, headers=headers, follow_redirects=True)
 
     def close(self) -> None:
         """Close the underlying HTTP client."""

--- a/src/akgentic/infra/cli/commands.py
+++ b/src/akgentic/infra/cli/commands.py
@@ -107,14 +107,28 @@ async def _agents_handler(args: str, session: ChatSession) -> None:
     """List team members with roles and state."""
     loop = asyncio.get_running_loop()
     try:
-        team = await loop.run_in_executor(None, session.client.get_team, session.team_id)
+        events = await loop.run_in_executor(None, session.client.get_events, session.team_id)
     except SystemExit:
         print("Error fetching agents.", file=sys.stderr)
         return
 
-    print(f"Team: {team.name}")
-    print(f"Status: {team.status}")
-    print("(Agent listing not available from this endpoint)")
+    seen: dict[str, str] = {}
+    for e in events:
+        evt = e.model_dump().get("event", {})
+        if evt.get("__model__", "").endswith("StartMessage"):
+            sender = evt.get("sender", {})
+            name = sender.get("name", "")
+            role = sender.get("role", "")
+            if name and name != "orchestrator":
+                seen[name] = role
+
+    if not seen:
+        print("No agents found.")
+        return
+
+    print("Team agents:")
+    for name, role in seen.items():
+        print(f"  {name:<16s} ({role})")
 
 
 # -- History command --

--- a/src/akgentic/infra/cli/repl.py
+++ b/src/akgentic/infra/cli/repl.py
@@ -7,6 +7,9 @@ import json
 from typing import Any
 
 import websockets.exceptions
+from prompt_toolkit import PromptSession
+from prompt_toolkit.completion import Completer, Completion
+from prompt_toolkit.history import InMemoryHistory
 
 from akgentic.infra.cli.client import ApiClient
 from akgentic.infra.cli.commands import CommandRegistry, build_default_registry
@@ -42,6 +45,10 @@ class ChatSession:
         self.command_registry: CommandRegistry = build_default_registry()
         self._running = True
         self._receive_task: asyncio.Task[None] | None = None
+        self._prompt_session: PromptSession[str] = PromptSession(
+            history=InMemoryHistory(),
+            completer=_SlashCompleter(self.command_registry),
+        )
 
     async def run(self) -> None:
         """Main REPL loop: connect WS, replay history, read input, stream events."""
@@ -71,7 +78,9 @@ class ChatSession:
         loop = asyncio.get_running_loop()
         while self._running:
             try:
-                line = await loop.run_in_executor(None, _read_input, "You: ")
+                line = await loop.run_in_executor(
+                    None, self._prompt_session.prompt, "You: "
+                )
             except (EOFError, KeyboardInterrupt):
                 break
 
@@ -142,9 +151,27 @@ class ChatSession:
         return _render_event_impl(data, self.renderer)
 
 
-def _read_input(prompt: str) -> str:
-    """Read a line from stdin (used via run_in_executor)."""
-    return input(prompt)
+class _SlashCompleter(Completer):
+    """Auto-complete slash commands from the command registry."""
+
+    def __init__(self, registry: CommandRegistry) -> None:
+        self._registry = registry
+
+    def get_completions(
+        self, document: Any, complete_event: Any
+    ) -> Any:  # noqa: ANN401
+        text = document.text_before_cursor
+        if not text.startswith("/"):
+            return
+        partial = text[1:]  # strip leading /
+        for cmd in self._registry.commands.values():
+            if cmd.name.startswith(partial):
+                yield Completion(
+                    f"/{cmd.name}",
+                    start_position=-len(text),
+                    display=f"/{cmd.name}",
+                    display_meta=cmd.help_text,
+                )
 
 
 def _render_event_impl(data: dict[str, Any], renderer: RichRenderer) -> bool:
@@ -157,22 +184,26 @@ def _render_event_impl(data: dict[str, Any], renderer: RichRenderer) -> bool:
             return False
 
     model = event.get("__model__", "")
-    if model not in _DISPLAY_EVENTS:
+    # Match short suffix (e.g. "SentMessage") from fully qualified model names
+    short_model = model.rsplit(".", 1)[-1] if model else ""
+    if short_model not in _DISPLAY_EVENTS:
         return False
 
-    if model == "ErrorMessage":
+    if short_model == "ErrorMessage":
         content = event.get("content", event.get("error", ""))
         renderer.render_error(str(content))
         return True
 
-    if model == "EventMessage":
+    if short_model == "EventMessage":
         return _render_event_message_impl(event, renderer)
 
-    # SentMessage — agent response
-    sender = event.get("sender", "agent")
-    content = event.get("content", "")
+    # SentMessage — agent response; content lives inside nested "message"
+    raw_sender = event.get("sender", "agent")
+    sender = raw_sender.get("name", "agent") if isinstance(raw_sender, dict) else str(raw_sender)
+    message = event.get("message", {})
+    content = message.get("content", "") if isinstance(message, dict) else ""
     if content:
-        renderer.render_agent_message(str(sender), str(content))
+        renderer.render_agent_message(sender, str(content))
         return True
     return False
 
@@ -191,10 +222,10 @@ def _render_event_message_impl(event: dict[str, Any], renderer: RichRenderer) ->
 
     nested_model = nested.get("__model__", "")
 
-    # Tool call events
+    # Tool call events (ToolCallEvent uses "arguments", others use "args"/"input")
     if "tool_name" in nested:
         tool_name = str(nested["tool_name"])
-        raw_input = nested.get("args", nested.get("input", ""))
+        raw_input = nested.get("arguments", nested.get("args", nested.get("input", "")))
         if isinstance(raw_input, dict | list):
             tool_input = json.dumps(raw_input, indent=2)
         else:

--- a/tests/test_cli_repl.py
+++ b/tests/test_cli_repl.py
@@ -13,7 +13,7 @@ from rich.console import Console
 from akgentic.infra.cli.client import EventInfo
 from akgentic.infra.cli.formatters import OutputFormat
 from akgentic.infra.cli.renderers import RichRenderer
-from akgentic.infra.cli.repl import ChatSession, _print_event
+from akgentic.infra.cli.repl import ChatSession, _print_event, _render_event_impl
 
 
 def _captured_renderer() -> tuple[RichRenderer, io.StringIO]:


### PR DESCRIPTION
## Summary
- Enable `follow_redirects=True` on the CLI HTTP client
- Fix REPL event rendering: handle fully qualified `__model__` names, nested `message.content`, and `arguments` field for tool calls
- Replace `input()` with `prompt_toolkit` for slash command autocomplete and input history
- Fix `/agents` command to extract agent roster from `StartMessage` events

## Test plan
- [x] Verify `ak-infra team list` works with redirects
- [x] Verify chat renders agent responses correctly
- [x] Verify `/agents` lists team members
- [x] Verify slash command autocomplete works when typing `/`