### PR TITLE
Catalog Browsing

### DIFF
--- a/src/akgentic/infra/cli/client.py
+++ b/src/akgentic/infra/cli/client.py
@@ -67,6 +67,14 @@ class WorkspaceUploadInfo(BaseModel):
     size: int
 
 
+class CatalogTeamInfo(BaseModel):
+    """Catalog team entry for display (subset of server-side TeamEntry)."""
+
+    id: str
+    name: str
+    description: str
+
+
 class ApiClient:
     """Thin HTTP client mapping CLI commands to server endpoints."""
 
@@ -119,6 +127,13 @@ class ApiClient:
             print(msg, file=sys.stderr)
             raise typer.Exit(code=1)
         return resp
+
+    # -- catalog endpoints --
+
+    def list_catalog_teams(self) -> list[CatalogTeamInfo]:
+        """GET /catalog/api/teams/ -> list of CatalogTeamInfo models."""
+        resp = self._request("GET", "/catalog/api/teams/")
+        return [CatalogTeamInfo.model_validate(entry) for entry in resp.json()]
 
     # -- team endpoints --
 

--- a/src/akgentic/infra/cli/commands.py
+++ b/src/akgentic/infra/cli/commands.py
@@ -443,6 +443,24 @@ async def _switch_handler(args: str, session: ChatSession) -> None:
     print(f"Switched to team {new_team_id}.")
 
 
+async def _catalog_handler(args: str, session: ChatSession) -> None:
+    """List available team templates from the catalog."""
+    loop = asyncio.get_running_loop()
+    try:
+        entries = await loop.run_in_executor(None, session.client.list_catalog_teams)
+    except SystemExit:
+        print("Error fetching catalog.", file=sys.stderr)
+        return
+
+    if not entries:
+        print("No team templates found.")
+        return
+
+    print("Available team templates:")
+    for entry in entries:
+        print(f"  {entry.id:<20s} {entry.name:<24s} {entry.description}")
+
+
 def build_default_registry() -> CommandRegistry:
     """Create a command registry with all built-in commands."""
     registry = CommandRegistry()
@@ -451,6 +469,7 @@ def build_default_registry() -> CommandRegistry:
     registry.register(
         "create", _create_handler, "Create a team from catalog", "/create <catalog_entry>"
     )
+    registry.register("catalog", _catalog_handler, "List team templates", "/catalog")
     registry.register("delete", _delete_handler, "Delete a team", "/delete [team_id]")
     registry.register("info", _info_handler, "Show team details", "/info [team_id]")
     registry.register("events", _events_handler, "Show raw team events", "/events [N]")

--- a/tests/cli/conftest.py
+++ b/tests/cli/conftest.py
@@ -77,6 +77,7 @@ def mock_client(**overrides: Any) -> MagicMock:
             WorkspaceEntry(name="readme.md", is_dir=False, size=42),
         ],
     )
+    mock.list_catalog_teams.return_value = []
     mock.workspace_read.return_value = b"file content"
     mock.workspace_upload.return_value = WorkspaceUploadInfo(path="readme.md", size=12)
     for k, v in overrides.items():

--- a/tests/cli/test_cli_commands_insession.py
+++ b/tests/cli/test_cli_commands_insession.py
@@ -73,6 +73,7 @@ def _mock_client(**overrides: Any) -> MagicMock:
     mock.workspace_upload.return_value = WorkspaceUploadInfo(path="test.txt", size=5)
     mock.stop_team.return_value = None
     mock.delete_team.return_value = None
+    mock.list_catalog_teams.return_value = []
     mock.restore_team.return_value = TeamInfo(
         team_id="t1",
         name="Test Team",

--- a/tests/cli/test_cli_commands_insession.py
+++ b/tests/cli/test_cli_commands_insession.py
@@ -10,6 +10,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from akgentic.infra.cli.client import (
+    CatalogTeamInfo,
     EventInfo,
     TeamInfo,
     WorkspaceEntry,
@@ -19,6 +20,7 @@ from akgentic.infra.cli.client import (
 from akgentic.infra.cli.commands import (
     CommandRegistry,
     _agents_handler,
+    _catalog_handler,
     _create_handler,
     _delete_handler,
     _events_handler,
@@ -929,6 +931,97 @@ class TestChatSessionCommandIntegration:
 
 
 # =============================================================================
+# Story 10.3: Catalog browsing tests
+# =============================================================================
+
+
+class TestCatalogHandler:
+    async def test_catalog_handler_lists_entries(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        client = _mock_client()
+        client.list_catalog_teams.return_value = [
+            CatalogTeamInfo(
+                id="research-team",
+                name="Research Team",
+                description="Multi-agent research and analysis team",
+            ),
+            CatalogTeamInfo(
+                id="code-review",
+                name="Code Review",
+                description="Automated code review with expert agents",
+            ),
+        ]
+        session = _make_session(client=client)
+
+        await _catalog_handler("", session)
+
+        out = capsys.readouterr().out
+        assert "Available team templates:" in out
+        assert "research-team" in out
+        assert "Research Team" in out
+        assert "Multi-agent research and analysis team" in out
+        assert "code-review" in out
+        assert "Code Review" in out
+        assert "Automated code review with expert agents" in out
+
+    async def test_catalog_handler_empty(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        client = _mock_client()
+        client.list_catalog_teams.return_value = []
+        session = _make_session(client=client)
+
+        await _catalog_handler("", session)
+
+        out = capsys.readouterr().out
+        assert "No team templates found." in out
+
+    async def test_catalog_handler_error(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        client = _mock_client()
+        client.list_catalog_teams.side_effect = SystemExit(1)
+        session = _make_session(client=client)
+
+        await _catalog_handler("", session)
+
+        err = capsys.readouterr().err
+        assert "Error fetching catalog." in err
+
+
+class TestListCatalogTeamsClient:
+    def test_list_catalog_teams_parses_response(self) -> None:
+        """Verify list_catalog_teams parses JSON array into CatalogTeamInfo list."""
+        from akgentic.infra.cli.client import ApiClient
+
+        mock_response = MagicMock()
+        mock_response.json.return_value = [
+            {
+                "id": "research-team",
+                "name": "Research Team",
+                "description": "Multi-agent research and analysis team",
+                "entry_point": "human-proxy",
+                "message_types": ["akgentic.core.messages.UserMessage"],
+                "members": [],
+                "profiles": [],
+            },
+        ]
+        mock_response.is_success = True
+
+        client = ApiClient.__new__(ApiClient)
+        client._client = MagicMock()
+        client._client.request.return_value = mock_response
+
+        result = client.list_catalog_teams()
+
+        assert len(result) == 1
+        assert result[0].id == "research-team"
+        assert result[0].name == "Research Team"
+        assert result[0].description == "Multi-agent research and analysis team"
+
+
+# =============================================================================
 # Task 8.4: Verify build_default_registry has all commands
 # =============================================================================
 
@@ -939,6 +1032,7 @@ class TestBuildDefaultRegistry:
         expected = {
             "help",
             "teams",
+            "catalog",
             "create",
             "delete",
             "info",


### PR DESCRIPTION
## Summary

- Add `/catalog` slash command that lists available team templates from the catalog API
- Add `CatalogTeamInfo` Pydantic model and `list_catalog_teams()` method to `ApiClient`
- Register `/catalog` in `build_default_registry()` with auto-complete support
- Add 4 unit tests covering happy path, empty result, error handling, and client response parsing

Closes #119