### PR TITLE
Fix CLI renderer bugs: FQ model names and ErrorMessage fields

### DIFF
--- a/src/akgentic/infra/cli/commands.py
+++ b/src/akgentic/infra/cli/commands.py
@@ -170,6 +170,8 @@ def _is_displayable(data: dict[str, Any]) -> bool:
         except (json_mod.JSONDecodeError, TypeError):
             return False
     model = event.get("__model__", "")
+    # Match short suffix from fully qualified model names (e.g. "akgentic.core.messages.orchestrator.SentMessage")
+    model = model.rsplit(".", 1)[-1] if model else ""
     # Keep in sync with repl._DISPLAY_EVENTS
     return model in {"SentMessage", "ErrorMessage", "EventMessage"}
 

--- a/src/akgentic/infra/cli/commands.py
+++ b/src/akgentic/infra/cli/commands.py
@@ -170,7 +170,7 @@ def _is_displayable(data: dict[str, Any]) -> bool:
         except (json_mod.JSONDecodeError, TypeError):
             return False
     model = event.get("__model__", "")
-    # Match short suffix from fully qualified model names (e.g. "akgentic.core.messages.orchestrator.SentMessage")
+    # Match short suffix from fully qualified model names
     model = model.rsplit(".", 1)[-1] if model else ""
     # Keep in sync with repl._DISPLAY_EVENTS
     return model in {"SentMessage", "ErrorMessage", "EventMessage"}

--- a/src/akgentic/infra/cli/repl.py
+++ b/src/akgentic/infra/cli/repl.py
@@ -190,7 +190,7 @@ def _render_event_impl(data: dict[str, Any], renderer: RichRenderer) -> bool:
         return False
 
     if short_model == "ErrorMessage":
-        content = event.get("content", event.get("error", ""))
+        content = event.get("exception_value", event.get("content", event.get("error", "")))
         renderer.render_error(str(content))
         return True
 

--- a/tests/cli/test_cli_commands_insession.py
+++ b/tests/cli/test_cli_commands_insession.py
@@ -42,8 +42,6 @@ _PROMPT_PATH = "prompt_toolkit.PromptSession.prompt"
 
 # -- Helpers --
 
-
-
 def _mock_client(**overrides: Any) -> MagicMock:
     """Build a mock ApiClient with in-session-specific defaults."""
     mock = MagicMock()

--- a/tests/cli/test_cli_commands_insession.py
+++ b/tests/cli/test_cli_commands_insession.py
@@ -43,19 +43,6 @@ _PROMPT_PATH = "prompt_toolkit.PromptSession.prompt"
 # -- Helpers --
 
 
-def _short_model(event: dict[str, Any]) -> dict[str, Any]:
-    """Normalize __model__ to short class name for _is_displayable compatibility.
-
-    _is_displayable checks __model__ against short names ("SentMessage") but factory
-    output uses fully-qualified names ("akgentic.core.messages.orchestrator.SentMessage").
-    _render_event_impl handles both via rsplit, but _is_displayable does not.
-    This is a known production inconsistency -- this helper works around it in tests.
-    """
-    model = event.get("__model__", "")
-    if "." in model:
-        event = {**event, "__model__": model.rsplit(".", 1)[-1]}
-    return event
-
 
 def _mock_client(**overrides: Any) -> MagicMock:
     """Build a mock ApiClient with in-session-specific defaults."""
@@ -254,7 +241,7 @@ class TestHistoryHandler:
             EventInfo(
                 team_id="t1",
                 sequence=i,
-                event=_short_model(make_sent_message(content=f"msg-{i}")),
+                event=make_sent_message(content=f"msg-{i}"),
                 timestamp="2026-01-01T00:00:00",
             )
             for i in range(25)
@@ -278,7 +265,7 @@ class TestHistoryHandler:
             EventInfo(
                 team_id="t1",
                 sequence=i,
-                event=_short_model(make_sent_message(content=f"msg-{i}")),
+                event=make_sent_message(content=f"msg-{i}"),
                 timestamp="2026-01-01T00:00:00",
             )
             for i in range(25)
@@ -331,7 +318,7 @@ class TestHistoryHandler:
             EventInfo(
                 team_id="t1",
                 sequence=2,
-                event=_short_model(make_sent_message(content="visible")),
+                event=make_sent_message(content="visible"),
                 timestamp="2026-01-01T00:00:00",
             ),
         ]

--- a/tests/cli/test_cli_repl.py
+++ b/tests/cli/test_cli_repl.py
@@ -284,11 +284,7 @@ class TestRenderEvent:
         assert result is True
         out = buf.getvalue()
         assert "error" in out
-        # Note: renderer extracts content via event.get("content") or event.get("error"),
-        # but ErrorMessage.model_dump() uses "exception_value". The renderer renders an
-        # error panel but with empty content. This is a known renderer limitation -- the
-        # renderer does not extract "exception_value" from real ErrorMessage serialization.
-        # A separate bug should address renderer compatibility with real ErrorMessage shape.
+        assert "something broke" in out
 
     def test_skip_start_message(self) -> None:
         renderer, buf = _captured_renderer()


### PR DESCRIPTION
## Summary

- Fix `_is_displayable()` in `commands.py` to handle fully-qualified `__model__` names via `rsplit` (e.g. `akgentic.core.messages.orchestrator.SentMessage` -> `SentMessage`)
- Fix `_render_event_impl()` in `repl.py` to extract `exception_value` from `ErrorMessage` events, matching real `ErrorMessage.model_dump()` schema
- Remove `_short_model()` test workaround helper and all call sites
- Strengthen `test_error_message` assertion to verify actual error text appears in rendered output

Closes #113