### PR TITLE
CI Triage: Make CI Honest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Override akgentic-infra submodule with current branch
         working-directory: packages/akgentic-infra
         run: |
-          git fetch origin ${{ github.head_ref || github.ref_name }}
+          git fetch origin master ${{ github.head_ref || github.ref_name }}
           git checkout FETCH_HEAD
 
       - name: Install uv
@@ -48,7 +48,7 @@ jobs:
         working-directory: packages/akgentic-infra
         run: |
           # test_cli.py exclusion deferred to story 9.4/9.5
-          if grep -r "MagicMock" tests/integration/ --include='*.py' -l | grep -v test_cli.py; then
+          if grep -r "MagicMock" tests/integration/ --include='*.py' -l | grep -v '/test_cli\.py$'; then
             echo "::error::MagicMock found in integration tests — integration tests must not use mocks"
             exit 1
           fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,13 +44,42 @@ jobs:
       - name: Linting
         run: uv run ruff check packages/akgentic-infra/src/
 
-      - name: Run tests with coverage
+      - name: Enforce no MagicMock in integration tests
+        working-directory: packages/akgentic-infra
+        run: |
+          # test_cli.py exclusion deferred to story 9.4/9.5
+          if grep -r "MagicMock" tests/integration/ --include='*.py' -l | grep -v test_cli.py; then
+            echo "::error::MagicMock found in integration tests — integration tests must not use mocks"
+            exit 1
+          fi
+
+      - name: Enforce zero src/ changes on test branches
+        if: startsWith(github.head_ref || github.ref_name, 'test/')
+        working-directory: packages/akgentic-infra
+        run: |
+          changed=$(git diff origin/master --name-only -- src/ || true)
+          if [ -n "$changed" ]; then
+            echo "::error::src/ changes detected on a test/* branch — test branches must not modify production code"
+            echo "$changed"
+            exit 1
+          fi
+
+      - name: Run unit tests with coverage
         run: >
           uv run pytest packages/akgentic-infra/tests/
+          --ignore=packages/akgentic-infra/tests/integration/
           --cov=akgentic.infra
           --cov-report=term-missing
           --cov-report=json:coverage.json
           --cov-fail-under=90
+
+      - name: Run integration tests (no coverage gate)
+        if: env.OPENAI_API_KEY != ''
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+        run: >
+          uv run pytest packages/akgentic-infra/tests/integration/ -v
+          -o "addopts="
 
       # Coverage badge is updated only on master push.
       # NOTE: Replace REPLACE_WITH_GIST_ID with the actual Gist ID after the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,7 +79,10 @@ max-statements = 50
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
 testpaths = ["tests"]
-markers = ["integration: Full server flow tests requiring real LLM and API keys"]
+markers = [
+    "integration: Full server flow tests requiring real LLM and API keys",
+    "llm: Tests requiring LLM API keys (auto-skipped when OPENAI_API_KEY is absent)",
+]
 addopts = "-m 'not integration' --cov=akgentic.infra --cov-branch"
 filterwarnings = ["ignore:No logs or spans:UserWarning"]
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,6 +18,15 @@ from akgentic.infra.server.settings import CommunitySettings
 from akgentic.infra.wiring import wire_community
 
 
+def pytest_collection_modifyitems(config: pytest.Config, items: list[pytest.Item]) -> None:
+    """Auto-skip tests marked with ``llm`` when OPENAI_API_KEY is not set."""
+    if not os.environ.get("OPENAI_API_KEY"):
+        skip_llm = pytest.mark.skip(reason="OPENAI_API_KEY not set")
+        for item in items:
+            if "llm" in item.keywords:
+                item.add_marker(skip_llm)
+
+
 def _write_yaml(path: Path, data: dict[str, object]) -> None:
     """Write a single YAML entry file."""
     path.parent.mkdir(parents=True, exist_ok=True)

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -44,11 +44,11 @@ _seed_integration_catalog = seed_integration_catalog
 
 @pytest.fixture(scope="session", autouse=True)
 def openai_api_key() -> str:
-    """Ensure OPENAI_API_KEY is available; fail fast if not."""
+    """Ensure OPENAI_API_KEY is available; skip if not."""
     load_dotenv(_PROJECT_ROOT / ".env")
     key = os.environ.get("OPENAI_API_KEY")
     if not key:
-        pytest.fail("OPENAI_API_KEY not set — required for integration tests")
+        pytest.skip("OPENAI_API_KEY not set — required for integration tests")
     return key
 
 

--- a/tests/integration/test_adr003_tier_agnostic.py
+++ b/tests/integration/test_adr003_tier_agnostic.py
@@ -26,7 +26,7 @@ from akgentic.infra.wiring import wire_community
 
 from ._helpers import create_team
 
-pytestmark = pytest.mark.integration
+pytestmark = [pytest.mark.integration, pytest.mark.llm]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/integration/test_adr004_v1_compat.py
+++ b/tests/integration/test_adr004_v1_compat.py
@@ -22,7 +22,7 @@ import time
 import pytest
 from fastapi.testclient import TestClient
 
