### PR TITLE
Shared fixture factory for event and model types

### DIFF
--- a/tests/fixtures/README.md
+++ b/tests/fixtures/README.md
@@ -1,0 +1,78 @@
+# Test Fixture Factories
+
+**Rule: No hand-crafted event dicts -- use the fixture factory.**
+
+## Why
+
+Factory functions create real Pydantic model (or dataclass) instances and call
+`model_dump()` (or `dataclasses.asdict()`). This guarantees that every test dict
+matches the actual serialization contract. If a model field is added, removed, or
+renamed, the factory breaks at construction time -- not silently at test time.
+
+## Usage
+
+```python
+from tests.fixtures.events import make_sent_message, make_error_message
+from tests.fixtures.models import make_team_info
+
+# Zero-arg call gives sensible defaults
+event = make_sent_message()
+
+# Override only the fields you care about
+event = make_sent_message(content="custom greeting")
+error = make_error_message(exception_type="RuntimeError")
+team = make_team_info(name="My Team", status="stopped")
+```
+
+## Available Factories
+
+### Event factories (`tests/fixtures/events.py`)
+
+| Factory | Source Model | Package |
+|---|---|---|
+| `make_sent_message()` | `SentMessage` | akgentic-core |
+| `make_event_message()` | `EventMessage` | akgentic-core |
+| `make_error_message()` | `ErrorMessage` | akgentic-core |
+| `make_start_message()` | `StartMessage` | akgentic-core |
+| `make_received_message()` | `ReceivedMessage` | akgentic-core |
+| `make_processed_message()` | `ProcessedMessage` | akgentic-core |
+| `make_tool_call_event()` | `ToolCallEvent` | akgentic-llm |
+| `make_tool_return_event()` | `ToolReturnEvent` | akgentic-llm |
+| `make_llm_usage_event()` | `LlmUsageEvent` | akgentic-llm |
+
+### Model factories (`tests/fixtures/models.py`)
+
+| Factory | Source Model | Package |
+|---|---|---|
+| `make_team_info()` | `TeamInfo` | akgentic-infra |
+| `make_event_info()` | `EventInfo` | akgentic-infra |
+
+## The `**overrides` Pattern
+
+Every factory accepts `**overrides` to customize fields:
+
+```python
+def make_error_message(**overrides):
+    defaults = {
+        "exception_type": "ValueError",
+        "exception_value": "something went wrong",
+    }
+    defaults.update(overrides)
+    return ErrorMessage(**defaults).model_dump()
+```
+
+For `make_sent_message`, the `content` override is a convenience shortcut that
+sets the inner `UserMessage.content` field.
+
+## Adding New Factories
+
+When a new model type is introduced:
+
+1. Add a factory function in `events.py` (for event/message types) or `models.py`
+   (for CLI/server response models).
+2. Follow the pattern: defaults dict, merge overrides, construct real model,
+   return `model_dump()`.
+3. Add round-trip tests in `test_fixture_factories.py`:
+   - `test_round_trip_defaults` -- zero-arg call validates back to model
+   - `test_round_trip_with_overrides` -- custom args validate back to model
+   - `test_override_appears_in_output` -- override value present in dict

--- a/tests/fixtures/events.py
+++ b/tests/fixtures/events.py
@@ -21,7 +21,7 @@ from typing import Any
 
 from akgentic.core.actor_address_impl import ActorAddressProxy
 from akgentic.core.agent_config import BaseConfig
