### PR TITLE
Implicit human-input reply routing

### DIFF
--- a/src/akgentic/infra/cli/repl.py
+++ b/src/akgentic/infra/cli/repl.py
@@ -79,7 +79,8 @@ class ChatSession:
     def _get_prompt(self) -> str:
         """Return the current input prompt, reflecting pending reply state."""
         if self._pending_reply_id:
-            return f"Reply to {self._pending_agent_name}: "
+            name = self._pending_agent_name or "Agent"
+            return f"Reply to {name}: "
         return "You: "
 
     async def _input_loop(self) -> None:
@@ -264,14 +265,16 @@ def _notify_human_input(
     on_human_input: Callable[[str, str], None],
 ) -> None:
     """Extract message_id and agent_name from outer event data and invoke callback."""
-    message_id = str(outer_data.get("id", ""))
+    raw_id = outer_data.get("id")
+    if not raw_id:
+        return
+    message_id = str(raw_id)
     raw_sender = outer_data.get("sender", "Agent")
     if isinstance(raw_sender, dict):
         agent_name = str(raw_sender.get("name", "Agent"))
     else:
         agent_name = str(raw_sender)
-    if message_id:
-        on_human_input(message_id, agent_name)
+    on_human_input(message_id, agent_name)
 
 
 def _render_event_message_impl(

--- a/tests/cli/test_cli_repl.py
+++ b/tests/cli/test_cli_repl.py
@@ -573,3 +573,47 @@ class TestImplicitHumanInputReplyRouting:
         session._render_event(data)
         assert session._pending_reply_id == "msg-str-sender"
         assert session._pending_agent_name == "SimpleAgent"
+
+    def test_pending_not_set_when_id_is_none(self) -> None:
+        """Verify that a None id in the outer event data does not set pending state."""
+        renderer, buf = _captured_renderer()
+        session = _make_session(renderer=renderer)
+        data = {
+            "id": None,
+            "sender": {"name": "AgentX"},
+            "event": {
+                "__model__": "EventMessage",
+                "event": {
+                    "__model__": "HumanInputRequest",
+                    "prompt": "question?",
+                },
+            },
+        }
+        session._render_event(data)
+        assert session._pending_reply_id is None
+        assert session._pending_agent_name is None
+
+    def test_pending_not_set_when_id_missing(self) -> None:
+        """Verify that a missing id in the outer event data does not set pending state."""
+        renderer, buf = _captured_renderer()
+        session = _make_session(renderer=renderer)
+        data = {
+            "sender": {"name": "AgentX"},
+            "event": {
+                "__model__": "EventMessage",
+                "event": {
+                    "__model__": "HumanInputRequest",
+                    "prompt": "question?",
+                },
+            },
+        }
+        session._render_event(data)
+        assert session._pending_reply_id is None
+        assert session._pending_agent_name is None
+
+    def test_prompt_fallback_when_agent_name_is_none(self) -> None:
+        """Verify prompt uses 'Agent' fallback when _pending_agent_name is None."""
+        session = _make_session()
+        session._pending_reply_id = "some-id"
+        session._pending_agent_name = None
+        assert session._get_prompt() == "Reply to Agent: "


### PR DESCRIPTION
## Summary

- Adds implicit reply routing: when a HumanInput/RequestInput event arrives, the REPL stashes the message ID and shows a "Reply to <agent>:" prompt
- Next plain-text input is routed via `ApiClient.human_input()` instead of `send_message()`; pending state is cleared before the API call
- Slash commands bypass pending state; `@AgentName` messages route normally via `send_message()`
- Refactored `_render_event_impl` with `on_human_input` callback and extracted `_render_tool_call`/`_notify_human_input` helpers

## Code Review Fixes

- Guarded `_notify_human_input` against `None` id values (was converting to string "None" which passed truthiness check)
- Added fallback in `_get_prompt` when `_pending_agent_name` is `None`
- Added 3 edge-case tests: None id, missing id, None agent name prompt fallback

## Test Results

- 700 tests pass, 88% coverage, ruff clean

Closes #117