-pytestmark = pytest.mark.integration
+pytestmark = [pytest.mark.integration, pytest.mark.llm]
 
 CATALOG_ENTRY_ID = "test-team"
 POLL_INTERVAL_S = 1.0

--- a/tests/integration/test_catalog.py
+++ b/tests/integration/test_catalog.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import pytest
 from fastapi.testclient import TestClient
 
-pytestmark = pytest.mark.integration
+pytestmark = [pytest.mark.integration, pytest.mark.llm]
 
 # ---------------------------------------------------------------------------
 # Tests (AC #3)

--- a/tests/integration/test_channels.py
+++ b/tests/integration/test_channels.py
@@ -21,7 +21,7 @@ from ._helpers import (
     wait_for_llm_response,
 )
 
-pytestmark = pytest.mark.integration
+pytestmark = [pytest.mark.integration, pytest.mark.llm]
 
 FOLLOWUP_CONTENT = "What is 7 + 7? Answer with the number."
 

--- a/tests/integration/test_cli.py
+++ b/tests/integration/test_cli.py
@@ -33,7 +33,7 @@ from ._helpers import (
     has_llm_content,
 )
 
-pytestmark = pytest.mark.integration
+pytestmark = [pytest.mark.integration, pytest.mark.llm]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/integration/test_events.py
+++ b/tests/integration/test_events.py
@@ -9,7 +9,7 @@ from fastapi.testclient import TestClient
 
 from ._helpers import create_team, has_llm_content, wait_for_llm_response
 
-pytestmark = pytest.mark.integration
+pytestmark = [pytest.mark.integration, pytest.mark.llm]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/integration/test_frontend_adapter.py
+++ b/tests/integration/test_frontend_adapter.py
@@ -8,7 +8,7 @@ import pytest
 from fastapi.testclient import TestClient
 from starlette.websockets import WebSocketDisconnect
 
-pytestmark = pytest.mark.integration
+pytestmark = [pytest.mark.integration, pytest.mark.llm]
 
 # ---------------------------------------------------------------------------
 # Helpers

--- a/tests/integration/test_spec_catalog.py
+++ b/tests/integration/test_spec_catalog.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 import pytest
 from fastapi.testclient import TestClient
 
-pytestmark = pytest.mark.integration
+pytestmark = [pytest.mark.integration, pytest.mark.llm]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/integration/test_spec_channels.py
+++ b/tests/integration/test_spec_channels.py
@@ -21,7 +21,7 @@ from akgentic.infra.adapters.channel_parser_registry import (
 
 from .test_channels import StubChannelAdapter
 
-pytestmark = pytest.mark.integration
+pytestmark = [pytest.mark.integration, pytest.mark.llm]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/integration/test_spec_compliance.py
+++ b/tests/integration/test_spec_compliance.py
@@ -19,7 +19,7 @@ from akgentic.infra.wiring import wire_community
 
 from ._helpers import create_team
 
-pytestmark = pytest.mark.integration
+pytestmark = [pytest.mark.integration, pytest.mark.llm]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/integration/test_spec_frontend.py
+++ b/tests/integration/test_spec_frontend.py
@@ -10,7 +10,7 @@ import time
 import pytest
 from fastapi.testclient import TestClient
 
-pytestmark = pytest.mark.integration
+pytestmark = [pytest.mark.integration, pytest.mark.llm]
 
 CATALOG_ENTRY_ID = "test-team"
 

--- a/tests/integration/test_team_lifecycle.py
+++ b/tests/integration/test_team_lifecycle.py
@@ -7,7 +7,7 @@ import time
 import pytest
 from fastapi.testclient import TestClient
 
-pytestmark = pytest.mark.integration
+pytestmark = [pytest.mark.integration, pytest.mark.llm]
 
 # ---------------------------------------------------------------------------
 # Helpers

--- a/tests/integration/test_websocket.py
+++ b/tests/integration/test_websocket.py
@@ -9,7 +9,7 @@ from fastapi.testclient import TestClient
 
 from ._helpers import create_team, has_llm_content, wait_for_llm_response
 
-pytestmark = pytest.mark.integration
+pytestmark = [pytest.mark.integration, pytest.mark.llm]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Added `pytest.mark.llm` marker to all 13 integration test files with auto-skip logic in `tests/conftest.py` when `OPENAI_API_KEY` is absent
- Added CI enforcement: no `MagicMock` in integration tests, zero `src/` changes on `test/*` branches
- Split CI coverage: unit tests with `--cov-fail-under=90`, integration tests run separately without coverage gate
- Changed integration `conftest.py` `openai_api_key` fixture from `pytest.fail` to `pytest.skip`
- Hardened CI grep pattern for exact `test_cli.py` match and ensured `origin/master` is fetched for src/ enforcement

Closes #97