### PR TITLE
Fix server and integration tests (Story 9.4)

### DIFF
--- a/tests/channels/test_channel_dispatcher.py
+++ b/tests/channels/test_channel_dispatcher.py
@@ -269,3 +269,30 @@ class TestEmptyAdapterList:
     def test_sent_message_with_no_adapters(self) -> None:
         dispatcher = InteractionChannelDispatcher(team_id=TEAM_ID, adapters=[])
         dispatcher.on_message(_make_sent_message())  # should not raise
+
+
+# ---------------------------------------------------------------------------
+# Reclassified from integration/test_spec_channels.py — TestMultiAdapterDispatch
+# Direct dispatcher construction with stubs; no real app needed.
+# ---------------------------------------------------------------------------
+
+
+class TestMultiAdapterDispatch:
+    """Verify dispatcher delivers to ALL matching adapters (no break short-circuit)."""
+
+    def test_two_adapters_both_receive_message(self) -> None:
+        """Two StubChannelAdapters both receive the dispatched SentMessage."""
+        adapter_a = _MatchingAdapter()
+        adapter_b = _MatchingAdapter()
+        dispatcher = InteractionChannelDispatcher(
+            team_id=TEAM_ID,
+            adapters=[adapter_a, adapter_b],
+        )
+
+        sent = _make_sent_message()
+        dispatcher.on_message(sent)
+
+        assert adapter_a.deliver_called, "Adapter A should receive the message"
+        assert adapter_b.deliver_called, "Adapter B should receive the message"
+        assert adapter_a.deliver_msg is sent
+        assert adapter_b.deliver_msg is sent

--- a/tests/channels/test_channel_parser_registry.py
+++ b/tests/channels/test_channel_parser_registry.py
@@ -321,3 +321,81 @@ def test_channel_config_is_pydantic_model() -> None:
     assert "parser_fqcn" in fields
     assert "adapter_fqcn" in fields
     assert "config" in fields
+
+
+# ---------------------------------------------------------------------------
+# Reclassified from integration/test_spec_channels.py — TestChannelConfigPassthrough
+# Uses monkeypatch + direct construction; no real app needed.
+# ---------------------------------------------------------------------------
+
+
+class _StubParserWithConfig:
+    """Parser stub that captures constructor config args."""
+
+    received_config: dict[str, str]
+
+    def __init__(self, **kwargs: str) -> None:
+        _StubParserWithConfig.received_config = dict(kwargs)
+
+    @property
+    def channel_name(self) -> str:
+        return "config-test-channel"
+
+    @property
+    def default_catalog_entry(self) -> str:
+        return "test-team"
+
+    async def parse(self, payload: dict[str, object]) -> None:
+        pass  # pragma: no cover
+
+
+class _StubAdapterWithConfig:
+    """Adapter stub that captures constructor config args."""
+
+    received_config: dict[str, str]
+
+    def __init__(self, **kwargs: str) -> None:
+        _StubAdapterWithConfig.received_config = dict(kwargs)
+
+    def matches(self, msg: object) -> bool:
+        return True  # pragma: no cover
+
+    def deliver(self, msg: object) -> None:
+        pass  # pragma: no cover
+
+    def on_stop(self, team_id: uuid.UUID) -> None:
+        pass  # pragma: no cover
+
+
+class TestChannelConfigPassthrough:
+    """Verify ChannelConfig.config values reach adapter/parser constructors."""
+
+    def test_config_dict_reaches_constructors(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Configure channel with config dict, verify it reaches constructors."""
+        monkeypatch.setattr(
+            "akgentic.infra.adapters.channel_parser_registry.import_class",
+            lambda fqcn: (
+                _StubParserWithConfig if "Parser" in fqcn else _StubAdapterWithConfig
+            ),
+        )
+
+        config = {
+            "test-chan": ChannelConfig(
+                parser_fqcn="fake.module.Parser",
+                adapter_fqcn="fake.module.Adapter",
+                config={"key": "value", "api_token": "secret123"},
+            )
+        }
+
+        ChannelParserRegistry(channels_config=config)
+
+        assert _StubParserWithConfig.received_config == {
+            "key": "value",
+            "api_token": "secret123",
+        }
+        assert _StubAdapterWithConfig.received_config == {
+            "key": "value",
+            "api_token": "secret123",
+        }

--- a/tests/frontend_adapter/test_v1_ws_classify.py
+++ b/tests/frontend_adapter/test_v1_ws_classify.py
@@ -1,0 +1,86 @@
+"""Unit tests — V1 WS envelope type classification.
+
+Reclassified from integration/test_spec_frontend.py (TestLlmContextEnvelope)
+and integration/test_adr004_v1_compat.py (TestWebSocketErrorEnvelope).
+These tests call _classify_envelope_type and wrap_event directly — no real app needed.
+"""
+
+from __future__ import annotations
+
+
+class TestLlmContextEnvelope:
+    """Verify the V1 WS handler emits llm_context envelope type."""
+
+    def test_classify_envelope_type_for_context_changed(self) -> None:
+        """_classify_envelope_type returns 'llm_context' for ContextChangedMessage."""
+        from akgentic.infra.server.routes.frontend_adapter.angular_v1.ws import (
+            _classify_envelope_type,
+        )
+
+        # _classify_envelope_type checks type(event).__name__ == "ContextChangedMessage"
+        class ContextChangedMessage:  # noqa: N801
+            """Fake message whose class name matches the real ContextChangedMessage."""
+
+            def __init__(self) -> None:
+                self.id = "test-id"
+                self.sender = None
+
+        result = _classify_envelope_type(ContextChangedMessage())  # type: ignore[arg-type]
+        assert result == "llm_context"
+
+    def test_classify_envelope_returns_message_for_user_message(self) -> None:
+        """_classify_envelope_type returns 'message' for UserMessage."""
+        from akgentic.core.messages.message import UserMessage
+
+        from akgentic.infra.server.routes.frontend_adapter.angular_v1.ws import (
+            _classify_envelope_type,
+        )
+
+        msg = UserMessage(content="hello")
+        result = _classify_envelope_type(msg)
+        assert result == "message"
+
+
+class TestWebSocketErrorEnvelope:
+    """Verify WebSocket error envelope classification and wrapping.
+
+    Reclassified from integration/test_adr004_v1_compat.py — these tests call
+    _classify_envelope_type and wrap_event directly, no real app needed.
+    """
+
+    def test_classify_error_message_returns_error(self) -> None:
+        """_classify_envelope_type(ErrorMessage) returns 'error'."""
+        from akgentic.core.messages.orchestrator import ErrorMessage
+
+        from akgentic.infra.server.routes.frontend_adapter.angular_v1.ws import (
+            _classify_envelope_type,
+        )
+
+        msg = ErrorMessage(exception_value="test error", exception_type="ValueError")
+        result = _classify_envelope_type(msg)
+        assert result == "error"
+
+    def test_wrap_event_error_produces_error_payload(self) -> None:
+        """wrap_event with ErrorMessage produces ErrorPayload with type=='error'."""
+        import uuid
+        from datetime import UTC, datetime
+
+        from akgentic.core.messages.orchestrator import ErrorMessage
+        from akgentic.team.models import PersistedEvent
+
+        from akgentic.infra.server.routes.frontend_adapter import ErrorPayload
+        from akgentic.infra.server.routes.frontend_adapter.angular_v1.ws import (
+            wrap_event,
+        )
+
+        msg = ErrorMessage(exception_value="something broke", exception_type="RuntimeError")
+        ev = PersistedEvent(
+            team_id=uuid.uuid4(),
+            sequence=1,
+            event=msg,
+            timestamp=datetime.now(tz=UTC),
+        )
+        wrapped = wrap_event(ev)
+        assert isinstance(wrapped.payload, ErrorPayload)
+        assert wrapped.payload.type == "error"
+        assert wrapped.payload.message == "something broke"

--- a/tests/integration/_helpers.py
+++ b/tests/integration/_helpers.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import time
+from collections.abc import Callable
 from pathlib import Path
 
 import pytest
@@ -118,6 +119,21 @@ def seed_integration_catalog(catalog_root: Path) -> None:
     )
     (catalog_root / "templates").mkdir(parents=True, exist_ok=True)
     (catalog_root / "tools").mkdir(parents=True, exist_ok=True)
+
+
+def poll_until(
+    predicate: Callable[[], bool],
+    timeout: float = 5.0,
+    interval: float = 0.1,
+    message: str = "Condition not met within timeout",
+) -> None:
+    """Poll predicate until True or raise TimeoutError after timeout."""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if predicate():
+            return
+        time.sleep(interval)
+    raise TimeoutError(message)
 
 
 def has_llm_content(events: list[dict[str, object]]) -> bool:

--- a/tests/integration/test_adr003_tier_agnostic.py
+++ b/tests/integration/test_adr003_tier_agnostic.py
@@ -107,6 +107,7 @@ class TestWorkerHandleLifecycle:
             assert cache.get(team_id) is not None
         finally:
             integration_client.post(f"/teams/{team_id_str}/stop")
+            # No pollable condition for teardown; sleep for actor cleanup
             time.sleep(0.5)
 
     def test_stop_team_via_worker_handle(

--- a/tests/integration/test_adr003_tier_agnostic.py
+++ b/tests/integration/test_adr003_tier_agnostic.py
@@ -2,13 +2,14 @@
 
 Validates stories 7.1 (WorkerHandle, PlacementStrategy) and 7.2
 (TierServices, ServerSettings, TeamService, create_app) end-to-end.
+
+Note: TestSettingsHierarchy and test_team_service_has_no_actor_internal_imports
+were reclassified as unit tests (story 9.4).
 """
 
 from __future__ import annotations
 
-import inspect
 import time
-import typing
 import uuid
 from pathlib import Path
 
@@ -21,10 +22,10 @@ from akgentic.infra.protocols.team_handle import RuntimeCache, TeamHandle
 from akgentic.infra.protocols.worker_handle import WorkerHandle
 from akgentic.infra.server.app import create_app
 from akgentic.infra.server.deps import CommunityServices, TierServices
-from akgentic.infra.server.settings import CommunitySettings, ServerSettings
+from akgentic.infra.server.settings import CommunitySettings
 from akgentic.infra.wiring import wire_community
 
-from ._helpers import create_team
+from ._helpers import create_team, poll_until
 
 pytestmark = [pytest.mark.integration, pytest.mark.llm]
 
@@ -100,13 +101,13 @@ class TestWorkerHandleLifecycle:
     ) -> None:
         """AC #1: POST /teams/ creates team; cache populated."""
         team_id_str = create_team(integration_client)
-        team_id = uuid.UUID(team_id_str)
-        cache = integration_app.state.services.runtime_cache
-        assert cache.get(team_id) is not None
-
-        # Cleanup
-        integration_client.post(f"/teams/{team_id_str}/stop")
-        time.sleep(0.5)
+        try:
+            team_id = uuid.UUID(team_id_str)
+            cache = integration_app.state.services.runtime_cache
+            assert cache.get(team_id) is not None
+        finally:
+            integration_client.post(f"/teams/{team_id_str}/stop")
+            time.sleep(0.5)
 
     def test_stop_team_via_worker_handle(
         self,
@@ -115,16 +116,19 @@ class TestWorkerHandleLifecycle:
     ) -> None:
         """AC #1: Stop team clears cache; team status reflects stopped."""
         team_id_str = create_team(integration_client)
-        team_id = uuid.UUID(team_id_str)
-        cache = integration_app.state.services.runtime_cache
+        try:
+            team_id = uuid.UUID(team_id_str)
+            cache = integration_app.state.services.runtime_cache
 
-        resp = integration_client.post(f"/teams/{team_id_str}/stop")
-        assert resp.status_code == 204
-        assert cache.get(team_id) is None
+            resp = integration_client.post(f"/teams/{team_id_str}/stop")
+            assert resp.status_code == 204
+            assert cache.get(team_id) is None
 
-        resp = integration_client.get(f"/teams/{team_id_str}")
-        assert resp.status_code == 200
-        assert resp.json()["status"] == "stopped"
+            resp = integration_client.get(f"/teams/{team_id_str}")
+            assert resp.status_code == 200
+            assert resp.json()["status"] == "stopped"
+        finally:
+            integration_client.post(f"/teams/{team_id_str}/stop")
 
     def test_resume_team_via_worker_handle(
         self,
@@ -133,20 +137,24 @@ class TestWorkerHandleLifecycle:
     ) -> None:
         """AC #1: Stop then restore repopulates cache; status is running."""
         team_id_str = create_team(integration_client)
-        team_id = uuid.UUID(team_id_str)
-        cache = integration_app.state.services.runtime_cache
+        try:
+            team_id = uuid.UUID(team_id_str)
+            cache = integration_app.state.services.runtime_cache
 
-        integration_client.post(f"/teams/{team_id_str}/stop")
-        time.sleep(0.5)
+            integration_client.post(f"/teams/{team_id_str}/stop")
+            poll_until(
+                lambda: cache.get(team_id) is None,
+                message="Cache not cleared after stop",
+            )
 
-        resp = integration_client.post(f"/teams/{team_id_str}/restore")
-        assert resp.status_code == 200
-        assert resp.json()["status"] == "running"
-        assert cache.get(team_id) is not None
-
-        # Cleanup
-        integration_client.post(f"/teams/{team_id_str}/stop")
-        time.sleep(0.5)
+            resp = integration_client.post(f"/teams/{team_id_str}/restore")
+            assert resp.status_code == 200
+            assert resp.json()["status"] == "running"
+            assert cache.get(team_id) is not None
+        finally:
+            integration_client.post(f"/teams/{team_id_str}/stop")
+            # No pollable condition for final teardown; sleep for actor cleanup
+            time.sleep(0.5)
 
     def test_delete_team_via_worker_handle(
         self,
@@ -155,21 +163,27 @@ class TestWorkerHandleLifecycle:
     ) -> None:
         """AC #1: Create, stop, delete -> team removed."""
         team_id_str = create_team(integration_client)
-        team_id = uuid.UUID(team_id_str)
-        cache = integration_app.state.services.runtime_cache
+        try:
+            team_id = uuid.UUID(team_id_str)
+            cache = integration_app.state.services.runtime_cache
 
-        integration_client.post(f"/teams/{team_id_str}/stop")
-        time.sleep(0.5)
+            integration_client.post(f"/teams/{team_id_str}/stop")
+            poll_until(
+                lambda: cache.get(team_id) is None,
+                message="Cache not cleared after stop",
+            )
 
-        resp = integration_client.delete(f"/teams/{team_id_str}")
-        assert resp.status_code == 204
-        assert cache.get(team_id) is None
+            resp = integration_client.delete(f"/teams/{team_id_str}")
+            assert resp.status_code == 204
+            assert cache.get(team_id) is None
 
-        resp = integration_client.get(f"/teams/{team_id_str}")
-        if resp.status_code == 200:
-            assert resp.json()["status"] == "deleted"
-        else:
-            assert resp.status_code == 404
+            resp = integration_client.get(f"/teams/{team_id_str}")
+            if resp.status_code == 200:
+                assert resp.json()["status"] == "deleted"
+            else:
+                assert resp.status_code == 404
+        finally:
+            integration_client.post(f"/teams/{team_id_str}/stop")
 
     def test_full_worker_lifecycle(
         self,
@@ -178,39 +192,46 @@ class TestWorkerHandleLifecycle:
     ) -> None:
         """AC #1: create -> stop -> resume -> stop -> delete in one test."""
         cache = integration_app.state.services.runtime_cache
-
-        # Create
         team_id_str = create_team(integration_client)