-from akgentic.core.messages.message import Message, UserMessage
+from akgentic.core.messages.message import UserMessage
 from akgentic.core.messages.orchestrator import (
     ErrorMessage,
     EventMessage,

--- a/tests/fixtures/events.py
+++ b/tests/fixtures/events.py
@@ -1,0 +1,178 @@
+"""Shared fixture factories for core and LLM event types.
+
+Each factory creates a real model/dataclass instance, then returns
+``model.model_dump()`` (Pydantic) or ``dataclasses.asdict()`` (dataclass).
+This guarantees the dict shape always matches the real serialization contract.
+
+Usage::
+
+    from tests.fixtures.events import make_sent_message
+
+    def test_something():
+        event = make_sent_message(content="custom")
+        # event is a plain dict matching SentMessage.model_dump()
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import uuid
+from typing import Any
+
+from akgentic.core.actor_address_impl import ActorAddressProxy
+from akgentic.core.agent_config import BaseConfig
+from akgentic.core.messages.message import Message, UserMessage
+from akgentic.core.messages.orchestrator import (
+    ErrorMessage,
+    EventMessage,
+    ProcessedMessage,
+    ReceivedMessage,
+    SentMessage,
+    StartMessage,
+)
+from akgentic.core.utils.deserializer import ActorAddressDict
+from akgentic.llm.event import LlmUsageEvent, ToolCallEvent, ToolReturnEvent
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_FIXED_UUID = uuid.UUID("00000000-0000-0000-0000-000000000001")
+_FIXED_TEAM_UUID = uuid.UUID("00000000-0000-0000-0000-000000000002")
+
+
+def _make_address_dict(**overrides: Any) -> ActorAddressDict:
+    """Build a minimal ``ActorAddressDict`` with sensible defaults."""
+    defaults: dict[str, Any] = {
+        "__actor_address__": True,
+        "__actor_type__": "akgentic.core.actor_address_impl.ActorAddressProxy",
+        "agent_id": str(overrides.pop("agent_id", _FIXED_UUID)),
+        "name": "test-agent",
+        "role": "TestRole",
+        "team_id": str(overrides.pop("team_id", _FIXED_TEAM_UUID)),
+        "squad_id": None,
+        "user_message": False,
+    }
+    defaults.update(overrides)
+    return defaults  # type: ignore[return-value]
+
+
+def _make_proxy(**overrides: Any) -> ActorAddressProxy:
+    """Create an ``ActorAddressProxy`` for use as sender/recipient."""
+    return ActorAddressProxy(_make_address_dict(**overrides))
+
+
+# ---------------------------------------------------------------------------
+# Core event factories
+# ---------------------------------------------------------------------------
+
+
+def make_sent_message(**overrides: Any) -> dict[str, Any]:
+    """Create a ``SentMessage`` fixture dict from a real model instance.
+
+    The inner ``message`` defaults to a ``UserMessage`` with ``content``
+    taken from *overrides* (default ``"Hello from test"``).
+    """
+    content = overrides.pop("content", "Hello from test")
+    inner = overrides.pop("message", UserMessage(content=content))
+    recipient = overrides.pop("recipient", _make_proxy(name="recipient"))
+    sender = overrides.pop("sender", _make_proxy(name="sender"))
+    defaults: dict[str, Any] = {
+        "message": inner,
+        "recipient": recipient,
+        "sender": sender,
+    }
+    defaults.update(overrides)
+    return SentMessage(**defaults).model_dump()
+
+
+def make_event_message(**overrides: Any) -> dict[str, Any]:
+    """Create an ``EventMessage`` fixture dict from a real model instance."""
+    defaults: dict[str, Any] = {
+        "event": overrides.pop("event", {"type": "test-event", "data": "sample"}),
+    }
+    defaults.update(overrides)
+    return EventMessage(**defaults).model_dump()
+
+
+def make_error_message(**overrides: Any) -> dict[str, Any]:
+    """Create an ``ErrorMessage`` fixture dict from a real model instance."""
+    defaults: dict[str, Any] = {
+        "exception_type": "ValueError",
+        "exception_value": "something went wrong",
+    }
+    defaults.update(overrides)
+    return ErrorMessage(**defaults).model_dump()
+
+
+def make_start_message(**overrides: Any) -> dict[str, Any]:
+    """Create a ``StartMessage`` fixture dict from a real model instance."""
+    config = overrides.pop("config", BaseConfig(name="test-agent", role="tester"))
+    defaults: dict[str, Any] = {
+        "config": config,
+    }
+    defaults.update(overrides)
+    return StartMessage(**defaults).model_dump()
+
+
+def make_received_message(**overrides: Any) -> dict[str, Any]:
+    """Create a ``ReceivedMessage`` fixture dict from a real model instance."""
+    defaults: dict[str, Any] = {
+        "message_id": overrides.pop("message_id", _FIXED_UUID),
+    }
+    defaults.update(overrides)
+    return ReceivedMessage(**defaults).model_dump()
+
+
+def make_processed_message(**overrides: Any) -> dict[str, Any]:
+    """Create a ``ProcessedMessage`` fixture dict from a real model instance."""
+    defaults: dict[str, Any] = {
+        "message_id": overrides.pop("message_id", _FIXED_UUID),
+    }
+    defaults.update(overrides)
+    return ProcessedMessage(**defaults).model_dump()
+
+
+# ---------------------------------------------------------------------------
+# LLM event factories (dataclasses → dataclasses.asdict)
+# ---------------------------------------------------------------------------
+
+
+def make_tool_call_event(**overrides: Any) -> dict[str, Any]:
+    """Create a ``ToolCallEvent`` fixture dict from a real dataclass instance."""
+    defaults: dict[str, Any] = {
+        "run_id": "run-001",
+        "tool_name": "test_tool",
+        "tool_call_id": "call-001",
+        "arguments": '{"key": "value"}',
+    }
+    defaults.update(overrides)
+    return dataclasses.asdict(ToolCallEvent(**defaults))
+
+
+def make_tool_return_event(**overrides: Any) -> dict[str, Any]:
+    """Create a ``ToolReturnEvent`` fixture dict from a real dataclass instance."""
+    defaults: dict[str, Any] = {
+        "run_id": "run-001",
+        "tool_name": "test_tool",
+        "tool_call_id": "call-001",
+        "success": True,
+    }
+    defaults.update(overrides)
+    return dataclasses.asdict(ToolReturnEvent(**defaults))
+
+
+def make_llm_usage_event(**overrides: Any) -> dict[str, Any]:
+    """Create an ``LlmUsageEvent`` fixture dict from a real dataclass instance."""
+    defaults: dict[str, Any] = {
+        "run_id": "run-001",
+        "model_name": "test-model",
+        "provider_name": "test-provider",
+        "input_tokens": 100,
+        "output_tokens": 50,
+        "cache_read_tokens": 0,
+        "cache_write_tokens": 0,
+        "requests": 1,
+    }
+    defaults.update(overrides)
+    return dataclasses.asdict(LlmUsageEvent(**defaults))

--- a/tests/fixtures/models.py
+++ b/tests/fixtures/models.py
@@ -1,0 +1,50 @@
+"""Shared fixture factories for CLI/server response models.
+
+Each factory creates a real Pydantic model instance, then returns
+``model.model_dump()``. This guarantees the dict shape always matches the
+real serialization contract.
+
+Usage::
+
+    from tests.fixtures.models import make_team_info
+
+    def test_something():
+        team = make_team_info(name="my-team")
+        # team is a plain dict matching TeamInfo.model_dump()
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from akgentic.infra.cli.client import EventInfo, TeamInfo
+
+# ---------------------------------------------------------------------------
+# CLI model factories
+# ---------------------------------------------------------------------------
+
+
+def make_team_info(**overrides: Any) -> dict[str, Any]:
+    """Create a ``TeamInfo`` fixture dict from a real model instance."""
+    defaults: dict[str, Any] = {
+        "team_id": "team-001",
+        "name": "Test Team",
+        "status": "running",
+        "user_id": "user-001",
+        "created_at": "2026-01-01T00:00:00Z",
+        "updated_at": "2026-01-01T00:00:00Z",
+    }
+    defaults.update(overrides)
+    return TeamInfo(**defaults).model_dump()
+
+
+def make_event_info(**overrides: Any) -> dict[str, Any]:
+    """Create an ``EventInfo`` fixture dict from a real model instance."""
+    defaults: dict[str, Any] = {
+        "team_id": "team-001",
+        "sequence": 1,
+        "event": {"__model__": "SentMessage", "content": "test"},
+        "timestamp": "2026-01-01T00:00:00Z",
+    }
+    defaults.update(overrides)
+    return EventInfo(**defaults).model_dump()

--- a/tests/fixtures/test_fixture_factories.py
+++ b/tests/fixtures/test_fixture_factories.py
@@ -1,0 +1,262 @@
+"""Round-trip validation tests for fixture factories.
+
+Every factory must produce a dict that the original model can validate
+back into a model instance via ``Model.model_validate()`` (Pydantic) or
+direct dataclass construction (for frozen dataclasses).
+"""
+
+from __future__ import annotations
+
+import dataclasses
+
+import pytest
+
+from akgentic.core.messages.orchestrator import (
+    ErrorMessage,
+    EventMessage,
+    ProcessedMessage,
+    ReceivedMessage,
+    SentMessage,
+    StartMessage,
+)
+from akgentic.infra.cli.client import EventInfo, TeamInfo
+from akgentic.llm.event import LlmUsageEvent, ToolCallEvent, ToolReturnEvent
+
+from tests.fixtures.events import (
+    make_error_message,
+    make_event_message,
+    make_llm_usage_event,
+    make_processed_message,
+    make_received_message,
+    make_sent_message,
+    make_start_message,
+    make_tool_call_event,
+    make_tool_return_event,
+)
+from tests.fixtures.models import make_event_info, make_team_info
+
+
+# ---------------------------------------------------------------------------
+# Core event round-trip tests — zero overrides
+# ---------------------------------------------------------------------------
+
+
+class TestSentMessageFactory:
+    """Round-trip tests for make_sent_message."""
+
+    def test_round_trip_defaults(self) -> None:
+        data = make_sent_message()
+        model = SentMessage.model_validate(data)
+        assert model.message is not None
+        assert model.recipient is not None
+
+    def test_round_trip_with_overrides(self) -> None:
+        data = make_sent_message(content="custom content")
+        model = SentMessage.model_validate(data)
+        assert model.message is not None
+
+    def test_override_appears_in_output(self) -> None:
+        data = make_sent_message(content="hello world")
+        # content is on the inner message
+        assert data["message"]["content"] == "hello world"
+
+
+class TestEventMessageFactory:
+    """Round-trip tests for make_event_message."""
+
+    def test_round_trip_defaults(self) -> None:
+        data = make_event_message()
+        model = EventMessage.model_validate(data)
+        assert model.event is not None
+
+    def test_round_trip_with_overrides(self) -> None:
+        custom_event = {"type": "custom", "payload": 42}
+        data = make_event_message(event=custom_event)
+        model = EventMessage.model_validate(data)
+        assert model.event == custom_event
+
+    def test_override_appears_in_output(self) -> None:
+        data = make_event_message(event={"x": 1})
+        assert data["event"] == {"x": 1}
+
+
+class TestErrorMessageFactory:
+    """Round-trip tests for make_error_message."""
+
+    def test_round_trip_defaults(self) -> None:
+        data = make_error_message()
+        model = ErrorMessage.model_validate(data)
+        assert model.exception_type == "ValueError"
+
+    def test_round_trip_with_overrides(self) -> None:
+        data = make_error_message(exception_type="RuntimeError", exception_value="boom")
+        model = ErrorMessage.model_validate(data)
+        assert model.exception_type == "RuntimeError"
+        assert model.exception_value == "boom"
+
+    def test_override_appears_in_output(self) -> None:
+        data = make_error_message(exception_type="KeyError")
+        assert data["exception_type"] == "KeyError"
+
+
+class TestStartMessageFactory:
+    """Round-trip tests for make_start_message."""
+
+    def test_round_trip_defaults(self) -> None:
+        data = make_start_message()
+        model = StartMessage.model_validate(data)
+        assert model.config is not None
+
+    def test_round_trip_with_overrides(self) -> None:
+        from akgentic.core.agent_config import BaseConfig
+
+        custom_cfg = BaseConfig(name="custom-agent", role="custom")
+        data = make_start_message(config=custom_cfg)
+        model = StartMessage.model_validate(data)
+        assert model.config.name == "custom-agent"
+
+
+class TestReceivedMessageFactory:
+    """Round-trip tests for make_received_message."""
+
+    def test_round_trip_defaults(self) -> None:
+        data = make_received_message()
+        model = ReceivedMessage.model_validate(data)
+        assert model.message_id is not None
+
+    def test_round_trip_with_overrides(self) -> None:
+        import uuid
+
+        custom_id = uuid.uuid4()
+        data = make_received_message(message_id=custom_id)
+        model = ReceivedMessage.model_validate(data)
+        assert model.message_id == custom_id
+
+    def test_override_appears_in_output(self) -> None:
+        import uuid
+
+        custom_id = uuid.uuid4()
+        data = make_received_message(message_id=custom_id)
+        assert data["message_id"] == str(custom_id)
+
+
+class TestProcessedMessageFactory:
+    """Round-trip tests for make_processed_message."""
+
+    def test_round_trip_defaults(self) -> None:
+        data = make_processed_message()
+        model = ProcessedMessage.model_validate(data)
+        assert model.message_id is not None
+
+    def test_round_trip_with_overrides(self) -> None:
+        import uuid
+
+        custom_id = uuid.uuid4()
+        data = make_processed_message(message_id=custom_id)
+        model = ProcessedMessage.model_validate(data)
+        assert model.message_id == custom_id
+
+
+# ---------------------------------------------------------------------------
+# LLM event round-trip tests
+# ---------------------------------------------------------------------------
+
+
+class TestToolCallEventFactory:
+    """Round-trip tests for make_tool_call_event."""
+
+    def test_round_trip_defaults(self) -> None:
+        data = make_tool_call_event()
+        event = ToolCallEvent(**data)
+        assert event.tool_name == "test_tool"
+
+    def test_round_trip_with_overrides(self) -> None:
+        data = make_tool_call_event(tool_name="search", arguments='{"q": "hello"}')
+        event = ToolCallEvent(**data)
+        assert event.tool_name == "search"
+        assert event.arguments == '{"q": "hello"}'
+
+    def test_override_appears_in_output(self) -> None:
+        data = make_tool_call_event(tool_name="my_tool")
+        assert data["tool_name"] == "my_tool"
+
+
+class TestToolReturnEventFactory:
+    """Round-trip tests for make_tool_return_event."""
+
+    def test_round_trip_defaults(self) -> None:
+        data = make_tool_return_event()
+        event = ToolReturnEvent(**data)
+        assert event.success is True
+
+    def test_round_trip_with_overrides(self) -> None:
+        data = make_tool_return_event(success=False)
+        event = ToolReturnEvent(**data)
+        assert event.success is False
+
+    def test_override_appears_in_output(self) -> None:
+        data = make_tool_return_event(success=False)
+        assert data["success"] is False
+
+
+class TestLlmUsageEventFactory:
+    """Round-trip tests for make_llm_usage_event."""
+
+    def test_round_trip_defaults(self) -> None:
+        data = make_llm_usage_event()
+        event = LlmUsageEvent(**data)
+        assert event.input_tokens == 100
+        assert event.output_tokens == 50
+
+    def test_round_trip_with_overrides(self) -> None:
+        data = make_llm_usage_event(input_tokens=500, model_name="gpt-4")
+        event = LlmUsageEvent(**data)
+        assert event.input_tokens == 500
+        assert event.model_name == "gpt-4"
+
+    def test_override_appears_in_output(self) -> None:
+        data = make_llm_usage_event(requests=3)
+        assert data["requests"] == 3
+
+
+# ---------------------------------------------------------------------------
+# CLI model round-trip tests
+# ---------------------------------------------------------------------------
+
+
+class TestTeamInfoFactory:
+    """Round-trip tests for make_team_info."""
+
+    def test_round_trip_defaults(self) -> None:
+        data = make_team_info()
+        model = TeamInfo.model_validate(data)
+        assert model.team_id == "team-001"
+
+    def test_round_trip_with_overrides(self) -> None:
+        data = make_team_info(name="Custom Team", status="stopped")
+        model = TeamInfo.model_validate(data)
+        assert model.name == "Custom Team"
+        assert model.status == "stopped"
+
+    def test_override_appears_in_output(self) -> None:
+        data = make_team_info(name="My Team")
+        assert data["name"] == "My Team"
+
+
+class TestEventInfoFactory:
+    """Round-trip tests for make_event_info."""
+
+    def test_round_trip_defaults(self) -> None:
+        data = make_event_info()
+        model = EventInfo.model_validate(data)
+        assert model.sequence == 1
+
+    def test_round_trip_with_overrides(self) -> None:
+        data = make_event_info(sequence=42, team_id="team-xyz")
+        model = EventInfo.model_validate(data)
+        assert model.sequence == 42
+        assert model.team_id == "team-xyz"
+
+    def test_override_appears_in_output(self) -> None:
+        data = make_event_info(sequence=10)
+        assert data["sequence"] == 10

--- a/tests/fixtures/test_fixture_factories.py
+++ b/tests/fixtures/test_fixture_factories.py
@@ -7,10 +7,6 @@ direct dataclass construction (for frozen dataclasses).
 
 from __future__ import annotations
 
-import dataclasses
-
-import pytest
-
 from akgentic.core.messages.orchestrator import (
     ErrorMessage,
     EventMessage,
@@ -19,9 +15,9 @@ from akgentic.core.messages.orchestrator import (
     SentMessage,
     StartMessage,
 )
-from akgentic.infra.cli.client import EventInfo, TeamInfo
 from akgentic.llm.event import LlmUsageEvent, ToolCallEvent, ToolReturnEvent
 
+from akgentic.infra.cli.client import EventInfo, TeamInfo
 from tests.fixtures.events import (
     make_error_message,
     make_event_message,
@@ -34,7 +30,6 @@ from tests.fixtures.events import (
     make_tool_return_event,
 )
 from tests.fixtures.models import make_event_info, make_team_info
-
 
 # ---------------------------------------------------------------------------
 # Core event round-trip tests — zero overrides
@@ -115,6 +110,13 @@ class TestStartMessageFactory:
         model = StartMessage.model_validate(data)
         assert model.config.name == "custom-agent"
 
+    def test_override_appears_in_output(self) -> None:
+        from akgentic.core.agent_config import BaseConfig
+
+        custom_cfg = BaseConfig(name="overridden-agent", role="custom")
+        data = make_start_message(config=custom_cfg)
+        assert data["config"]["name"] == "overridden-agent"
+
 
 class TestReceivedMessageFactory:
     """Round-trip tests for make_received_message."""
@@ -155,6 +157,13 @@ class TestProcessedMessageFactory:
         data = make_processed_message(message_id=custom_id)
         model = ProcessedMessage.model_validate(data)
         assert model.message_id == custom_id
+
+    def test_override_appears_in_output(self) -> None:
+        import uuid
+
+        custom_id = uuid.uuid4()
+        data = make_processed_message(message_id=custom_id)
+        assert data["message_id"] == str(custom_id)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Add shared fixture factories for 9 event types and 2 CLI model types in `tests/fixtures/`
- Each factory creates real model instances and returns `model_dump()` / `dataclasses.asdict()` dicts
- 33 round-trip validation tests verify factories match actual serialization contracts
- Convention documented in `tests/fixtures/README.md`

## Review Fixes Applied

- Removed unused imports (Message, dataclasses, pytest)
- Fixed import sorting (ruff I001)
- Added missing `test_override_appears_in_output` tests for StartMessage and ProcessedMessage factories

## Test Results

- 732 tests pass, 94.84% coverage
- Zero `src/` changes (Epic 9 rule)
- No MagicMock in integration tests

Closes #99