-        team_id = uuid.UUID(team_id_str)
-        assert cache.get(team_id) is not None
+        try:
+            team_id = uuid.UUID(team_id_str)
+            assert cache.get(team_id) is not None
 
-        # Stop
-        resp = integration_client.post(f"/teams/{team_id_str}/stop")
-        assert resp.status_code == 204
-        assert cache.get(team_id) is None
+            # Stop
+            resp = integration_client.post(f"/teams/{team_id_str}/stop")
+            assert resp.status_code == 204
+            assert cache.get(team_id) is None
 
-        # Resume
-        time.sleep(0.5)
-        resp = integration_client.post(f"/teams/{team_id_str}/restore")
-        assert resp.status_code == 200
-        assert cache.get(team_id) is not None
+            # Resume
+            poll_until(
+                lambda: cache.get(team_id) is None,
+                message="Cache not cleared after stop",
+            )
+            resp = integration_client.post(f"/teams/{team_id_str}/restore")
+            assert resp.status_code == 200
+            assert cache.get(team_id) is not None
 
-        # Stop again
-        resp = integration_client.post(f"/teams/{team_id_str}/stop")
-        assert resp.status_code == 204
-        assert cache.get(team_id) is None
+            # Stop again
+            resp = integration_client.post(f"/teams/{team_id_str}/stop")
+            assert resp.status_code == 204
+            assert cache.get(team_id) is None
 
-        # Delete
-        time.sleep(0.5)
-        resp = integration_client.delete(f"/teams/{team_id_str}")
-        assert resp.status_code == 204
-        assert cache.get(team_id) is None
+            # Delete
+            poll_until(
+                lambda: cache.get(team_id) is None,
+                message="Cache not cleared after second stop",
+            )
+            resp = integration_client.delete(f"/teams/{team_id_str}")
+            assert resp.status_code == 204
+            assert cache.get(team_id) is None
 
-        resp = integration_client.get(f"/teams/{team_id_str}")
-        if resp.status_code == 200:
-            assert resp.json()["status"] == "deleted"
-        else:
-            assert resp.status_code == 404
+            resp = integration_client.get(f"/teams/{team_id_str}")
+            if resp.status_code == 200:
+                assert resp.json()["status"] == "deleted"
+            else:
+                assert resp.status_code == 404
+        finally:
+            integration_client.post(f"/teams/{team_id_str}/stop")
 
 
 # ---------------------------------------------------------------------------
@@ -228,15 +249,15 @@ class TestTeamServiceProtocolRouting:
     ) -> None:
         """AC #3: Creating a team produces a handle in the runtime cache."""
         team_id_str = create_team(integration_client)
-        team_id = uuid.UUID(team_id_str)
-        cache = integration_app.state.services.runtime_cache
-        handle = cache.get(team_id)
-        assert handle is not None
-        assert isinstance(handle, TeamHandle)
-
-        # Cleanup
-        integration_client.post(f"/teams/{team_id_str}/stop")
-        time.sleep(0.5)
+        try:
+            team_id = uuid.UUID(team_id_str)
+            cache = integration_app.state.services.runtime_cache
+            handle = cache.get(team_id)
+            assert handle is not None
+            assert isinstance(handle, TeamHandle)
+        finally:
+            integration_client.post(f"/teams/{team_id_str}/stop")
+            time.sleep(0.5)
 
     def test_send_message_routes_through_team_handle(
         self,
@@ -244,28 +265,26 @@ class TestTeamServiceProtocolRouting:
     ) -> None:
         """AC #3: Send message via API; events appear."""
         team_id = create_team(integration_client)
+        try:
+            resp = integration_client.post(
+                f"/teams/{team_id}/message",
+                json={"content": "Hello from integration test"},
+            )
+            assert resp.status_code == 204
 
-        resp = integration_client.post(
-            f"/teams/{team_id}/message",
-            json={"content": "Hello from integration test"},
-        )
-        assert resp.status_code == 204
-
-        # SentMessage event should appear immediately
-        time.sleep(0.5)
-        resp = integration_client.get(f"/teams/{team_id}/events")
-        assert resp.status_code == 200
-        events = resp.json()["events"]
-        assert len(events) >= 1
-        # Verify at least one event contains the sent message content
-        event_strs = [str(ev) for ev in events]
-        assert any("Hello from integration test" in s for s in event_strs), (
-            f"Expected sent message content in events, got: {events}"
-        )
-
-        # Cleanup
-        integration_client.post(f"/teams/{team_id}/stop")
-        time.sleep(0.5)
+            # SentMessage event should appear immediately
+            time.sleep(0.5)
+            resp = integration_client.get(f"/teams/{team_id}/events")
+            assert resp.status_code == 200
+            events = resp.json()["events"]
+            assert len(events) >= 1
+            event_strs = [str(ev) for ev in events]
+            assert any("Hello from integration test" in s for s in event_strs), (
+                f"Expected sent message content in events, got: {events}"
+            )
+        finally:
+            integration_client.post(f"/teams/{team_id}/stop")
+            time.sleep(0.5)
 
     def test_stop_routes_through_worker_handle(
         self,
@@ -273,23 +292,22 @@ class TestTeamServiceProtocolRouting:
     ) -> None:
         """AC #3: Stop preserves events in event store."""
         team_id = create_team(integration_client)
+        try:
+            integration_client.post(
+                f"/teams/{team_id}/message",
+                json={"content": "Test message"},
+            )
+            time.sleep(0.5)
 
-        # Send a message to generate events
-        integration_client.post(
-            f"/teams/{team_id}/message",
-            json={"content": "Test message"},
-        )
-        time.sleep(0.5)
+            resp = integration_client.post(f"/teams/{team_id}/stop")
+            assert resp.status_code == 204
 
-        # Stop team
-        resp = integration_client.post(f"/teams/{team_id}/stop")
-        assert resp.status_code == 204
-
-        # Events should still be accessible
-        resp = integration_client.get(f"/teams/{team_id}/events")
-        assert resp.status_code == 200
-        events = resp.json()["events"]
-        assert len(events) >= 1
+            resp = integration_client.get(f"/teams/{team_id}/events")
+            assert resp.status_code == 200
+            events = resp.json()["events"]
+            assert len(events) >= 1
+        finally:
+            integration_client.post(f"/teams/{team_id}/stop")
 
     def test_restore_routes_through_worker_handle(
         self,
@@ -298,90 +316,23 @@ class TestTeamServiceProtocolRouting:
     ) -> None:
         """AC #3: Create, stop, restore -> team running, cache handle is TeamHandle."""
         team_id_str = create_team(integration_client)
-        team_id = uuid.UUID(team_id_str)
-
-        integration_client.post(f"/teams/{team_id_str}/stop")
-        time.sleep(0.5)
-
-        resp = integration_client.post(f"/teams/{team_id_str}/restore")
-        assert resp.status_code == 200
-        assert resp.json()["status"] == "running"
-
-        cache = integration_app.state.services.runtime_cache
-        handle = cache.get(team_id)
-        assert handle is not None
-        assert isinstance(handle, TeamHandle)
-
-        # Cleanup
-        integration_client.post(f"/teams/{team_id_str}/stop")
-        time.sleep(0.5)
-
-    def test_team_service_has_no_actor_internal_imports(self) -> None:
-        """AC #3: TeamService module does not import actor internals."""
-        from akgentic.infra.server.services import team_service as ts_module
-
-        source = inspect.getsource(ts_module)
-        forbidden = ["TeamManager", "ActorSystem", "LocalTeamHandle", "CommunityServices"]
-        for name in forbidden:
-            assert name not in source, f"TeamService module must not import {name}"
-
-
-# ---------------------------------------------------------------------------
-# AC #4 — Settings hierarchy validation
-# ---------------------------------------------------------------------------
-
-
-class TestSettingsHierarchy:
-    """Verify ServerSettings / CommunitySettings hierarchy."""
-
-    def test_server_settings_has_only_tier_agnostic_fields(self) -> None:
-        """AC #4: ServerSettings has only tier-agnostic fields."""
-        server_fields = set(ServerSettings.model_fields.keys())
-        expected = {"host", "port", "cors_origins", "frontend_adapter"}
-        assert server_fields == expected, (
-            f"ServerSettings fields mismatch: got {server_fields}, expected {expected}"
-        )
-
-    def test_community_settings_extends_server_settings(self) -> None:
-        """AC #4: CommunitySettings is a subclass of ServerSettings."""
-        assert issubclass(CommunitySettings, ServerSettings)
-        community_own_fields = set(CommunitySettings.model_fields.keys()) - set(
-            ServerSettings.model_fields.keys()
-        )
-        assert "workspaces_root" in community_own_fields
-        assert "catalog_path" in community_own_fields
-
-    def test_community_settings_no_literal_fields(self) -> None:
-        """AC #4: No Literal['yaml'] fields on either settings class."""
-        for cls in (ServerSettings, CommunitySettings):
-            for field_name, field_info in cls.model_fields.items():
-                annotation = field_info.annotation
-                origin = typing.get_origin(annotation)
-                if origin is typing.Literal:
-                    args = typing.get_args(annotation)
-                    assert "yaml" not in args, f"{cls.__name__}.{field_name} has Literal['yaml']"
-
-    def test_community_settings_wires_functional_app(self, tmp_path: Path) -> None:
-        """AC #4: End-to-end: CommunitySettings -> wire -> create_app -> team works."""
-        from ._helpers import seed_integration_catalog
-
-        settings = CommunitySettings(workspaces_root=tmp_path / "workspaces")
-        seed_integration_catalog(settings.workspaces_root / "catalog")
-        services = wire_community(settings)
         try:
-            app = create_app(services, settings)
-            client = TestClient(app)
+            team_id = uuid.UUID(team_id_str)
 
-            team_id = create_team(client)
-            resp = client.get(f"/teams/{team_id}")
+            integration_client.post(f"/teams/{team_id_str}/stop")
+            time.sleep(0.5)
+
+            resp = integration_client.post(f"/teams/{team_id_str}/restore")
             assert resp.status_code == 200
             assert resp.json()["status"] == "running"
 
-            # Cleanup
-            client.post(f"/teams/{team_id}/stop")
-            time.sleep(0.5)
+            cache = integration_app.state.services.runtime_cache
+            handle = cache.get(team_id)
+            assert handle is not None
+            assert isinstance(handle, TeamHandle)
         finally:
-            services.actor_system.shutdown()
+            integration_client.post(f"/teams/{team_id_str}/stop")
+            time.sleep(0.5)
 
 
 # ---------------------------------------------------------------------------
@@ -419,14 +370,11 @@ class TestCatalogAccessViaTierServices:
     ) -> None:
         """AC #3: Team created via API uses catalog resolution."""
         team_id = create_team(integration_client)
-        resp = integration_client.get(f"/teams/{team_id}")
-        assert resp.status_code == 200
-        data = resp.json()
-        assert data["status"] == "running"
-        # The team was created from catalog entry "test-team" which has
-        # entry_point "human-proxy" — verifying the team exists proves
-        # catalog resolution worked.
-
-        # Cleanup
-        integration_client.post(f"/teams/{team_id}/stop")
-        time.sleep(0.5)
+        try:
+            resp = integration_client.get(f"/teams/{team_id}")
+            assert resp.status_code == 200
+            data = resp.json()
+            assert data["status"] == "running"
+        finally:
+            integration_client.post(f"/teams/{team_id}/stop")
+            time.sleep(0.5)

--- a/tests/integration/test_adr004_v1_compat.py
+++ b/tests/integration/test_adr004_v1_compat.py
@@ -1,17 +1,9 @@
 """Integration tests -- ADR-004 V1 Frontend Adapter Compatibility.
 
-Validates all V1 adapter changes from Stories 8.1 and 8.2:
-- /processes plural route alias
-- V1ActorAddress orchestrator shape in V1ProcessContext
-- params with workspace/knowledge_graph keys
-- PUT /config/{config_type} new URL path shape
-- DELETE /config/{config_type}/{config_id} URL params
-- Human input with message dict body
-- Auth stubs (/auth/me, /auth/ws-ticket, /auth/logout)
-- GET /team-configs/ dict response
-- GET /llm_context/{id} grouped response
-- GET /states/{id} grouped response
-- WebSocket error envelope (verified via existing unit tests)
+Validates all V1 adapter changes from Stories 8.1 and 8.2.
+
+Note: TestWebSocketErrorEnvelope was reclassified as a unit test and moved to
+tests/frontend_adapter/test_v1_ws_classify.py (story 9.4).
 """
 
 from __future__ import annotations
@@ -91,15 +83,15 @@ class TestProcessEndpoint:
     ) -> None:
         """AC1: GET /processes returns 200 with flat list response."""
         team_id = _create_v1_team(v1_adapter_client)
-
-        resp = v1_adapter_client.get("/processes/")
-        assert resp.status_code == 200
-        data = resp.json()
-        assert isinstance(data, list)
-        assert len(data) >= 1
-
-        v1_adapter_client.delete(f"/process/{team_id}/archive")
-        time.sleep(0.5)
+        try:
+            resp = v1_adapter_client.get("/processes/")
+            assert resp.status_code == 200
+            data = resp.json()
+            assert isinstance(data, list)
+            assert len(data) >= 1
+        finally:
+            v1_adapter_client.delete(f"/process/{team_id}/archive")
+            time.sleep(0.5)
 
     def test_orchestrator_v1_actor_address_fields(
         self,
@@ -107,28 +99,29 @@ class TestProcessEndpoint:
     ) -> None:
         """AC1: orchestrator is V1ActorAddress with name, role, and string defaults."""
         team_id = _create_v1_team(v1_adapter_client)
+        try:
+            resp = v1_adapter_client.get("/processes/")
+            assert resp.status_code == 200
+            data = resp.json()
+            assert len(data) >= 1
 
-        resp = v1_adapter_client.get("/processes/")
-        assert resp.status_code == 200
-        data = resp.json()
-        assert len(data) >= 1
+            process = data[0]
+            orch = process["orchestrator"]
+            assert isinstance(orch, dict)
+            assert "name" in orch
+            assert "role" in orch
+            assert "__actor_address__" in orch
+            assert "address" in orch
+            assert "agent_id" in orch
+            assert "squad_id" in orch
 
-        process = data[0]
-        orch = process["orchestrator"]
-        assert isinstance(orch, dict)
-        assert "name" in orch
-        assert "role" in orch
-        assert "__actor_address__" in orch
-        assert "address" in orch
-        assert "agent_id" in orch
-        assert "squad_id" in orch
-
-        # All string-type fields
-        for field in ("name", "role", "__actor_address__", "address", "agent_id", "squad_id"):
-            assert isinstance(orch[field], str)
-
-        v1_adapter_client.delete(f"/process/{team_id}/archive")
-        time.sleep(0.5)
+            for field in (
+                "name", "role", "__actor_address__", "address", "agent_id", "squad_id",
+            ):
+                assert isinstance(orch[field], str)
+        finally:
+            v1_adapter_client.delete(f"/process/{team_id}/archive")
+            time.sleep(0.5)
 
     def test_params_workspace_and_knowledge_graph(
         self,
@@ -136,20 +129,20 @@ class TestProcessEndpoint:
     ) -> None:
         """AC1: params contains workspace and knowledge_graph keys."""
         team_id = _create_v1_team(v1_adapter_client)
+        try:
+            resp = v1_adapter_client.get("/processes/")
+            assert resp.status_code == 200
+            data = resp.json()
+            assert len(data) >= 1
 
-        resp = v1_adapter_client.get("/processes/")
-        assert resp.status_code == 200
-        data = resp.json()
-        assert len(data) >= 1
-
-        process = data[0]
-        params = process["params"]
-        assert isinstance(params, dict)
-        assert "workspace" in params
-        assert "knowledge_graph" in params
-
-        v1_adapter_client.delete(f"/process/{team_id}/archive")
-        time.sleep(0.5)
+            process = data[0]
+            params = process["params"]
+            assert isinstance(params, dict)
+            assert "workspace" in params
+            assert "knowledge_graph" in params
+        finally:
+            v1_adapter_client.delete(f"/process/{team_id}/archive")
+            time.sleep(0.5)
 
     def test_processes_alias_matches_process_list(
         self,
@@ -157,18 +150,18 @@ class TestProcessEndpoint:
     ) -> None:
         """AC1: GET /process/ returns same data as GET /processes."""
         team_id = _create_v1_team(v1_adapter_client)
+        try:
+            resp_processes = v1_adapter_client.get("/processes/")
+            resp_process = v1_adapter_client.get("/process/")
+            assert resp_processes.status_code == 200
+            assert resp_process.status_code == 200
 
-        resp_processes = v1_adapter_client.get("/processes/")
-        resp_process = v1_adapter_client.get("/process/")
-        assert resp_processes.status_code == 200
-        assert resp_process.status_code == 200
-
-        data_processes = resp_processes.json()
-        data_process = resp_process.json()
-        assert len(data_processes) == len(data_process)
-
-        v1_adapter_client.delete(f"/process/{team_id}/archive")
-        time.sleep(0.5)
+            data_processes = resp_processes.json()
+            data_process = resp_process.json()
+            assert len(data_processes) == len(data_process)
+        finally:
+            v1_adapter_client.delete(f"/process/{team_id}/archive")
+            time.sleep(0.5)
 
 
 # ---------------------------------------------------------------------------
@@ -184,7 +177,6 @@ class TestConfigEndpoint:
         v1_adapter_client: TestClient,
     ) -> None:
         """AC2: PUT /config/team with V1ConfigPutBody succeeds."""
-        # Get existing entry to build a valid config
         resp = v1_adapter_client.get("/config/team")
         assert resp.status_code == 200
         existing = resp.json()[0]
@@ -207,7 +199,6 @@ class TestConfigEndpoint:
         v1_adapter_client: TestClient,
     ) -> None:
         """AC2: DELETE /config/team/{config_id} with URL params succeeds."""
-        # Create an entry first
         resp = v1_adapter_client.get("/config/team")
         assert resp.status_code == 200
         existing = resp.json()[0]
@@ -220,7 +211,6 @@ class TestConfigEndpoint:
         }
         v1_adapter_client.put("/config/team", json=body)
 
-        # Delete via new URL shape
         resp = v1_adapter_client.delete("/config/team/adr004-del-test")
         assert resp.status_code == 200
         assert resp.json()["status"] == "ok"
@@ -240,32 +230,28 @@ class TestHumanInput:
     ) -> None:
         """AC3: human input with message dict containing id field succeeds."""
         team_id = _create_v1_team(v1_adapter_client)
+        try:
+            v1_adapter_client.patch(
+                f"/process/{team_id}",
+                json={"content": "Say hello in one word."},
+            )
+            messages = _wait_for_v1_messages(v1_adapter_client, team_id)
 
-        # Send initial message and wait for LLM response
-        v1_adapter_client.patch(
-            f"/process/{team_id}",
-            json={"content": "Say hello in one word."},
-        )
-        messages = _wait_for_v1_messages(v1_adapter_client, team_id)
+            assert len(messages) >= 1
+            msg_id = messages[0]["id"]
 
-        # Find a message ID
-        assert len(messages) >= 1
-        msg_id = messages[0]["id"]
-
-        # Send human input with the new message body shape
-        resp = v1_adapter_client.post(
-            f"/process_human_input/{team_id}/human/@Human",
-            json={
-                "content": "reply",
-                "message": {"id": str(msg_id), "content": "original"},
-            },
-        )
-        assert resp.status_code == 200
-        assert resp.json()["status"] == "ok"
-
-        # Cleanup
-        v1_adapter_client.delete(f"/process/{team_id}/archive")
-        time.sleep(0.5)
+            resp = v1_adapter_client.post(
+                f"/process_human_input/{team_id}/human/@Human",
+                json={
+                    "content": "reply",
+                    "message": {"id": str(msg_id), "content": "original"},
+                },
+            )
+            assert resp.status_code == 200
+            assert resp.json()["status"] == "ok"
+        finally:
+            v1_adapter_client.delete(f"/process/{team_id}/archive")
+            time.sleep(0.5)
 
 
 # ---------------------------------------------------------------------------
@@ -280,22 +266,19 @@ class TestAuthStubs:
         """AC4: GET /auth/me returns anonymous user dict."""
         resp = v1_adapter_client.get("/auth/me")
         assert resp.status_code == 200
-        data = resp.json()
-        assert data == {"user_id": "anonymous", "email": "", "name": "Anonymous"}
+        assert resp.json() == {"user_id": "anonymous", "email": "", "name": "Anonymous"}
 
     def test_auth_ws_ticket(self, v1_adapter_client: TestClient) -> None:
         """AC4: GET /auth/ws-ticket returns noauth ticket."""
         resp = v1_adapter_client.get("/auth/ws-ticket")
         assert resp.status_code == 200
-        data = resp.json()
-        assert data == {"ticket": "noauth"}
+        assert resp.json() == {"ticket": "noauth"}
 
     def test_auth_logout(self, v1_adapter_client: TestClient) -> None:
         """AC4: GET /auth/logout returns none auth_type."""
         resp = v1_adapter_client.get("/auth/logout")
         assert resp.status_code == 200
-        data = resp.json()
-        assert data == {"auth_type": "none"}
+        assert resp.json() == {"auth_type": "none"}
 
 
 # ---------------------------------------------------------------------------
@@ -306,30 +289,19 @@ class TestAuthStubs:
 class TestTeamConfigs:
     """Test GET /team-configs/ returns dict keyed by team name."""
 
-    def test_team_configs_returns_dict(
-        self,
-        v1_adapter_client: TestClient,
-    ) -> None:
+    def test_team_configs_returns_dict(self, v1_adapter_client: TestClient) -> None:
         """AC5: GET /team-configs/ returns a dict (not a list)."""
         resp = v1_adapter_client.get("/team-configs/")
         assert resp.status_code == 200
-        data = resp.json()
-        assert isinstance(data, dict)
+        assert isinstance(resp.json(), dict)
 
-    def test_team_configs_has_seeded_entry(
-        self,
-        v1_adapter_client: TestClient,
-    ) -> None:
+    def test_team_configs_has_seeded_entry(self, v1_adapter_client: TestClient) -> None:
         """AC5: at least one entry exists from seeded catalog."""
         resp = v1_adapter_client.get("/team-configs/")
         assert resp.status_code == 200
-        data = resp.json()
-        assert len(data) >= 1
+        assert len(resp.json()) >= 1
 
-    def test_team_configs_entry_shape(
-        self,
-        v1_adapter_client: TestClient,
-    ) -> None:
+    def test_team_configs_entry_shape(self, v1_adapter_client: TestClient) -> None:
         """AC5: each value has module (str) and setup (str, parseable as JSON) keys."""
         resp = v1_adapter_client.get("/team-configs/")
         assert resp.status_code == 200
@@ -341,7 +313,6 @@ class TestTeamConfigs:
             assert "setup" in entry
             assert isinstance(entry["module"], str)
             assert isinstance(entry["setup"], str)
-            # setup must be parseable as JSON
             parsed = json.loads(entry["setup"])
             assert isinstance(parsed, dict)
 
@@ -358,30 +329,26 @@ class TestLlmContextGrouped:
         self,
         v1_adapter_client: TestClient,
     ) -> None:
-        """AC6: GET /llm_context/{id} returns dict with agent keys and context lists."""
+        """AC6: GET /llm_context/{id} returns dict with agent keys."""
         team_id = _create_v1_team(v1_adapter_client)
+        try:
+            v1_adapter_client.patch(
+                f"/process/{team_id}",
+                json={"content": "Say hello in one word."},
+            )
+            _wait_for_v1_messages(v1_adapter_client, team_id)
 
-        # Send message and wait for LLM response
-        v1_adapter_client.patch(
-            f"/process/{team_id}",
-            json={"content": "Say hello in one word."},
-        )
-        _wait_for_v1_messages(v1_adapter_client, team_id)
-
-        resp = v1_adapter_client.get(f"/llm_context/{team_id}")
-        assert resp.status_code == 200
-        data = resp.json()
-        assert isinstance(data, dict)
-
-        # At least one agent key should exist
-        assert len(data) >= 1
-        for _agent_id, value in data.items():
-            assert "context" in value
-            assert isinstance(value["context"], list)
-
-        # Cleanup
-        v1_adapter_client.delete(f"/process/{team_id}/archive")
-        time.sleep(0.5)
+            resp = v1_adapter_client.get(f"/llm_context/{team_id}")
+            assert resp.status_code == 200
+            data = resp.json()
+            assert isinstance(data, dict)
+            assert len(data) >= 1
+            for _agent_id, value in data.items():
+                assert "context" in value
+                assert isinstance(value["context"], list)
+        finally:
+            v1_adapter_client.delete(f"/process/{team_id}/archive")
+            time.sleep(0.5)
 
 
 # ---------------------------------------------------------------------------
@@ -398,78 +365,20 @@ class TestStatesGrouped:
     ) -> None:
         """AC7: GET /states/{id} returns dict."""
         team_id = _create_v1_team(v1_adapter_client)
+        try:
+            # Give a moment for agent startup
+            time.sleep(1.0)
 
-        # Agent startup may or may not trigger StateChangedMessage events
-        # depending on agent implementation. Give a moment for startup.
-        time.sleep(1.0)
+            resp = v1_adapter_client.get(f"/states/{team_id}")
+            assert resp.status_code == 200
+            data = resp.json()
+            assert isinstance(data, dict)
 
-        resp = v1_adapter_client.get(f"/states/{team_id}")
-        assert resp.status_code == 200
-        data = resp.json()
-        assert isinstance(data, dict)
-
-        # If entries present, verify shape
-        for _agent_id, value in data.items():
-            assert "schema" in value
-            assert "state" in value
-            assert isinstance(value["schema"], dict)
-            assert isinstance(value["state"], dict)
-
-        # Cleanup
-        v1_adapter_client.delete(f"/process/{team_id}/archive")
-        time.sleep(0.5)
-
-
-# ---------------------------------------------------------------------------
-# AC #8 -- WebSocket error envelope integration (FR14)
-# ---------------------------------------------------------------------------
-
-
-class TestWebSocketErrorEnvelope:
-    """Verify WebSocket error envelope -- existing unit tests in test_angular_v1_ws.py.
-
-    The WebSocket error envelope (ErrorMessage -> type: "error") is thoroughly
-    tested at the unit level in tests/test_angular_v1_ws.py (TestWrapErrorMessage
-    class). An end-to-end WebSocket error integration test would require triggering
-    a real error during LLM processing, which is fragile and non-deterministic.
-
-    This test class confirms the unit-level coverage by exercising the same
-    functions in the integration context.
-    """
-
-    def test_classify_error_message_returns_error(self) -> None:
-        """AC8: _classify_envelope_type(ErrorMessage) returns 'error'."""
-        from akgentic.core.messages.orchestrator import ErrorMessage
-
-        from akgentic.infra.server.routes.frontend_adapter.angular_v1.ws import (
-            _classify_envelope_type,
-        )
-
-        msg = ErrorMessage(exception_value="test error", exception_type="ValueError")
-        result = _classify_envelope_type(msg)
-        assert result == "error"
-
-    def test_wrap_event_error_produces_error_payload(self) -> None:
-        """AC8: wrap_event with ErrorMessage produces ErrorPayload with type=='error'."""
-        import uuid
-        from datetime import UTC, datetime
-
-        from akgentic.core.messages.orchestrator import ErrorMessage
-        from akgentic.team.models import PersistedEvent
-
-        from akgentic.infra.server.routes.frontend_adapter import ErrorPayload
-        from akgentic.infra.server.routes.frontend_adapter.angular_v1.ws import (
-            wrap_event,
-        )
-
-        msg = ErrorMessage(exception_value="something broke", exception_type="RuntimeError")
-        ev = PersistedEvent(
-            team_id=uuid.uuid4(),
-            sequence=1,
-            event=msg,
-            timestamp=datetime.now(tz=UTC),
-        )
-        wrapped = wrap_event(ev)
-        assert isinstance(wrapped.payload, ErrorPayload)
-        assert wrapped.payload.type == "error"
-        assert wrapped.payload.message == "something broke"
+            for _agent_id, value in data.items():
+                assert "schema" in value
+                assert "state" in value
+                assert isinstance(value["schema"], dict)
+                assert isinstance(value["state"], dict)
+        finally:
+            v1_adapter_client.delete(f"/process/{team_id}/archive")
+            time.sleep(0.5)

--- a/tests/integration/test_channels.py
+++ b/tests/integration/test_channels.py
@@ -32,11 +32,7 @@ FOLLOWUP_CONTENT = "What is 7 + 7? Answer with the number."
 
 
 class StubChannelParser:
-    """Stub ChannelParser for integration tests.
-
-    Satisfies the ChannelParser protocol via structural subtyping.
-    Parses a simple dict payload into a ChannelMessage.
-    """
+    """Stub ChannelParser for integration tests."""
 
     @property
     def channel_name(self) -> str:
@@ -65,25 +61,19 @@ class StubChannelParser:
 
 
 class StubChannelAdapter:
-    """Stub InteractionChannelAdapter for integration tests.
-
-    Captures outbound SentMessage events in a shared list.
-    Matches all messages (returns True for every SentMessage).
-    """
+    """Stub InteractionChannelAdapter for integration tests."""
 
     def __init__(self) -> None:
         self.delivered: list[SentMessage] = []
 
     def matches(self, msg: SentMessage) -> bool:  # noqa: ARG002
-        """Match all messages."""
         return True
 
     def deliver(self, msg: SentMessage) -> None:
-        """Capture delivered message."""
         self.delivered.append(msg)
 
     def on_stop(self, team_id: uuid.UUID) -> None:  # noqa: ARG002
-        """No-op cleanup."""
+        pass
 
 
 # ---------------------------------------------------------------------------
@@ -132,14 +122,14 @@ class TestChannelInitiation:
         )
         assert team_id is not None, "Channel registry should map ext-user-1 after initiation"
 
-        events = wait_for_llm_response(
-            channel_client,
-            str(team_id),
-        )
-        assert has_llm_content(events)
-
-        # Stop the team to allow clean actor system teardown
-        channel_client.post(f"/teams/{team_id}/stop")
+        try:
+            events = wait_for_llm_response(
+                channel_client,
+                str(team_id),
+            )
+            assert has_llm_content(events)
+        finally:
+            channel_client.post(f"/teams/{team_id}/stop")
 
 
 class TestChannelReply:
@@ -156,21 +146,21 @@ class TestChannelReply:
         assert create_resp.status_code == 201
         team_id = create_resp.json()["team_id"]
 
-        resp = channel_client.post(
-            "/webhook/test-channel",
-            json={
-                "content": "What is 3 + 3? Answer with the number.",
-                "channel_user_id": "ext-user-2",
-                "team_id": team_id,
-            },
-        )
-        assert resp.status_code == 204
+        try:
+            resp = channel_client.post(
+                "/webhook/test-channel",
+                json={
+                    "content": "What is 3 + 3? Answer with the number.",
+                    "channel_user_id": "ext-user-2",
+                    "team_id": team_id,
+                },
+            )
+            assert resp.status_code == 204
 
-        events = wait_for_llm_response(channel_client, team_id)
-        assert has_llm_content(events)
-
-        # Stop the team to allow clean actor system teardown
-        channel_client.post(f"/teams/{team_id}/stop")
+            events = wait_for_llm_response(channel_client, team_id)
+            assert has_llm_content(events)
+        finally:
+            channel_client.post(f"/teams/{team_id}/stop")
 
 
 class TestChannelContinuation:
@@ -199,66 +189,57 @@ class TestChannelContinuation:
         )
         assert team_id is not None, "Channel registry should have mapping after initiation"
 
-        # Wait for LLM to process first message before sending follow-up
-        wait_for_llm_response(channel_client, str(team_id))
+        try:
+            wait_for_llm_response(channel_client, str(team_id))
 
-        # Step 2: Follow-up with same channel_user_id, no team_id
-        resp = channel_client.post(
-            "/webhook/test-channel",
-            json={
-                "content": FOLLOWUP_CONTENT,
-                "channel_user_id": "ext-user-cont",
-            },
-        )
-        assert resp.status_code == 204
-
-        # Verify follow-up is routed to the SAME team
-        deadline = time.monotonic() + POLL_TIMEOUT_S
-        found_followup = False
-        while time.monotonic() < deadline:
-            ev_resp = channel_client.get(
-                f"/teams/{team_id}/events",
+            # Step 2: Follow-up with same channel_user_id, no team_id
+            resp = channel_client.post(
+                "/webhook/test-channel",
+                json={
+                    "content": FOLLOWUP_CONTENT,
+                    "channel_user_id": "ext-user-cont",
+                },
             )
-            assert ev_resp.status_code == 200
-            events = ev_resp.json()["events"]
-            for ev_wrapper in events:
-                ev = ev_wrapper["event"]
-                if not isinstance(ev, dict):
-                    continue
-                content = ev.get("content")
-                if content == FOLLOWUP_CONTENT:
-                    found_followup = True
-                    break
-                msg = ev.get("message")
-                if isinstance(msg, dict) and msg.get("content") == FOLLOWUP_CONTENT:
-                    found_followup = True
-                    break
-            if found_followup:
-                break
-            time.sleep(POLL_INTERVAL_S)
+            assert resp.status_code == 204
 
-        assert found_followup, (
-            "Follow-up message should appear in the same team's "
-            "events (continuation flow via channel_user_id)"
-        )
+            # Verify follow-up is routed to the SAME team
+            deadline = time.monotonic() + POLL_TIMEOUT_S
+            found_followup = False
+            while time.monotonic() < deadline:
+                ev_resp = channel_client.get(f"/teams/{team_id}/events")
+                assert ev_resp.status_code == 200
+                events = ev_resp.json()["events"]
+                for ev_wrapper in events:
+                    ev = ev_wrapper["event"]
+                    if not isinstance(ev, dict):
+                        continue
+                    content = ev.get("content")
+                    if content == FOLLOWUP_CONTENT:
+                        found_followup = True
+                        break
+                    msg = ev.get("message")
+                    if isinstance(msg, dict) and msg.get("content") == FOLLOWUP_CONTENT:
+                        found_followup = True
+                        break
+                if found_followup:
+                    break
+                time.sleep(POLL_INTERVAL_S)
 
-        # Stop the team to allow clean actor system teardown
-        channel_client.post(f"/teams/{team_id}/stop")
+            assert found_followup, (
+                "Follow-up message should appear in the same team's "
+                "events (continuation flow via channel_user_id)"
+            )
+        finally:
+            channel_client.post(f"/teams/{team_id}/stop")
 
 
 class TestDispatcherRestoreSuppression:
-    """AC #4: Stop/restore preserves events without duplicating them.
-
-    Uses the same channel_client to verify the channel-enabled app
-    handles the stop/restore lifecycle correctly. Does not send
-    messages requiring LLM, avoiding rate-limit contention.
-    """
+    """AC #4: Stop/restore preserves events without duplicating them."""
 
     def test_restore_cycle_preserves_events(
         self,
         channel_client: TestClient,
     ) -> None:
-        # Create team via REST (no LLM call needed)
         create_resp = channel_client.post(
             "/teams/",
             json={"catalog_entry_id": "test-team"},
@@ -266,32 +247,27 @@ class TestDispatcherRestoreSuppression:
         assert create_resp.status_code == 201
         team_id = create_resp.json()["team_id"]
 
-        # Verify running
-        resp = channel_client.get(f"/teams/{team_id}")
-        assert resp.status_code == 200
-        assert resp.json()["status"] == "running"
+        try:
+            resp = channel_client.get(f"/teams/{team_id}")
+            assert resp.status_code == 200
+            assert resp.json()["status"] == "running"
 
-        # Count initial events (team creation events)
-        ev_resp = channel_client.get(f"/teams/{team_id}/events")
-        assert ev_resp.status_code == 200
-        events_before = len(ev_resp.json()["events"])
+            ev_resp = channel_client.get(f"/teams/{team_id}/events")
+            assert ev_resp.status_code == 200
+            events_before = len(ev_resp.json()["events"])
 
-        # Stop
-        resp = channel_client.post(f"/teams/{team_id}/stop")
-        assert resp.status_code == 204
-        resp = channel_client.get(f"/teams/{team_id}")
-        assert resp.json()["status"] == "stopped"
+            resp = channel_client.post(f"/teams/{team_id}/stop")
+            assert resp.status_code == 204
+            resp = channel_client.get(f"/teams/{team_id}")
+            assert resp.json()["status"] == "stopped"
 
-        # Restore
-        resp = channel_client.post(f"/teams/{team_id}/restore")
-        assert resp.status_code == 200
-        assert resp.json()["status"] == "running"
+            resp = channel_client.post(f"/teams/{team_id}/restore")
+            assert resp.status_code == 200
+            assert resp.json()["status"] == "running"
 
-        # Events preserved (not duplicated by restore replay)
-        ev_resp = channel_client.get(f"/teams/{team_id}/events")
-        assert ev_resp.status_code == 200
-        events_after = ev_resp.json()["events"]
-        assert len(events_after) == events_before
-
-        # Stop the team to allow clean actor system teardown
-        channel_client.post(f"/teams/{team_id}/stop")
+            ev_resp = channel_client.get(f"/teams/{team_id}/events")
+            assert ev_resp.status_code == 200
+            events_after = ev_resp.json()["events"]
+            assert len(events_after) == events_before
+        finally:
+            channel_client.post(f"/teams/{team_id}/stop")

--- a/tests/integration/test_cli.py
+++ b/tests/integration/test_cli.py
@@ -10,7 +10,7 @@ import time
 from collections.abc import Generator
 from pathlib import Path
 from typing import Any
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import httpx
 import pytest
@@ -134,7 +134,6 @@ class TestCliTeamLifecycle:
         cli_server: str,
     ) -> None:
         """Create a team via CLI, then list teams and verify it appears."""
-        # Create via JSON format for reliable team_id extraction
         result = cli_invoke(
             cli_runner,
             cli_server,
@@ -144,17 +143,16 @@ class TestCliTeamLifecycle:
         assert result.exit_code == 0, result.output
         team_data = json.loads(result.output)
         team_id = team_data["team_id"]
-        assert team_data["status"] == "running"
+        try:
+            assert team_data["status"] == "running"
 
-        # List teams and verify the created team appears
-        result_list = cli_invoke(cli_runner, cli_server, ["team", "list"])
-        assert result_list.exit_code == 0, result_list.output
-        assert team_id in result_list.output
-
-        # Cleanup: stop team to avoid LLM-in-flight hang
-        with httpx.Client(base_url=cli_server) as c:
-            c.post(f"/teams/{team_id}/stop")
-            time.sleep(0.3)
+            result_list = cli_invoke(cli_runner, cli_server, ["team", "list"])
+            assert result_list.exit_code == 0, result_list.output
+            assert team_id in result_list.output
+        finally:
+            with httpx.Client(base_url=cli_server) as c:
+                c.post(f"/teams/{team_id}/stop")
+                time.sleep(0.3)
 
     def test_cli_team_get(
         self,
@@ -162,7 +160,6 @@ class TestCliTeamLifecycle:
         cli_server: str,
     ) -> None:
         """Create a team, then get its detail via CLI."""
-        # Create team via JSON for reliable parsing
         result = cli_invoke(
             cli_runner,
             cli_server,
@@ -172,17 +169,15 @@ class TestCliTeamLifecycle:
         assert result.exit_code == 0
         team_data = json.loads(result.output)
         team_id = team_data["team_id"]
-
-        # Get team detail
-        result_get = cli_invoke(cli_runner, cli_server, ["team", "get", team_id])
-        assert result_get.exit_code == 0
-        assert team_id in result_get.output
-        assert "running" in result_get.output.lower()
-
-        # Cleanup
-        with httpx.Client(base_url=cli_server) as c:
-            c.post(f"/teams/{team_id}/stop")
-            time.sleep(0.3)
+        try:
+            result_get = cli_invoke(cli_runner, cli_server, ["team", "get", team_id])
+            assert result_get.exit_code == 0
+            assert team_id in result_get.output
+            assert "running" in result_get.output.lower()
+        finally:
+            with httpx.Client(base_url=cli_server) as c:
+                c.post(f"/teams/{team_id}/stop")
+                time.sleep(0.3)
 
     def test_cli_message_and_llm_response(
         self,
@@ -190,7 +185,6 @@ class TestCliTeamLifecycle:
         cli_server: str,
     ) -> None:
         """Create a team via CLI, send a message, verify LLM response in events."""
-        # Create team
         result = cli_invoke(
             cli_runner,
             cli_server,
@@ -199,34 +193,32 @@ class TestCliTeamLifecycle:
         )
         assert result.exit_code == 0
         team_id = json.loads(result.output)["team_id"]
+        try:
+            result_msg = cli_invoke(
+                cli_runner,
+                cli_server,
+                ["message", team_id, "Say hello in one word"],
+            )
+            assert result_msg.exit_code == 0
 
-        # Send message via CLI
-        result_msg = cli_invoke(
-            cli_runner,
-            cli_server,
-            ["message", team_id, "Say hello in one word"],
-        )
-        assert result_msg.exit_code == 0
+            with httpx.Client(base_url=cli_server) as c:
+                deadline = time.monotonic() + POLL_TIMEOUT_S
+                events: list[dict[str, object]] = []
+                while time.monotonic() < deadline:
+                    resp = c.get(f"/teams/{team_id}/events")
+                    assert resp.status_code == 200
+                    events = resp.json()["events"]
+                    if has_llm_content(events):
+                        break
+                    time.sleep(POLL_INTERVAL_S)
+                else:
+                    pytest.fail("Timed out waiting for LLM response via CLI message")
 
-        # Poll for LLM response using the REST client directly
-        with httpx.Client(base_url=cli_server) as c:
-            deadline = time.monotonic() + POLL_TIMEOUT_S
-            events: list[dict[str, object]] = []
-            while time.monotonic() < deadline:
-                resp = c.get(f"/teams/{team_id}/events")
-                assert resp.status_code == 200
-                events = resp.json()["events"]
-                if has_llm_content(events):
-                    break
-                time.sleep(POLL_INTERVAL_S)
-            else:
-                pytest.fail("Timed out waiting for LLM response via CLI message")
-
-            assert has_llm_content(events)
-
-            # Cleanup
-            c.post(f"/teams/{team_id}/stop")
-            time.sleep(0.3)
+                assert has_llm_content(events)
+        finally:
+            with httpx.Client(base_url=cli_server) as c:
+                c.post(f"/teams/{team_id}/stop")
+                time.sleep(0.3)
 
     def test_cli_team_delete(
         self,
@@ -261,21 +253,18 @@ class TestCliTeamLifecycle:
         )
         assert result.exit_code == 0
         team_id = json.loads(result.output)["team_id"]
+        try:
+            with httpx.Client(base_url=cli_server) as c:
+                resp = c.post(f"/teams/{team_id}/stop")
+                assert resp.status_code == 204
 
-        # Stop via REST
-        with httpx.Client(base_url=cli_server) as c:
-            resp = c.post(f"/teams/{team_id}/stop")
-            assert resp.status_code == 204
-
-        # Restore via CLI
-        result_restore = cli_invoke(cli_runner, cli_server, ["team", "restore", team_id])
-        assert result_restore.exit_code == 0
-        assert "running" in result_restore.output.lower()
-
-        # Cleanup
-        with httpx.Client(base_url=cli_server) as c:
-            c.post(f"/teams/{team_id}/stop")
-            time.sleep(0.3)
+            result_restore = cli_invoke(cli_runner, cli_server, ["team", "restore", team_id])
+            assert result_restore.exit_code == 0
+            assert "running" in result_restore.output.lower()
+        finally:
+            with httpx.Client(base_url=cli_server) as c:
+                c.post(f"/teams/{team_id}/stop")
+                time.sleep(0.3)
 
     def test_cli_team_events(
         self,
@@ -291,37 +280,33 @@ class TestCliTeamLifecycle:
         )
         assert result.exit_code == 0
         team_id = json.loads(result.output)["team_id"]
+        try:
+            with httpx.Client(base_url=cli_server) as c:
+                c.post(
+                    f"/teams/{team_id}/message",
+                    json={"content": "Say yes"},
+                )
+                deadline = time.monotonic() + POLL_TIMEOUT_S
+                while time.monotonic() < deadline:
+                    resp = c.get(f"/teams/{team_id}/events")
+                    events = resp.json()["events"]
+                    if has_llm_content(events):
+                        break
+                    time.sleep(POLL_INTERVAL_S)
 
-        # Send message and wait for LLM response
-        with httpx.Client(base_url=cli_server) as c:
-            c.post(
-                f"/teams/{team_id}/message",
-                json={"content": "Say yes"},
+            result_events = cli_invoke(cli_runner, cli_server, ["team", "events", team_id])
+            assert result_events.exit_code == 0
+            output = result_events.output.strip()
+            assert len(output) > 0
+            assert (
+                "sequence" in output.lower()
+                or "timestamp" in output.lower()
+                or "event" in output.lower()
             )
-            deadline = time.monotonic() + POLL_TIMEOUT_S
-            while time.monotonic() < deadline:
-                resp = c.get(f"/teams/{team_id}/events")
-                events = resp.json()["events"]
-                if has_llm_content(events):
-                    break
-                time.sleep(POLL_INTERVAL_S)
-
-        # Fetch events via CLI
-        result_events = cli_invoke(cli_runner, cli_server, ["team", "events", team_id])
-        assert result_events.exit_code == 0
-        # Events output should contain event data with sequence/timestamp columns
-        output = result_events.output.strip()
-        assert len(output) > 0
-        assert (
-            "sequence" in output.lower()
-            or "timestamp" in output.lower()
-            or "event" in output.lower()
-        )
-
-        # Cleanup
-        with httpx.Client(base_url=cli_server) as c:
-            c.post(f"/teams/{team_id}/stop")
-            time.sleep(0.3)
+        finally:
+            with httpx.Client(base_url=cli_server) as c:
+                c.post(f"/teams/{team_id}/stop")
+                time.sleep(0.3)
 
     def test_cli_json_format(
         self,
@@ -345,6 +330,31 @@ class TestCliTeamLifecycle:
 # ---------------------------------------------------------------------------
 
 
+class _StubRenderer:
+    """Lightweight renderer stub that captures agent messages without MagicMock."""
+
+    def __init__(self) -> None:
+        self.agent_messages: list[str] = []
+
+    def render_agent_message(self, sender: str, content: str) -> None:
+        self.agent_messages.append(f"{sender}: {content}")
+
+    def render_system_message(self, *args: object, **kwargs: object) -> None:
+        pass
+
+    def render_error(self, *args: object, **kwargs: object) -> None:
+        pass
+
+    def render_tool_call(self, *args: object, **kwargs: object) -> None:
+        pass
+
+    def render_human_input_request(self, *args: object, **kwargs: object) -> None:
+        pass
+
+    def render_history_separator(self, *args: object, **kwargs: object) -> None:
+        pass
+
+
 class TestCliChat:
     """Integration tests for the interactive chat REPL."""
 
@@ -366,16 +376,7 @@ class TestCliChat:
         )
 
         # Track rendered events to verify WebSocket delivery
-        rendered_events: list[str] = []
-        renderer = MagicMock()
-        renderer.render_agent_message = lambda sender, content: rendered_events.append(
-            f"{sender}: {content}"
-        )
-        renderer.render_system_message = MagicMock()
-        renderer.render_error = MagicMock()
-        renderer.render_tool_call = MagicMock()
-        renderer.render_human_input_request = MagicMock()
-        renderer.render_history_separator = MagicMock()
+        renderer = _StubRenderer()
 
         session = ChatSession(
             api_client,
@@ -386,8 +387,8 @@ class TestCliChat:
             renderer=renderer,
         )
 
-        # Mock stdin: send a message, wait for LLM to respond, then /quit.
-        # After /quit the mock must block (not StopIteration) so the session
+        # Stub stdin: send a message, wait for LLM to respond, then /quit.
+        # After /quit the stub must block (not StopIteration) so the session
         # exits cleanly through the /quit break rather than an exception.
         def _mock_read_input(_prompt: str) -> str:
             nonlocal call_count
@@ -397,8 +398,6 @@ class TestCliChat:
             if call_count == 2:
                 return "/quit"
             # After /quit: block until cancelled (session should have exited)
-            import threading
-
             threading.Event().wait(timeout=30)
             return "/quit"
 
@@ -413,7 +412,7 @@ class TestCliChat:
 
         try:
             asyncio.run(_run_session())
-        except (TimeoutError, asyncio.TimeoutError):
+        except TimeoutError:
             pass  # session may not exit instantly after /quit
 
         # Cleanup — MUST run before assertion to avoid actor system hang
@@ -422,7 +421,7 @@ class TestCliChat:
         time.sleep(0.5)
 
         # Verify at least one WebSocket event was rendered (AC #2)
-        assert len(rendered_events) > 0, (
+        assert len(renderer.agent_messages) > 0, (
             "ChatSession received no WebSocket events — expected at least one agent message"
         )
 
@@ -491,39 +490,39 @@ class TestCliWorkspace:
         assert result.exit_code == 0
         team_id = json.loads(result.output)["team_id"]
 
-        # Write a temp file
-        test_file = tmp_path / "hello.txt"
-        test_content = "Hello from CLI integration test!"
-        test_file.write_text(test_content)
+        try:
+            # Write a temp file
+            test_file = tmp_path / "hello.txt"
+            test_content = "Hello from CLI integration test!"
+            test_file.write_text(test_content)
 
-        # Upload via CLI
-        result_upload = cli_invoke(
-            cli_runner,
-            cli_server,
-            ["workspace", "upload", team_id, str(test_file)],
-        )
-        assert result_upload.exit_code == 0
-        assert "Uploaded" in result_upload.output
+            # Upload via CLI
+            result_upload = cli_invoke(
+                cli_runner,
+                cli_server,
+                ["workspace", "upload", team_id, str(test_file)],
+            )
+            assert result_upload.exit_code == 0
+            assert "Uploaded" in result_upload.output
 
-        # Tree via CLI
-        result_tree = cli_invoke(
-            cli_runner,
-            cli_server,
-            ["workspace", "tree", team_id],
-        )
-        assert result_tree.exit_code == 0
-        assert "hello.txt" in result_tree.output
+            # Tree via CLI
+            result_tree = cli_invoke(
+                cli_runner,
+                cli_server,
+                ["workspace", "tree", team_id],
+            )
+            assert result_tree.exit_code == 0
+            assert "hello.txt" in result_tree.output
 
-        # Read via CLI
-        result_read = cli_invoke(
-            cli_runner,
-            cli_server,
-            ["workspace", "read", team_id, "hello.txt"],
-        )
-        assert result_read.exit_code == 0
-        assert test_content in result_read.output
-
-        # Cleanup
-        with httpx.Client(base_url=cli_server) as c:
-            c.post(f"/teams/{team_id}/stop")
-            time.sleep(0.3)
+            # Read via CLI
+            result_read = cli_invoke(
+                cli_runner,
+                cli_server,
+                ["workspace", "read", team_id, "hello.txt"],
+            )
+            assert result_read.exit_code == 0
+            assert test_content in result_read.output
+        finally:
+            with httpx.Client(base_url=cli_server) as c:
+                c.post(f"/teams/{team_id}/stop")
+                time.sleep(0.3)

--- a/tests/integration/test_events.py
+++ b/tests/integration/test_events.py
@@ -26,35 +26,33 @@ class TestEventPersistence:
     ) -> None:
         """AC #2: Create team, send message, wait for LLM, stop, verify events via REST."""
         team_id = create_team(integration_client)
+        try:
+            integration_client.post(
+                f"/teams/{team_id}/message",
+                json={"content": "Reply with exactly one word."},
+            )
+            events = wait_for_llm_response(integration_client, team_id)
+            assert has_llm_content(events)
 
-        # Send message and wait for LLM response
-        integration_client.post(
-            f"/teams/{team_id}/message",
-            json={"content": "Reply with exactly one word."},
-        )
-        events = wait_for_llm_response(integration_client, team_id)
-        assert has_llm_content(events)
+            resp = integration_client.post(f"/teams/{team_id}/stop")
+            assert resp.status_code == 204
 
-        # Stop the team
-        resp = integration_client.post(f"/teams/{team_id}/stop")
-        assert resp.status_code == 204
+            resp = integration_client.get(f"/teams/{team_id}/events")
+            assert resp.status_code == 200
+            stopped_events = resp.json()["events"]
 
-        # Events should still be accessible via REST after stop
-        resp = integration_client.get(f"/teams/{team_id}/events")
-        assert resp.status_code == 200
-        stopped_events = resp.json()["events"]
-
-        # Verify SentMessage and ReceivedMessage are present
-        models = [
-            ev["event"].get("__model__", "")
-            for ev in stopped_events
-            if isinstance(ev.get("event"), dict)
-        ]
-        has_sent = any("SentMessage" in str(m) for m in models)
-        has_received = any("ReceivedMessage" in str(m) for m in models)
-        assert has_sent or has_received, (
-            f"Expected SentMessage or ReceivedMessage in persisted events, got: {models}"
-        )
+            models = [
+                ev["event"].get("__model__", "")
+                for ev in stopped_events
+                if isinstance(ev.get("event"), dict)
+            ]
+            has_sent = any("SentMessage" in str(m) for m in models)
+            has_received = any("ReceivedMessage" in str(m) for m in models)
+            assert has_sent or has_received, (
+                f"Expected SentMessage or ReceivedMessage in persisted events, got: {models}"
+            )
+        finally:
+            integration_client.post(f"/teams/{team_id}/stop")
 
     def test_event_count_after_send_and_respond(
         self,
@@ -62,19 +60,18 @@ class TestEventPersistence:
     ) -> None:
         """AC #2: Verify event count >= 3 after a full send-and-respond cycle."""
         team_id = create_team(integration_client)
-
-        integration_client.post(
-            f"/teams/{team_id}/message",
-            json={"content": "What is 1 + 1? Answer with the number."},
-        )
-        events = wait_for_llm_response(integration_client, team_id)
-        assert len(events) >= 3, (
-            f"Expected >= 3 events after send-and-respond cycle, got {len(events)}"
-        )
-
-        # Stop team before fixture teardown to avoid LLM-in-flight hang
-        integration_client.post(f"/teams/{team_id}/stop")
-        time.sleep(0.5)
+        try:
+            integration_client.post(
+                f"/teams/{team_id}/message",
+                json={"content": "What is 1 + 1? Answer with the number."},
+            )
+            events = wait_for_llm_response(integration_client, team_id)
+            assert len(events) >= 3, (
+                f"Expected >= 3 events after send-and-respond cycle, got {len(events)}"
+            )
+        finally:
+            integration_client.post(f"/teams/{team_id}/stop")
+            time.sleep(0.5)
 
     def test_events_survive_stop_restore_cycle(
         self,
@@ -82,33 +79,28 @@ class TestEventPersistence:
     ) -> None:
         """AC #2: Events from before stop are still accessible after restore."""
         team_id = create_team(integration_client)
+        try:
+            integration_client.post(
+                f"/teams/{team_id}/message",
+                json={"content": "Respond with one word."},
+            )
+            events_before = wait_for_llm_response(integration_client, team_id)
+            count_before = len(events_before)
+            assert count_before >= 3
 
-        # Send message and wait for LLM response
-        integration_client.post(
-            f"/teams/{team_id}/message",
-            json={"content": "Respond with one word."},
-        )
-        events_before = wait_for_llm_response(integration_client, team_id)
-        count_before = len(events_before)
-        assert count_before >= 3
+            resp = integration_client.post(f"/teams/{team_id}/stop")
+            assert resp.status_code == 204
 
-        # Stop
-        resp = integration_client.post(f"/teams/{team_id}/stop")
-        assert resp.status_code == 204
+            resp = integration_client.post(f"/teams/{team_id}/restore")
+            assert resp.status_code == 200
+            assert resp.json()["status"] == "running"
 
-        # Restore
-        resp = integration_client.post(f"/teams/{team_id}/restore")
-        assert resp.status_code == 200
-        assert resp.json()["status"] == "running"
-
-        # Events from before stop should still be accessible
-        resp = integration_client.get(f"/teams/{team_id}/events")
-        assert resp.status_code == 200
-        events_after = resp.json()["events"]
-        assert len(events_after) >= count_before, (
-            f"Events lost after stop/restore: had {count_before}, now {len(events_after)}"
-        )
-
-        # Stop team before fixture teardown to avoid LLM-in-flight hang
-        integration_client.post(f"/teams/{team_id}/stop")
-        time.sleep(0.5)
+            resp = integration_client.get(f"/teams/{team_id}/events")
+            assert resp.status_code == 200
+            events_after = resp.json()["events"]
+            assert len(events_after) >= count_before, (
+                f"Events lost after stop/restore: had {count_before}, now {len(events_after)}"
+            )
+        finally:
+            integration_client.post(f"/teams/{team_id}/stop")
+            time.sleep(0.5)

--- a/tests/integration/test_frontend_adapter.py
+++ b/tests/integration/test_frontend_adapter.py
@@ -81,110 +81,96 @@ class TestV1FrontendAdapter:
         assert resp.status_code == 200
         data = resp.json()
 
-        # V1ProcessContext fields
-        assert "id" in data
-        assert "status" in data
-        assert "params" in data
-        assert "type" in data
-        assert "created_at" in data
-        assert "updated_at" in data
-
-        # Validate types
-        assert isinstance(data["id"], str)
-        assert isinstance(data["status"], str)
-        assert isinstance(data["params"], dict)
-
-        # Stop team to avoid LLM-in-flight hang
-        v1_adapter_client.delete(f"/process/{data['id']}/archive")
-        time.sleep(0.5)
+        try:
+            assert "id" in data
+            assert "status" in data
+            assert "params" in data
+            assert "type" in data
+            assert "created_at" in data
+            assert "updated_at" in data
+            assert isinstance(data["id"], str)
+            assert isinstance(data["status"], str)
+            assert isinstance(data["params"], dict)
+        finally:
+            v1_adapter_client.delete(f"/process/{data['id']}/archive")
+            time.sleep(0.5)
 
     def test_send_message_v1(self, v1_adapter_client: TestClient) -> None:
         """AC #2: PATCH /process/{id} sends message and returns V1StatusResponse."""
         team_id = _create_v1_team(v1_adapter_client)
-
-        resp = v1_adapter_client.patch(
-            f"/process/{team_id}",
-            json={"content": "Say hello in one word."},
-        )
-        assert resp.status_code == 200
-        data = resp.json()
-        assert data["status"] == "ok"
-
-        # Stop team to avoid LLM-in-flight hang
-        v1_adapter_client.delete(f"/process/{team_id}/archive")
-        time.sleep(0.5)
+        try:
+            resp = v1_adapter_client.patch(
+                f"/process/{team_id}",
+                json={"content": "Say hello in one word."},
+            )
+            assert resp.status_code == 200
+            data = resp.json()
+            assert data["status"] == "ok"
+        finally:
+            v1_adapter_client.delete(f"/process/{team_id}/archive")
+            time.sleep(0.5)
 
     def test_get_messages_v1(self, v1_adapter_client: TestClient) -> None:
         """AC #2: GET /messages/{id} returns V1MessageEntry list with LLM response."""
         team_id = _create_v1_team(v1_adapter_client)
+        try:
+            v1_adapter_client.patch(
+                f"/process/{team_id}",
+                json={"content": "Say hello in one word."},
+            )
 
-        # Send message
-        v1_adapter_client.patch(
-            f"/process/{team_id}",
-            json={"content": "Say hello in one word."},
-        )
+            messages = _wait_for_v1_messages(v1_adapter_client, team_id)
 
-        # Poll for LLM response
-        messages = _wait_for_v1_messages(v1_adapter_client, team_id)
-
-        # Verify V1MessageEntry shape
-        assert len(messages) >= 1
-        for msg in messages:
-            assert "id" in msg
-            assert "sender" in msg
-            assert "content" in msg
-            assert "timestamp" in msg
-            assert "type" in msg
-
-        # Stop team
-        v1_adapter_client.delete(f"/process/{team_id}/archive")
-        time.sleep(0.5)
+            assert len(messages) >= 1
+            for msg in messages:
+                assert "id" in msg
+                assert "sender" in msg
+                assert "content" in msg
+                assert "timestamp" in msg
+                assert "type" in msg
+        finally:
+            v1_adapter_client.delete(f"/process/{team_id}/archive")
+            time.sleep(0.5)
 
     def test_full_round_trip_v1(self, v1_adapter_client: TestClient) -> None:
-        """AC #1, #2: Full V1 round-trip — create, send, retrieve, archive."""
-        # 1. Create team via V1
+        """AC #1, #2: Full V1 round-trip -- create, send, retrieve, archive."""
         resp = v1_adapter_client.post(f"/process/{CATALOG_ENTRY_ID}")
         assert resp.status_code == 200
         create_data = resp.json()
         assert "id" in create_data
-        assert "status" in create_data
-        assert "params" in create_data
         team_id = create_data["id"]
 
-        # 2. Send message via V1
-        resp = v1_adapter_client.patch(
-            f"/process/{team_id}",
-            json={"content": "Say hello in one word."},
-        )
-        assert resp.status_code == 200
-        assert resp.json()["status"] == "ok"
+        try:
+            resp = v1_adapter_client.patch(
+                f"/process/{team_id}",
+                json={"content": "Say hello in one word."},
+            )
+            assert resp.status_code == 200
+            assert resp.json()["status"] == "ok"
 
-        # 3. Poll messages via V1
-        messages = _wait_for_v1_messages(v1_adapter_client, team_id)
-        assert _has_v1_llm_content(messages)
+            messages = _wait_for_v1_messages(v1_adapter_client, team_id)
+            assert _has_v1_llm_content(messages)
 
-        # Verify V1MessageEntry shape on the LLM response
-        llm_messages = [
-            m
-            for m in messages
-            if isinstance(m.get("sender"), str)
-            and "@Manager" in str(m.get("sender"))
-            and isinstance(m.get("content"), str)
-            and len(str(m.get("content"))) > 0
-        ]
-        assert len(llm_messages) >= 1
-        llm_msg = llm_messages[0]
-        assert "id" in llm_msg
-        assert "sender" in llm_msg
-        assert "content" in llm_msg
-        assert "timestamp" in llm_msg
-        assert "type" in llm_msg
-
-        # 4. Archive (stop) via V1
-        resp = v1_adapter_client.delete(f"/process/{team_id}/archive")
-        assert resp.status_code == 200
-        assert resp.json()["status"] == "ok"
-        time.sleep(0.5)
+            llm_messages = [
+                m
+                for m in messages
+                if isinstance(m.get("sender"), str)
+                and "@Manager" in str(m.get("sender"))
+                and isinstance(m.get("content"), str)
+                and len(str(m.get("content"))) > 0
+            ]
+            assert len(llm_messages) >= 1
+            llm_msg = llm_messages[0]
+            assert "id" in llm_msg
+            assert "sender" in llm_msg
+            assert "content" in llm_msg
+            assert "timestamp" in llm_msg
+            assert "type" in llm_msg
+        finally:
+            resp = v1_adapter_client.delete(f"/process/{team_id}/archive")
+            assert resp.status_code == 200
+            assert resp.json()["status"] == "ok"
+            time.sleep(0.5)
 
 
 # ---------------------------------------------------------------------------
@@ -198,74 +184,66 @@ class TestV1WebSocket:
     def test_ws_v1_envelope_format(self, v1_adapter_client: TestClient) -> None:
         """AC #3: WebSocket delivers events in V1 envelope format."""
         team_id = _create_v1_team(v1_adapter_client)
+        try:
+            with v1_adapter_client.websocket_connect(f"/ws/{team_id}") as ws:
+                time.sleep(0.3)
+                v1_adapter_client.patch(
+                    f"/process/{team_id}",
+                    json={"content": "Say hello"},
+                )
 
-        with v1_adapter_client.websocket_connect(f"/ws/{team_id}") as ws:
-            time.sleep(0.3)
-            v1_adapter_client.patch(
-                f"/process/{team_id}",
-                json={"content": "Say hello"},
-            )
+                data = ws.receive_json(mode="text")
+                assert isinstance(data, dict)
+                assert "payload" in data
+                payload = data["payload"]
+                assert isinstance(payload, dict)
+                assert "type" in payload
+                assert payload["type"] in ("message", "state", "tool_update")
 
-            data = ws.receive_json(mode="text")
-            assert isinstance(data, dict)
-
-            # V1 envelope should have 'payload' from WrappedWsEvent
-            assert "payload" in data
-            payload = data["payload"]
-            assert isinstance(payload, dict)
-
-            # V1 envelope must have 'type' discriminator
-            assert "type" in payload
-            assert payload["type"] in ("message", "state", "tool_update")
-
-            # Verify V1-compatible fields based on type
-            if payload["type"] == "message":
-                assert "sender" in payload
-                assert "content" in payload
-                assert "message_type" in payload
-            elif payload["type"] == "state":
-                assert "agent" in payload
-                assert "state" in payload
-
-        # Stop team to avoid LLM-in-flight hang
-        v1_adapter_client.delete(f"/process/{team_id}/archive")
-        time.sleep(0.5)
+                if payload["type"] == "message":
+                    assert "sender" in payload
+                    assert "content" in payload
+                    assert "message_type" in payload
+                elif payload["type"] == "state":
+                    assert "agent" in payload
+                    assert "state" in payload
+        finally:
+            v1_adapter_client.delete(f"/process/{team_id}/archive")
+            time.sleep(0.5)
 
     def test_ws_v1_message_fields(self, v1_adapter_client: TestClient) -> None:
         """AC #3: V1 message envelope contains sender, content, message_type."""
         team_id = _create_v1_team(v1_adapter_client)
+        try:
+            message_events: list[dict[str, object]] = []
+            with v1_adapter_client.websocket_connect(f"/ws/{team_id}") as ws:
+                time.sleep(0.3)
+                v1_adapter_client.patch(
+                    f"/process/{team_id}",
+                    json={"content": "Say yes"},
+                )
 
-        message_events: list[dict[str, object]] = []
-        with v1_adapter_client.websocket_connect(f"/ws/{team_id}") as ws:
-            time.sleep(0.3)
-            v1_adapter_client.patch(
-                f"/process/{team_id}",
-                json={"content": "Say yes"},
-            )
+                deadline = time.monotonic() + 30.0
+                while time.monotonic() < deadline:
+                    try:
+                        data = ws.receive_json(mode="text")
+                    except (WebSocketDisconnect, RuntimeError):
+                        break
+                    if not isinstance(data, dict) or "payload" not in data:
+                        continue
+                    payload = data["payload"]
+                    if isinstance(payload, dict) and payload.get("type") == "message":
+                        message_events.append(payload)
+                        break
 
-            # Collect a few events to find a message-type one
-            deadline = time.monotonic() + 30.0
-            while time.monotonic() < deadline:
-                try:
-                    data = ws.receive_json(mode="text")
-                except (WebSocketDisconnect, RuntimeError):
-                    break
-                if not isinstance(data, dict) or "payload" not in data:
-                    continue
-                payload = data["payload"]
-                if isinstance(payload, dict) and payload.get("type") == "message":
-                    message_events.append(payload)
-                    break
-
-        assert len(message_events) >= 1, "Expected at least one V1 message envelope"
-        msg = message_events[0]
-        assert "sender" in msg
-        assert "content" in msg
-        assert "message_type" in msg
-        assert "id" in msg
-        assert "timestamp" in msg
-        assert msg["message_type"] in ("user", "agent", "system")
-
-        # Stop team
-        v1_adapter_client.delete(f"/process/{team_id}/archive")
-        time.sleep(0.5)
+            assert len(message_events) >= 1, "Expected at least one V1 message envelope"
+            msg = message_events[0]
+            assert "sender" in msg
+            assert "content" in msg
+            assert "message_type" in msg
+            assert "id" in msg
+            assert "timestamp" in msg
+            assert msg["message_type"] in ("user", "agent", "system")
+        finally:
+            v1_adapter_client.delete(f"/process/{team_id}/archive")
+            time.sleep(0.5)

--- a/tests/integration/test_spec_channels.py
+++ b/tests/integration/test_spec_channels.py
@@ -1,67 +1,19 @@
-"""Integration tests — channel spec compliance: multi-adapter, form-encoded, config passthrough.
+"""Integration tests — channel spec compliance: form-encoded webhook payloads.
 
 Validates ADR-002 remediation for story 6.1 channel subsystem fixes.
+
+Note: TestMultiAdapterDispatch and TestChannelConfigPassthrough were reclassified
+as unit tests and moved to tests/channels/ (story 9.4).
 """
 
 from __future__ import annotations
 
-import uuid
+import time
 
 import pytest
-from akgentic.core.actor_address_impl import ActorAddressProxy
-from akgentic.core.messages import SentMessage
-from akgentic.core.messages.message import UserMessage
 from fastapi.testclient import TestClient
 
-from akgentic.infra.adapters.channel_dispatcher import InteractionChannelDispatcher
-from akgentic.infra.adapters.channel_parser_registry import (
-    ChannelConfig,
-    ChannelParserRegistry,
-)
-
-from .test_channels import StubChannelAdapter
-
 pytestmark = [pytest.mark.integration, pytest.mark.llm]
-
-
-# ---------------------------------------------------------------------------
-# AC #3 — Multi-adapter dispatch
-# ---------------------------------------------------------------------------
-
-
-class TestMultiAdapterDispatch:
-    """Verify dispatcher delivers to ALL matching adapters (no break short-circuit)."""
-
-    def test_two_adapters_both_receive_message(self) -> None:
-        """AC #3: Register 2 StubChannelAdapters, dispatch, verify both received."""
-        adapter_a = StubChannelAdapter()
-        adapter_b = StubChannelAdapter()
-        dispatcher = InteractionChannelDispatcher(
-            team_id=uuid.uuid4(),
-            adapters=[adapter_a, adapter_b],
-        )
-
-        # Build a SentMessage to dispatch
-        addr_dict = {
-            "__actor_address__": True,
-            "__actor_type__": "test",
-            "agent_id": str(uuid.uuid4()),
-            "name": "@Test",
-            "role": "Test",
-            "team_id": str(uuid.uuid4()),
-            "squad_id": str(uuid.uuid4()),
-            "user_message": False,
-        }
-        proxy = ActorAddressProxy(addr_dict)
-        inner = UserMessage(content="test message")
-        sent = SentMessage(message=inner, sender=proxy, recipient=proxy)
-
-        dispatcher.on_message(sent)
-
-        assert len(adapter_a.delivered) == 1, "Adapter A should receive the message"
-        assert len(adapter_b.delivered) == 1, "Adapter B should receive the message"
-        assert adapter_a.delivered[0] is sent
-        assert adapter_b.delivered[0] is sent
 
 
 # ---------------------------------------------------------------------------
@@ -81,8 +33,6 @@ class TestFormEncodedWebhook:
         Uses an existing team via reply flow to avoid creating a new team
         with in-flight LLM calls that would block teardown.
         """
-        import time
-
         # Create a team first so we can use reply flow (no LLM initiation)
         create_resp = channel_client.post(
             "/teams/",
@@ -91,91 +41,18 @@ class TestFormEncodedWebhook:
         assert create_resp.status_code == 201
         team_id = create_resp.json()["team_id"]
 
-        resp = channel_client.post(
-            "/webhook/test-channel",
-            data={
-                "content": "form test message",
-                "channel_user_id": "form-user-1",
-                "team_id": team_id,
-            },
-            headers={"content-type": "application/x-www-form-urlencoded"},
-        )
-        assert resp.status_code == 204
-
-        # Stop team to allow clean teardown
-        channel_client.post(f"/teams/{team_id}/stop")
-        time.sleep(0.5)
-
-
-# ---------------------------------------------------------------------------
-# AC #3 — ChannelConfig passthrough
-# ---------------------------------------------------------------------------
-
-
-class StubParserWithConfig:
-    """Parser stub that captures constructor config args."""
-
-    received_config: dict[str, str]
-
-    def __init__(self, **kwargs: str) -> None:
-        StubParserWithConfig.received_config = dict(kwargs)
-
-    @property
-    def channel_name(self) -> str:
-        return "config-test-channel"
-
-    @property
-    def default_catalog_entry(self) -> str:
-        return "test-team"
-
-    async def parse(self, payload: dict[str, object]) -> None:
-        pass  # pragma: no cover
-
-
-class StubAdapterWithConfig:
-    """Adapter stub that captures constructor config args."""
-
-    received_config: dict[str, str]
-
-    def __init__(self, **kwargs: str) -> None:
-        StubAdapterWithConfig.received_config = dict(kwargs)
-
-    def matches(self, msg: SentMessage) -> bool:
-        return True  # pragma: no cover
-
-    def deliver(self, msg: SentMessage) -> None:
-        pass  # pragma: no cover
-
-    def on_stop(self, team_id: uuid.UUID) -> None:
-        pass  # pragma: no cover
-
-
-class TestChannelConfigPassthrough:
-    """Verify ChannelConfig.config values reach adapter/parser constructors."""
-
-    def test_config_dict_reaches_constructors(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """AC #3: Configure channel with config dict, verify it reaches constructors."""
-        # Monkeypatch import_class to return our stubs
-        monkeypatch.setattr(
-            "akgentic.infra.adapters.channel_parser_registry.import_class",
-            lambda fqcn: StubParserWithConfig if "Parser" in fqcn else StubAdapterWithConfig,
-        )
-
-        config = {
-            "test-chan": ChannelConfig(
-                parser_fqcn="fake.module.Parser",
-                adapter_fqcn="fake.module.Adapter",
-                config={"key": "value", "api_token": "secret123"},
+        try:
+            resp = channel_client.post(
+                "/webhook/test-channel",
+                data={
+                    "content": "form test message",
+                    "channel_user_id": "form-user-1",
+                    "team_id": team_id,
+                },
+                headers={"content-type": "application/x-www-form-urlencoded"},
             )
-        }
-
-        ChannelParserRegistry(channels_config=config)
-
-        assert StubParserWithConfig.received_config == {
-            "key": "value",
-            "api_token": "secret123",
-        }
-        assert StubAdapterWithConfig.received_config == {
-            "key": "value",
-            "api_token": "secret123",
-        }
+            assert resp.status_code == 204
+        finally:
+            # Stop team to allow clean teardown
+            channel_client.post(f"/teams/{team_id}/stop")
+            time.sleep(0.5)

--- a/tests/integration/test_spec_compliance.py
+++ b/tests/integration/test_spec_compliance.py
@@ -45,14 +45,15 @@ class TestAppFactory:
         settings = CommunitySettings(workspaces_root=tmp_path / "workspaces")
         _seed_integration_catalog(settings.workspaces_root / "catalog")
         services = wire_community(settings)
-        app = create_app(services, settings)
-        client = TestClient(app)
+        try:
+            app = create_app(services, settings)
+            client = TestClient(app)
 
-        resp = client.get("/teams/")
-        assert resp.status_code == 200
-        assert "teams" in resp.json()
-
-        services.actor_system.shutdown()
+            resp = client.get("/teams/")
+            assert resp.status_code == 200
+            assert "teams" in resp.json()
+        finally:
+            services.actor_system.shutdown()
 
     def test_team_create_get_delete_via_test_client(
         self,
@@ -61,25 +62,24 @@ class TestAppFactory:
     ) -> None:
         """AC #1: Team create/get/delete work through TestClient."""
         team_id = create_team(integration_client)
+        try:
+            resp = integration_client.get(f"/teams/{team_id}")
+            assert resp.status_code == 200
+            assert resp.json()["status"] == "running"
 
-        # GET returns the team
-        resp = integration_client.get(f"/teams/{team_id}")
-        assert resp.status_code == 200
-        assert resp.json()["status"] == "running"
+            integration_client.post(f"/teams/{team_id}/stop")
+            time.sleep(0.5)
 
-        # Stop then delete
-        integration_client.post(f"/teams/{team_id}/stop")
-        time.sleep(0.5)
+            resp = integration_client.delete(f"/teams/{team_id}")
+            assert resp.status_code == 204
 
-        resp = integration_client.delete(f"/teams/{team_id}")
-        assert resp.status_code == 204
-
-        # GET after delete returns 404 or deleted status
-        resp = integration_client.get(f"/teams/{team_id}")
-        if resp.status_code == 200:
-            assert resp.json()["status"] == "deleted"
-        else:
-            assert resp.status_code == 404
+            resp = integration_client.get(f"/teams/{team_id}")
+            if resp.status_code == 200:
+                assert resp.json()["status"] == "deleted"
+            else:
+                assert resp.status_code == 404
+        finally:
+            integration_client.post(f"/teams/{team_id}/stop")
 
 
 # ---------------------------------------------------------------------------
@@ -95,37 +95,34 @@ class TestRuntimeCacheLifecycle:
         integration_client: TestClient,
         integration_app: FastAPI,
     ) -> None:
-        """AC #2: Full RuntimeCache lifecycle — create, stop, restore, delete."""
+        """AC #2: Full RuntimeCache lifecycle -- create, stop, restore, delete."""
         cache = integration_app.state.services.runtime_cache
-
-        # 1. Create team -> cache.get(team_id) is not None
         team_id_str = create_team(integration_client)
-        team_id = uuid.UUID(team_id_str)
-        assert cache.get(team_id) is not None, "RuntimeCache should hold handle after create"
+        try:
+            team_id = uuid.UUID(team_id_str)
+            assert cache.get(team_id) is not None
 
-        # 2. Stop team -> cache.get(team_id) returns None
-        resp = integration_client.post(f"/teams/{team_id_str}/stop")
-        assert resp.status_code == 204
-        assert cache.get(team_id) is None, "RuntimeCache should be empty after stop"
+            resp = integration_client.post(f"/teams/{team_id_str}/stop")
+            assert resp.status_code == 204
+            assert cache.get(team_id) is None
 
-        # 3. Verify events still accessible (event store preserved)
-        resp = integration_client.get(f"/teams/{team_id_str}/events")
-        assert resp.status_code == 200
-        events = resp.json()["events"]
-        assert len(events) >= 1, "Events should be preserved after stop"
+            resp = integration_client.get(f"/teams/{team_id_str}/events")
+            assert resp.status_code == 200
+            events = resp.json()["events"]
+            assert len(events) >= 1
 
-        # 4. Restore team -> cache.get(team_id) is not None again
-        resp = integration_client.post(f"/teams/{team_id_str}/restore")
-        assert resp.status_code == 200
-        assert resp.json()["status"] == "running"
-        assert cache.get(team_id) is not None, "RuntimeCache should hold handle after restore"
+            resp = integration_client.post(f"/teams/{team_id_str}/restore")
+            assert resp.status_code == 200
+            assert resp.json()["status"] == "running"
+            assert cache.get(team_id) is not None
 
-        # 5. Delete team -> team gone
-        resp = integration_client.post(f"/teams/{team_id_str}/stop")
-        assert resp.status_code == 204
-        resp = integration_client.delete(f"/teams/{team_id_str}")
-        assert resp.status_code == 204
-        assert cache.get(team_id) is None, "RuntimeCache should be empty after delete"
+            resp = integration_client.post(f"/teams/{team_id_str}/stop")
+            assert resp.status_code == 204
+            resp = integration_client.delete(f"/teams/{team_id_str}")
+            assert resp.status_code == 204
+            assert cache.get(team_id) is None
+        finally:
+            integration_client.post(f"/teams/{team_id_str}/stop")
 
 
 # ---------------------------------------------------------------------------
@@ -142,25 +139,24 @@ class TestWebSocketTeamHandle:
     ) -> None:
         """AC #4: Create team, open WS, verify events arrive via TeamHandle."""
         team_id = create_team(integration_client)
+        try:
+            with integration_client.websocket_connect(f"/ws/{team_id}") as ws:
+                time.sleep(0.3)
+                integration_client.post(
+                    f"/teams/{team_id}/message",
+                    json={"content": "Say hello"},
+                )
 
-        with integration_client.websocket_connect(f"/ws/{team_id}") as ws:
-            time.sleep(0.3)
-            integration_client.post(
-                f"/teams/{team_id}/message",
-                json={"content": "Say hello"},
-            )
-
-            data = ws.receive_json(mode="text")
-            assert isinstance(data, dict)
-            assert "__model__" in data
-            model = str(data.get("__model__", ""))
-            assert "SentMessage" in model or "ReceivedMessage" in model, (
-                f"Expected SentMessage or ReceivedMessage, got: {model}"
-            )
-
-        # Stop team to avoid LLM-in-flight hang
-        integration_client.post(f"/teams/{team_id}/stop")
-        time.sleep(0.5)
+                data = ws.receive_json(mode="text")
+                assert isinstance(data, dict)
+                assert "__model__" in data
+                model = str(data.get("__model__", ""))
+                assert "SentMessage" in model or "ReceivedMessage" in model, (
+                    f"Expected SentMessage or ReceivedMessage, got: {model}"
+                )
+        finally:
+            integration_client.post(f"/teams/{team_id}/stop")
+            time.sleep(0.5)
 
     def test_ws_send_message_via_rest_receive_via_ws(
         self,
@@ -168,22 +164,20 @@ class TestWebSocketTeamHandle:
     ) -> None:
         """AC #4: Send message via REST, verify WS receives events, close cleanly."""
         team_id = create_team(integration_client)
+        try:
+            with integration_client.websocket_connect(f"/ws/{team_id}") as ws:
+                time.sleep(0.3)
+                integration_client.post(
+                    f"/teams/{team_id}/message",
+                    json={"content": "Say yes"},
+                )
 
-        with integration_client.websocket_connect(f"/ws/{team_id}") as ws:
-            time.sleep(0.3)
-            integration_client.post(
-                f"/teams/{team_id}/message",
-                json={"content": "Say yes"},
-            )
+                data = ws.receive_json(mode="text")
+                assert isinstance(data, dict)
+                assert "__model__" in data
 
-            data = ws.receive_json(mode="text")
-            assert isinstance(data, dict)
-            assert "__model__" in data
-
-        # WS closed — verify no errors accessing team
-        resp = integration_client.get(f"/teams/{team_id}")
-        assert resp.status_code == 200
-
-        # Stop team
-        integration_client.post(f"/teams/{team_id}/stop")
-        time.sleep(0.5)
+            resp = integration_client.get(f"/teams/{team_id}")
+            assert resp.status_code == 200
+        finally:
+            integration_client.post(f"/teams/{team_id}/stop")
+            time.sleep(0.5)

--- a/tests/integration/test_spec_frontend.py
+++ b/tests/integration/test_spec_frontend.py
@@ -1,6 +1,9 @@
 """Integration tests — V1 frontend adapter spec compliance for story 6.8 endpoints.
 
-Validates all V1 endpoints added in story 6.8 and the llm_context WS envelope type.
+Validates all V1 endpoints added in story 6.8.
+
+Note: TestLlmContextEnvelope was reclassified as a unit test and moved to
+tests/frontend_adapter/test_v1_ws_classify.py (story 9.4).
 """
 
 from __future__ import annotations
@@ -35,43 +38,46 @@ class TestV1Story68Endpoints:
     def test_patch_description(self, v1_adapter_client: TestClient) -> None:
         """AC #5: PATCH /process/{id}/description returns ok."""
         team_id = _create_v1_team(v1_adapter_client)
-
-        resp = v1_adapter_client.patch(
-            f"/process/{team_id}/description",
-            json={"description": "Updated description"},
-        )
-        assert resp.status_code == 200
-        assert resp.json()["status"] == "ok"
-
-        v1_adapter_client.delete(f"/process/{team_id}/archive")
-        time.sleep(0.5)
+        try:
+            resp = v1_adapter_client.patch(
+                f"/process/{team_id}/description",
+                json={"description": "Updated description"},
+            )
+            assert resp.status_code == 200
+            assert resp.json()["status"] == "ok"
+        finally:
+            v1_adapter_client.delete(f"/process/{team_id}/archive")
+            time.sleep(0.5)
 
     def test_relaunch_message_not_found(self, v1_adapter_client: TestClient) -> None:
         """AC #5: POST /relaunch/{id}/message/{msgId} returns 404 for unknown msg."""
         team_id = _create_v1_team(v1_adapter_client)
-
-        resp = v1_adapter_client.post(
-            f"/relaunch/{team_id}/message/00000000-0000-0000-0000-000000000000",
-        )
-        assert resp.status_code == 404
-        assert "not found" in resp.json()["detail"].lower()
-
-        v1_adapter_client.delete(f"/process/{team_id}/archive")
-        time.sleep(0.5)
+        try:
+            resp = v1_adapter_client.post(
+                f"/relaunch/{team_id}/message/00000000-0000-0000-0000-000000000000",
+            )
+            assert resp.status_code == 404
+            assert "not found" in resp.json()["detail"].lower()
+        finally:
+            v1_adapter_client.delete(f"/process/{team_id}/archive")
+            time.sleep(0.5)
 
     def test_patch_state_not_running(self, v1_adapter_client: TestClient) -> None:
         """AC #5: PATCH /state/{id}/of/{agent} returns 404 for stopped team."""
         team_id = _create_v1_team(v1_adapter_client)
+        try:
+            # Stop the team first
+            v1_adapter_client.delete(f"/process/{team_id}/archive")
+            time.sleep(0.5)
 
-        # Stop the team first
-        v1_adapter_client.delete(f"/process/{team_id}/archive")
-        time.sleep(0.5)
-
-        resp = v1_adapter_client.patch(
-            f"/state/{team_id}/of/@Manager",
-            json={"content": "state update"},
-        )
-        assert resp.status_code == 404
+            resp = v1_adapter_client.patch(
+                f"/state/{team_id}/of/@Manager",
+                json={"content": "state update"},
+            )
+            assert resp.status_code == 404
+        finally:
+            # Already archived above; no additional cleanup needed
+            pass
 
     def test_get_config_team(self, v1_adapter_client: TestClient) -> None:
         """AC #5: GET /config/team returns catalog entries."""
@@ -127,7 +133,7 @@ class TestV1Story68Endpoints:
         assert resp.json()["status"] == "ok"
 
     def test_put_config_create_and_update(self, v1_adapter_client: TestClient) -> None:
-        """AC #5: PUT /config/{config_type} creates a new entry and updates an existing one."""
+        """AC #5: PUT /config/{config_type} creates a new entry and updates."""
         # Get an existing entry to know the data shape
         resp = v1_adapter_client.get("/config/team")
         assert resp.status_code == 200
@@ -164,41 +170,3 @@ class TestV1Story68Endpoints:
         # ADR-004 path shape: DELETE /config/{config_type}/{config_id}
         resp = v1_adapter_client.delete("/config/team/nonexistent")
         assert resp.status_code == 404
-
-
-# ---------------------------------------------------------------------------
-# AC #5 — llm_context WS envelope type
-# ---------------------------------------------------------------------------
-
-
-class TestLlmContextEnvelope:
-    """Verify the V1 WS handler emits llm_context envelope type."""
-
-    def test_classify_envelope_type_for_context_changed(self) -> None:
-        """AC #5: _classify_envelope_type returns 'llm_context' for ContextChangedMessage."""
-        from akgentic.infra.server.routes.frontend_adapter.angular_v1.ws import (
-            _classify_envelope_type,
-        )
-
-        # _classify_envelope_type checks type(event).__name__ == "ContextChangedMessage"
-        class ContextChangedMessage:  # noqa: N801
-            """Fake message whose class name matches the real ContextChangedMessage."""
-
-            def __init__(self) -> None:
-                self.id = "test-id"
-                self.sender = None
-
-        result = _classify_envelope_type(ContextChangedMessage())  # type: ignore[arg-type]
-        assert result == "llm_context"
-
-    def test_classify_envelope_returns_message_for_user_message(self) -> None:
-        """AC #5: _classify_envelope_type returns 'message' for UserMessage."""
-        from akgentic.core.messages.message import UserMessage
-
-        from akgentic.infra.server.routes.frontend_adapter.angular_v1.ws import (
-            _classify_envelope_type,
-        )
-
-        msg = UserMessage(content="hello")
-        result = _classify_envelope_type(msg)
-        assert result == "message"

--- a/tests/integration/test_team_lifecycle.py
+++ b/tests/integration/test_team_lifecycle.py
@@ -45,7 +45,6 @@ def _has_llm_content(events: list[dict[str, object]]) -> bool:
         ev = ev_wrapper["event"]
         if not isinstance(ev, dict):
             continue
-        # SentMessage wraps a message with content
         msg = ev.get("message")
         if not isinstance(msg, dict):
             continue
@@ -81,10 +80,12 @@ class TestTeamLifecycle:
     ) -> None:
         """AC #1, #2: Create a team and verify it is running."""
         team_id = _create_team(integration_client)
-
-        resp = integration_client.get(f"/teams/{team_id}")
-        assert resp.status_code == 200
-        assert resp.json()["status"] == "running"
+        try:
+            resp = integration_client.get(f"/teams/{team_id}")
+            assert resp.status_code == 200
+            assert resp.json()["status"] == "running"
+        finally:
+            integration_client.post(f"/teams/{team_id}/stop")
 
     def test_send_message_and_receive_llm_response(
         self,
@@ -92,15 +93,17 @@ class TestTeamLifecycle:
     ) -> None:
         """AC #5 (partial): Send a message and verify LLM responds."""
         team_id = _create_team(integration_client)
+        try:
+            resp = integration_client.post(
+                f"/teams/{team_id}/message",
+                json={"content": "Say hello in exactly three words."},
+            )
+            assert resp.status_code == 204
 
-        resp = integration_client.post(
-            f"/teams/{team_id}/message",
-            json={"content": "Say hello in exactly three words."},
-        )
-        assert resp.status_code == 204
-
-        events = _wait_for_llm_response(integration_client, team_id)
-        assert _has_llm_content(events)
+            events = _wait_for_llm_response(integration_client, team_id)
+            assert _has_llm_content(events)
+        finally:
+            integration_client.post(f"/teams/{team_id}/stop")
 
     def test_stop_and_restore_team(
         self,
@@ -108,19 +111,19 @@ class TestTeamLifecycle:
     ) -> None:
         """AC #5 (partial): Stop and restore a team."""
         team_id = _create_team(integration_client)
+        try:
+            resp = integration_client.post(f"/teams/{team_id}/stop")
+            assert resp.status_code == 204
 
-        # Stop
-        resp = integration_client.post(f"/teams/{team_id}/stop")
-        assert resp.status_code == 204
+            resp = integration_client.get(f"/teams/{team_id}")
+            assert resp.status_code == 200
+            assert resp.json()["status"] == "stopped"
 
-        resp = integration_client.get(f"/teams/{team_id}")
-        assert resp.status_code == 200
-        assert resp.json()["status"] == "stopped"
-
-        # Restore
-        resp = integration_client.post(f"/teams/{team_id}/restore")
-        assert resp.status_code == 200
-        assert resp.json()["status"] == "running"
+            resp = integration_client.post(f"/teams/{team_id}/restore")
+            assert resp.status_code == 200
+            assert resp.json()["status"] == "running"
+        finally:
+            integration_client.post(f"/teams/{team_id}/stop")
 
     def test_events_persisted_after_stop(
         self,
@@ -128,58 +131,52 @@ class TestTeamLifecycle:
     ) -> None:
         """AC #5 (partial): Events persist after stop."""
         team_id = _create_team(integration_client)
+        try:
+            integration_client.post(
+                f"/teams/{team_id}/message",
+                json={"content": "Respond with one word."},
+            )
+            _wait_for_llm_response(integration_client, team_id)
 
-        # Send a message and wait for LLM to respond
-        integration_client.post(
-            f"/teams/{team_id}/message",
-            json={"content": "Respond with one word."},
-        )
-        _wait_for_llm_response(integration_client, team_id)
+            resp = integration_client.post(f"/teams/{team_id}/stop")
+            assert resp.status_code == 204
 
-        # Stop the team
-        resp = integration_client.post(f"/teams/{team_id}/stop")
-        assert resp.status_code == 204
-
-        # Events should still be accessible after stop
-        resp = integration_client.get(f"/teams/{team_id}/events")
-        assert resp.status_code == 200
-        events = resp.json()["events"]
-        assert len(events) >= 3
+            resp = integration_client.get(f"/teams/{team_id}/events")
+            assert resp.status_code == 200
+            events = resp.json()["events"]
+            assert len(events) >= 3
+        finally:
+            integration_client.post(f"/teams/{team_id}/stop")
 
     def test_full_lifecycle_round_trip(
         self,
         integration_client: TestClient,
     ) -> None:
-        """AC #5: Full round-trip — create, message, LLM, stop, restore."""
-        # 1. Create
+        """AC #5: Full round-trip -- create, message, LLM, stop, restore."""
         team_id = _create_team(integration_client)
+        try:
+            resp = integration_client.post(
+                f"/teams/{team_id}/message",
+                json={"content": "What is 2 + 2? Answer with the number."},
+            )
+            assert resp.status_code == 204
 
-        # 2. Send message
-        resp = integration_client.post(
-            f"/teams/{team_id}/message",
-            json={"content": "What is 2 + 2? Answer with the number."},
-        )
-        assert resp.status_code == 204
+            events = _wait_for_llm_response(integration_client, team_id)
+            assert _has_llm_content(events)
 
-        # 3. Wait for LLM response
-        events = _wait_for_llm_response(integration_client, team_id)
-        assert _has_llm_content(events)
+            resp = integration_client.post(f"/teams/{team_id}/stop")
+            assert resp.status_code == 204
+            resp = integration_client.get(f"/teams/{team_id}")
+            assert resp.json()["status"] == "stopped"
 
-        # 4. Stop
-        resp = integration_client.post(f"/teams/{team_id}/stop")
-        assert resp.status_code == 204
+            resp = integration_client.post(f"/teams/{team_id}/restore")
+            assert resp.status_code == 200
+            assert resp.json()["status"] == "running"
 
-        resp = integration_client.get(f"/teams/{team_id}")
-        assert resp.json()["status"] == "stopped"
-
-        # 5. Restore
-        resp = integration_client.post(f"/teams/{team_id}/restore")
-        assert resp.status_code == 200
-        assert resp.json()["status"] == "running"
-
-        # 6. Verify events persisted through stop/restore cycle
-        resp = integration_client.get(f"/teams/{team_id}/events")
-        assert resp.status_code == 200
-        final_events = resp.json()["events"]
-        assert len(final_events) >= 3
-        assert _has_llm_content(final_events)
+            resp = integration_client.get(f"/teams/{team_id}/events")
+            assert resp.status_code == 200
+            final_events = resp.json()["events"]
+            assert len(final_events) >= 3
+            assert _has_llm_content(final_events)
+        finally:
+            integration_client.post(f"/teams/{team_id}/stop")

--- a/tests/integration/test_websocket.py
+++ b/tests/integration/test_websocket.py
@@ -26,89 +26,79 @@ class TestWebSocketIntegration:
     ) -> None:
         """AC #1: Create team, open WS, send message, verify events delivered via WS."""
         team_id = create_team(integration_client)
+        try:
+            with integration_client.websocket_connect(f"/ws/{team_id}") as ws:
+                time.sleep(0.3)
+                integration_client.post(
+                    f"/teams/{team_id}/message",
+                    json={"content": "Say hello"},
+                )
 
-        with integration_client.websocket_connect(f"/ws/{team_id}") as ws:
-            # Send a message to trigger events through the actor system
-            time.sleep(0.3)
-            integration_client.post(
-                f"/teams/{team_id}/message",
-                json={"content": "Say hello"},
-            )
-
-            data = ws.receive_json(mode="text")
-            assert isinstance(data, dict)
-            assert "__model__" in data
-            model = str(data.get("__model__", ""))
-            assert "SentMessage" in model or "ReceivedMessage" in model, (
-                f"Expected SentMessage or ReceivedMessage, got: {model}"
-            )
-
-        # Stop team before fixture teardown to avoid LLM-in-flight hang
-        integration_client.post(f"/teams/{team_id}/stop")
-        time.sleep(0.5)
+                data = ws.receive_json(mode="text")
+                assert isinstance(data, dict)
+                assert "__model__" in data
+                model = str(data.get("__model__", ""))
+                assert "SentMessage" in model or "ReceivedMessage" in model, (
+                    f"Expected SentMessage or ReceivedMessage, got: {model}"
+                )
+        finally:
+            integration_client.post(f"/teams/{team_id}/stop")
+            time.sleep(0.5)
 
     def test_ws_full_round_trip_with_llm(
         self,
         integration_client: TestClient,
     ) -> None:
-        """AC #1: Send message via HTTP, verify LLM response arrives, open WS for new events."""
+        """AC #1: Send message via HTTP, verify LLM response arrives, open WS."""
         team_id = create_team(integration_client)
-
-        # Send message and wait for LLM response via REST polling
-        integration_client.post(
-            f"/teams/{team_id}/message",
-            json={"content": "Reply with exactly one word."},
-        )
-        events = wait_for_llm_response(integration_client, team_id)
-        assert has_llm_content(events)
-
-        # Now open WS and send another message — verify WS delivers events
-        with integration_client.websocket_connect(f"/ws/{team_id}") as ws:
-            time.sleep(0.3)
+        try:
             integration_client.post(
                 f"/teams/{team_id}/message",
-                json={"content": "Say yes."},
+                json={"content": "Reply with exactly one word."},
             )
-            data = ws.receive_json(mode="text")
-            assert isinstance(data, dict)
-            assert "__model__" in data
+            events = wait_for_llm_response(integration_client, team_id)
+            assert has_llm_content(events)
 
-            # Verify at least one event has SentMessage or ReceivedMessage
-            model = str(data.get("__model__", ""))
-            assert "SentMessage" in model or "ReceivedMessage" in model, (
-                f"Expected SentMessage or ReceivedMessage, got: {model}"
-            )
+            with integration_client.websocket_connect(f"/ws/{team_id}") as ws:
+                time.sleep(0.3)
+                integration_client.post(
+                    f"/teams/{team_id}/message",
+                    json={"content": "Say yes."},
+                )
+                data = ws.receive_json(mode="text")
+                assert isinstance(data, dict)
+                assert "__model__" in data
 
-        # Stop team before fixture teardown to avoid LLM-in-flight hang
-        integration_client.post(f"/teams/{team_id}/stop")
-        time.sleep(0.5)
+                model = str(data.get("__model__", ""))
+                assert "SentMessage" in model or "ReceivedMessage" in model, (
+                    f"Expected SentMessage or ReceivedMessage, got: {model}"
+                )
+        finally:
+            integration_client.post(f"/teams/{team_id}/stop")
+            time.sleep(0.5)
 
     def test_ws_restore_receives_events(
         self,
         integration_client: TestClient,
     ) -> None:
-        """AC #1: Connect WS to stopped team, restore, verify events flow after restore."""
+        """AC #1: Connect WS to stopped team, restore, verify events after restore."""
         team_id = create_team(integration_client)
+        try:
+            resp = integration_client.post(f"/teams/{team_id}/stop")
+            assert resp.status_code == 204
 
-        # Stop the team
-        resp = integration_client.post(f"/teams/{team_id}/stop")
-        assert resp.status_code == 204
+            with integration_client.websocket_connect(f"/ws/{team_id}") as ws:
+                integration_client.post(f"/teams/{team_id}/restore")
+                time.sleep(0.5)
 
-        with integration_client.websocket_connect(f"/ws/{team_id}") as ws:
-            # Restore the team — idle WS should start receiving events
-            integration_client.post(f"/teams/{team_id}/restore")
+                integration_client.post(
+                    f"/teams/{team_id}/message",
+                    json={"content": "hello after restore"},
+                )
+
+                data = ws.receive_json(mode="text")
+                assert isinstance(data, dict)
+                assert "__model__" in data
+        finally:
+            integration_client.post(f"/teams/{team_id}/stop")
             time.sleep(0.5)
-
-            # Send a message to generate events
-            integration_client.post(
-                f"/teams/{team_id}/message",
-                json={"content": "hello after restore"},
-            )
-
-            data = ws.receive_json(mode="text")
-            assert isinstance(data, dict)
-            assert "__model__" in data
-
-        # Stop team before fixture teardown to avoid LLM-in-flight hang
-        integration_client.post(f"/teams/{team_id}/stop")
-        time.sleep(0.5)

--- a/tests/server/models/test_server_settings.py
+++ b/tests/server/models/test_server_settings.py
@@ -119,6 +119,124 @@ class TestServerSettingsModel:
             assert field_info.description is not None, f"Field {name} missing description"
 
 
+# ---------------------------------------------------------------------------
+# Reclassified from integration/test_adr003_tier_agnostic.py — TestSettingsHierarchy
+# Pure model field inspection; no real app needed.
+# ---------------------------------------------------------------------------
+
+
+class TestSettingsHierarchy:
+    """Verify ServerSettings / CommunitySettings hierarchy."""
+
+    def test_server_settings_has_only_tier_agnostic_fields(self) -> None:
+        """ServerSettings has only tier-agnostic fields."""
+        server_fields = set(ServerSettings.model_fields.keys())
+        expected = {"host", "port", "log_level", "cors_origins", "frontend_adapter"}
+        assert server_fields == expected, (
+            f"ServerSettings fields mismatch: got {server_fields}, expected {expected}"
+        )
+
+    def test_community_settings_extends_server_settings(self) -> None:
+        """CommunitySettings is a subclass of ServerSettings."""
+        assert issubclass(CommunitySettings, ServerSettings)
+        community_own_fields = set(CommunitySettings.model_fields.keys()) - set(
+            ServerSettings.model_fields.keys()
+        )
+        assert "workspaces_root" in community_own_fields
+        assert "catalog_path" in community_own_fields
+
+    def test_community_settings_no_literal_fields(self) -> None:
+        """No Literal['yaml'] fields on either settings class."""
+        import typing
+
+        for cls in (ServerSettings, CommunitySettings):
+            for field_name, field_info in cls.model_fields.items():
+                annotation = field_info.annotation
+                origin = typing.get_origin(annotation)
+                if origin is typing.Literal:
+                    args = typing.get_args(annotation)
+                    assert "yaml" not in args, (
+                        f"{cls.__name__}.{field_name} has Literal['yaml']"
+                    )
+
+    def test_community_settings_wires_functional_app(self, tmp_path: Path) -> None:
+        """End-to-end: CommunitySettings -> wire -> create_app -> team works."""
+        from akgentic.infra.server.app import create_app
+        from akgentic.infra.wiring import wire_community
+
+        settings = CommunitySettings(workspaces_root=tmp_path / "workspaces")
+        # Seed a minimal catalog
+        _seed_minimal_catalog(settings.workspaces_root / "catalog")
+        services = wire_community(settings)
+        try:
+            from fastapi.testclient import TestClient
+
+            app = create_app(services, settings)
+            client = TestClient(app)
+
+            resp = client.get("/teams/")
+            assert resp.status_code == 200
+            assert "teams" in resp.json()
+        finally:
+            services.actor_system.shutdown()
+
+
+def _seed_minimal_catalog(catalog_root: Path) -> None:
+    """Seed minimal catalog for settings hierarchy test."""
+    import yaml
+
+    def _write_yaml(path: Path, data: dict[str, object]) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(yaml.dump(data, default_flow_style=False))
+
+    _write_yaml(
+        catalog_root / "agents" / "human-proxy.yaml",
+        {
+            "id": "human-proxy",
+            "tool_ids": [],
+            "card": {
+                "role": "Human",
+                "description": "Human user interface",
+                "skills": [],
+                "agent_class": "akgentic.agent.HumanProxy",
+                "config": {"name": "@Human", "role": "Human"},
+                "routes_to": ["@Manager"],
+            },
+        },
+    )
+    _write_yaml(
+        catalog_root / "agents" / "manager.yaml",
+        {
+            "id": "manager",
+            "tool_ids": [],
+            "card": {
+                "role": "Manager",
+                "description": "Test manager",
+                "skills": ["coordination"],
+                "agent_class": "akgentic.agent.BaseAgent",
+                "config": {"name": "@Manager", "role": "Manager"},
+                "routes_to": [],
+            },
+        },
+    )
+    _write_yaml(
+        catalog_root / "teams" / "test-team.yaml",
+        {
+            "id": "test-team",
+            "name": "Test Team",
+            "entry_point": "human-proxy",
+            "message_types": ["akgentic.core.messages.UserMessage"],
+            "members": [
+                {"agent_id": "human-proxy"},
+                {"agent_id": "manager"},
+            ],
+            "profiles": [],
+        },
+    )
+    (catalog_root / "templates").mkdir(parents=True, exist_ok=True)
+    (catalog_root / "tools").mkdir(parents=True, exist_ok=True)
+
+
 class TestCommunitySettingsDefaults:
     """CommunitySettings extends ServerSettings with community-specific fields."""
 

--- a/tests/server/routes/test_webhook_route.py
+++ b/tests/server/routes/test_webhook_route.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import uuid
 from pathlib import Path
 
+import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
@@ -85,15 +86,30 @@ class StubIngestion:
 # ---------------------------------------------------------------------------
 
 
-def _build_parser_registry(parser: StubParser) -> ChannelParserRegistry:
+def _build_parser_registry(
+    parser: StubParser,
+    monkeypatch: pytest.MonkeyPatch | None = None,
+) -> ChannelParserRegistry:
     """Build a ChannelParserRegistry with a pre-registered stub parser.
 
-    Uses __new__ to bypass the constructor which requires importable FQCNs.
-    The webhook route only needs get_parser(), so adapter resolution is irrelevant.
+    Constructs via the public API with an empty config, then monkeypatches
+    get_parser to return the stub. This avoids __new__ hacks and private
+    attribute access.
     """
-    registry = ChannelParserRegistry.__new__(ChannelParserRegistry)
-    registry._parsers = {parser.channel_name: parser}  # noqa: SLF001
-    registry._adapters = []  # noqa: SLF001
+    registry = ChannelParserRegistry(channels_config={})
+
+    original_get_parser = registry.get_parser
+
+    def _patched_get_parser(channel_name: str) -> StubParser | None:
+        if channel_name == parser.channel_name:
+            return parser  # type: ignore[return-value]
+        return original_get_parser(channel_name)
+
+    if monkeypatch is not None:
+        monkeypatch.setattr(registry, "get_parser", _patched_get_parser)
+    else:
+        registry.get_parser = _patched_get_parser  # type: ignore[assignment]
+
     return registry
 
 

--- a/tests/server/services/test_team_service.py
+++ b/tests/server/services/test_team_service.py
@@ -82,6 +82,27 @@ def test_delete_team_not_found_raises(team_service: TeamService) -> None:
         team_service.delete_team(uuid.uuid4())
 
 
+# ---------------------------------------------------------------------------
+# Reclassified from integration/test_adr003_tier_agnostic.py
+# Source inspection; no real app needed.
+# ---------------------------------------------------------------------------
+
+
+class TestTeamServiceImports:
+    """Verify TeamService module does not import actor internals."""
+
+    def test_team_service_has_no_actor_internal_imports(self) -> None:
+        """TeamService module does not import actor internals."""
+        import inspect
+
+        from akgentic.infra.server.services import team_service as ts_module
+
+        source = inspect.getsource(ts_module)
+        forbidden = ["TeamManager", "ActorSystem", "LocalTeamHandle", "CommunityServices"]
+        for name in forbidden:
+            assert name not in source, f"TeamService module must not import {name}"
+
+
 class TestTeamServiceLogging:
     """TeamService emits expected log messages."""
 


### PR DESCRIPTION
## Summary

- Reclassified 6 fake integration tests (pure function calls, monkeypatch, MagicMock) as unit tests in proper domain directories
- Fixed broken `TestSettingsHierarchy` assertion to include `log_level` field
- Replaced `ChannelParserRegistry.__new__` constructor bypass with public API in `test_webhook_route.py`
- Eliminated `MagicMock` from `tests/integration/test_cli.py` (replaced with `_StubRenderer`)
- Added `try/finally` cleanup to all integration tests that create teams (10+ files)
- Created `poll_until` helper in `_helpers.py`; replaced bare `time.sleep` with polling where a verifiable condition exists
- Removed all `noqa: SLF001` and private attribute access from test files
- Zero `src/` changes (Epic 9 global rule)
- 749 unit tests pass, 95.32% coverage

Closes #103