### PR TITLE
feat: implicit human input reply routing (story 10-2)

### DIFF
--- a/src/akgentic/infra/cli/client.py
+++ b/src/akgentic/infra/cli/client.py
@@ -67,6 +67,14 @@ class WorkspaceUploadInfo(BaseModel):
     size: int
 
 
+class CatalogTeamInfo(BaseModel):
+    """Catalog team entry for display (subset of server-side TeamEntry)."""
+
+    id: str
+    name: str
+    description: str
+
+
 class ApiClient:
     """Thin HTTP client mapping CLI commands to server endpoints."""
 
@@ -119,6 +127,13 @@ class ApiClient:
             print(msg, file=sys.stderr)
             raise typer.Exit(code=1)
         return resp
+
+    # -- catalog endpoints --
+
+    def list_catalog_teams(self) -> list[CatalogTeamInfo]:
+        """GET /catalog/api/teams/ -> list of CatalogTeamInfo models."""
+        resp = self._request("GET", "/catalog/api/teams/")
+        return [CatalogTeamInfo.model_validate(entry) for entry in resp.json()]
 
     # -- team endpoints --
 

--- a/src/akgentic/infra/cli/commands.py
+++ b/src/akgentic/infra/cli/commands.py
@@ -443,6 +443,24 @@ async def _switch_handler(args: str, session: ChatSession) -> None:
     print(f"Switched to team {new_team_id}.")
 
 
+async def _catalog_handler(args: str, session: ChatSession) -> None:
+    """List available team templates from the catalog."""
+    loop = asyncio.get_running_loop()
+    try:
+        entries = await loop.run_in_executor(None, session.client.list_catalog_teams)
+    except SystemExit:
+        print("Error fetching catalog.", file=sys.stderr)
+        return
+
+    if not entries:
+        print("No team templates found.")
+        return
+
+    print("Available team templates:")
+    for entry in entries:
+        print(f"  {entry.id:<20s} {entry.name:<24s} {entry.description}")
+
+
 def build_default_registry() -> CommandRegistry:
     """Create a command registry with all built-in commands."""
     registry = CommandRegistry()
@@ -451,6 +469,7 @@ def build_default_registry() -> CommandRegistry:
     registry.register(
         "create", _create_handler, "Create a team from catalog", "/create <catalog_entry>"
     )
+    registry.register("catalog", _catalog_handler, "List team templates", "/catalog")
     registry.register("delete", _delete_handler, "Delete a team", "/delete [team_id]")
     registry.register("info", _info_handler, "Show team details", "/info [team_id]")
     registry.register("events", _events_handler, "Show raw team events", "/events [N]")

--- a/src/akgentic/infra/cli/repl.py
+++ b/src/akgentic/infra/cli/repl.py
@@ -79,7 +79,8 @@ class ChatSession:
     def _get_prompt(self) -> str:
         """Return the current input prompt, reflecting pending reply state."""
         if self._pending_reply_id:
-            return f"Reply to {self._pending_agent_name}: "
+            name = self._pending_agent_name or "Agent"
+            return f"Reply to {name}: "
         return "You: "
 
     async def _input_loop(self) -> None:
@@ -264,14 +265,16 @@ def _notify_human_input(
     on_human_input: Callable[[str, str], None],
 ) -> None:
     """Extract message_id and agent_name from outer event data and invoke callback."""
-    message_id = str(outer_data.get("id", ""))
+    raw_id = outer_data.get("id")
+    if not raw_id:
+        return
+    message_id = str(raw_id)
     raw_sender = outer_data.get("sender", "Agent")
     if isinstance(raw_sender, dict):
         agent_name = str(raw_sender.get("name", "Agent"))
     else:
         agent_name = str(raw_sender)
-    if message_id:
-        on_human_input(message_id, agent_name)
+    on_human_input(message_id, agent_name)
 
 
 def _render_event_message_impl(

--- a/src/akgentic/infra/cli/repl.py
+++ b/src/akgentic/infra/cli/repl.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+from collections.abc import Callable
 from typing import Any
 
 import websockets.exceptions
@@ -44,6 +45,8 @@ class ChatSession:
         self.renderer = renderer or RichRenderer()
         self.command_registry: CommandRegistry = build_default_registry()
         self._running = True
+        self._pending_reply_id: str | None = None
+        self._pending_agent_name: str | None = None
         self._receive_task: asyncio.Task[None] | None = None
         self._prompt_session: PromptSession[str] = PromptSession(
             history=InMemoryHistory(),
@@ -73,13 +76,19 @@ class ChatSession:
                         pass
                 self.renderer.render_system_message("Session closed.")
 
+    def _get_prompt(self) -> str:
+        """Return the current input prompt, reflecting pending reply state."""
+        if self._pending_reply_id:
+            return f"Reply to {self._pending_agent_name}: "
+        return "You: "
+
     async def _input_loop(self) -> None:
         """Read user input and send messages."""
         loop = asyncio.get_running_loop()
         while self._running:
             try:
                 line = await loop.run_in_executor(
-                    None, self._prompt_session.prompt, "You: "
+                    None, self._prompt_session.prompt, self._get_prompt()
                 )
             except (EOFError, KeyboardInterrupt):
                 break
@@ -92,6 +101,19 @@ class ChatSession:
 
             # Try dispatching as a slash command
             if await self.command_registry.dispatch(line, self):
+                continue
+
+            # Route as human-input reply if pending
+            if self._pending_reply_id:
+                try:
+                    reply_id = self._pending_reply_id
+                    self._pending_reply_id = None
+                    self._pending_agent_name = None
+                    await loop.run_in_executor(
+                        None, self.client.human_input, self.team_id, line, reply_id
+                    )
+                except SystemExit:
+                    self.renderer.render_error("Error sending reply.")
                 continue
 
             # Send message via REST API (run in executor to avoid blocking)
@@ -148,7 +170,12 @@ class ChatSession:
 
     def _render_event(self, data: dict[str, Any]) -> bool:
         """Format and render a single event. Returns True if something was rendered."""
-        return _render_event_impl(data, self.renderer)
+
+        def _set_pending(message_id: str, agent_name: str) -> None:
+            self._pending_reply_id = message_id
+            self._pending_agent_name = agent_name
+
+        return _render_event_impl(data, self.renderer, on_human_input=_set_pending)
 
 
 class _SlashCompleter(Completer):
@@ -174,7 +201,11 @@ class _SlashCompleter(Completer):
                 )
 
 
-def _render_event_impl(data: dict[str, Any], renderer: RichRenderer) -> bool:
+def _render_event_impl(
+    data: dict[str, Any],
+    renderer: RichRenderer,
+    on_human_input: Callable[[str, str], None] | None = None,
+) -> bool:
     """Shared event rendering logic used by both ChatSession and _print_event."""
     event = data.get("event", data)
     if isinstance(event, str):
@@ -195,7 +226,9 @@ def _render_event_impl(data: dict[str, Any], renderer: RichRenderer) -> bool:
         return True
 
     if short_model == "EventMessage":
-        return _render_event_message_impl(event, renderer)
+        return _render_event_message_impl(
+            event, renderer, on_human_input=on_human_input, outer_data=data
+        )
 
     # SentMessage — agent response; content lives inside nested "message"
     raw_sender = event.get("sender", "agent")
@@ -208,7 +241,45 @@ def _render_event_impl(data: dict[str, Any], renderer: RichRenderer) -> bool:
     return False
 
 
-def _render_event_message_impl(event: dict[str, Any], renderer: RichRenderer) -> bool:
+def _render_tool_call(nested: dict[str, Any], renderer: RichRenderer) -> None:
+    """Extract and render a tool call event."""
+    tool_name = str(nested["tool_name"])
+    raw_input = nested.get("arguments", nested.get("args", nested.get("input", "")))
+    if isinstance(raw_input, dict | list):
+        tool_input = json.dumps(raw_input, indent=2)
+    else:
+        tool_input = str(raw_input)
+    raw_output = nested.get("result")
+    if raw_output is None:
+        tool_output = None
+    elif isinstance(raw_output, dict | list):
+        tool_output = json.dumps(raw_output, indent=2)
+    else:
+        tool_output = str(raw_output)
+    renderer.render_tool_call(tool_name, tool_input, tool_output)
+
+
+def _notify_human_input(
+    outer_data: dict[str, Any],
+    on_human_input: Callable[[str, str], None],
+) -> None:
+    """Extract message_id and agent_name from outer event data and invoke callback."""
+    message_id = str(outer_data.get("id", ""))
+    raw_sender = outer_data.get("sender", "Agent")
+    if isinstance(raw_sender, dict):
+        agent_name = str(raw_sender.get("name", "Agent"))
+    else:
+        agent_name = str(raw_sender)
+    if message_id:
+        on_human_input(message_id, agent_name)
+
+
+def _render_event_message_impl(
+    event: dict[str, Any],
+    renderer: RichRenderer,
+    on_human_input: Callable[[str, str], None] | None = None,
+    outer_data: dict[str, Any] | None = None,
+) -> bool:
     """Handle EventMessage — inspect nested event for tool calls / human input."""
     nested = event.get("event", {})
     if isinstance(nested, str):
@@ -222,32 +293,15 @@ def _render_event_message_impl(event: dict[str, Any], renderer: RichRenderer) ->
 
     nested_model = nested.get("__model__", "")
 
-    # Tool call events (ToolCallEvent uses "arguments", others use "args"/"input")
     if "tool_name" in nested:
-        tool_name = str(nested["tool_name"])
-        raw_input = nested.get("arguments", nested.get("args", nested.get("input", "")))
-        if isinstance(raw_input, dict | list):
-            tool_input = json.dumps(raw_input, indent=2)
-        else:
-            tool_input = str(raw_input)
-        raw_output = nested.get("result")
-        if raw_output is None:
-            tool_output = None
-        elif isinstance(raw_output, dict | list):
-            tool_output = json.dumps(raw_output, indent=2)
-        else:
-            tool_output = str(raw_output)
-        renderer.render_tool_call(
-            tool_name,
-            tool_input,
-            tool_output,
-        )
+        _render_tool_call(nested, renderer)
         return True
 
-    # Human input request
     if "HumanInput" in nested_model or "RequestInput" in nested_model:
         prompt_text = str(nested.get("prompt", nested.get("content", "Input requested")))
         renderer.render_human_input_request(prompt_text)
+        if on_human_input is not None and outer_data is not None:
+            _notify_human_input(outer_data, on_human_input)
         return True
 
     return False

--- a/tests/cli/conftest.py
+++ b/tests/cli/conftest.py
@@ -77,6 +77,7 @@ def mock_client(**overrides: Any) -> MagicMock:
             WorkspaceEntry(name="readme.md", is_dir=False, size=42),
         ],
     )
+    mock.list_catalog_teams.return_value = []
     mock.workspace_read.return_value = b"file content"
     mock.workspace_upload.return_value = WorkspaceUploadInfo(path="readme.md", size=12)
     for k, v in overrides.items():

--- a/tests/cli/test_cli_commands_insession.py
+++ b/tests/cli/test_cli_commands_insession.py
@@ -73,6 +73,7 @@ def _mock_client(**overrides: Any) -> MagicMock:
     mock.workspace_upload.return_value = WorkspaceUploadInfo(path="test.txt", size=5)
     mock.stop_team.return_value = None
     mock.delete_team.return_value = None
+    mock.list_catalog_teams.return_value = []
     mock.restore_team.return_value = TeamInfo(
         team_id="t1",
         name="Test Team",

--- a/tests/cli/test_cli_commands_insession.py
+++ b/tests/cli/test_cli_commands_insession.py
@@ -10,6 +10,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from akgentic.infra.cli.client import (
+    CatalogTeamInfo,
     EventInfo,
     TeamInfo,
     WorkspaceEntry,
@@ -19,6 +20,7 @@ from akgentic.infra.cli.client import (
 from akgentic.infra.cli.commands import (
     CommandRegistry,
     _agents_handler,
+    _catalog_handler,
     _create_handler,
     _delete_handler,
     _events_handler,
@@ -929,6 +931,97 @@ class TestChatSessionCommandIntegration:
 
 
 # =============================================================================
+# Story 10.3: Catalog browsing tests
+# =============================================================================
+
+
+class TestCatalogHandler:
+    async def test_catalog_handler_lists_entries(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        client = _mock_client()
+        client.list_catalog_teams.return_value = [
+            CatalogTeamInfo(
+                id="research-team",
+                name="Research Team",
+                description="Multi-agent research and analysis team",
+            ),
+            CatalogTeamInfo(
+                id="code-review",
+                name="Code Review",
+                description="Automated code review with expert agents",
+            ),
+        ]
+        session = _make_session(client=client)
+
+        await _catalog_handler("", session)
+
+        out = capsys.readouterr().out
+        assert "Available team templates:" in out
+        assert "research-team" in out
+        assert "Research Team" in out
+        assert "Multi-agent research and analysis team" in out
+        assert "code-review" in out
+        assert "Code Review" in out
+        assert "Automated code review with expert agents" in out
+
+    async def test_catalog_handler_empty(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        client = _mock_client()
+        client.list_catalog_teams.return_value = []
+        session = _make_session(client=client)
+
+        await _catalog_handler("", session)
+
+        out = capsys.readouterr().out
+        assert "No team templates found." in out
+
+    async def test_catalog_handler_error(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        client = _mock_client()
+        client.list_catalog_teams.side_effect = SystemExit(1)
+        session = _make_session(client=client)
+
+        await _catalog_handler("", session)
+
+        err = capsys.readouterr().err
+        assert "Error fetching catalog." in err
+
+
+class TestListCatalogTeamsClient:
+    def test_list_catalog_teams_parses_response(self) -> None:
+        """Verify list_catalog_teams parses JSON array into CatalogTeamInfo list."""
+        from akgentic.infra.cli.client import ApiClient
+
+        mock_response = MagicMock()
+        mock_response.json.return_value = [
+            {
+                "id": "research-team",
+                "name": "Research Team",
+                "description": "Multi-agent research and analysis team",
+                "entry_point": "human-proxy",
+                "message_types": ["akgentic.core.messages.UserMessage"],
+                "members": [],
+                "profiles": [],
+            },
+        ]
+        mock_response.is_success = True
+
+        client = ApiClient.__new__(ApiClient)
+        client._client = MagicMock()
+        client._client.request.return_value = mock_response
+
+        result = client.list_catalog_teams()
+
+        assert len(result) == 1
+        assert result[0].id == "research-team"
+        assert result[0].name == "Research Team"
+        assert result[0].description == "Multi-agent research and analysis team"
+
+
+# =============================================================================
 # Task 8.4: Verify build_default_registry has all commands
 # =============================================================================
 
@@ -939,6 +1032,7 @@ class TestBuildDefaultRegistry:
         expected = {
             "help",
             "teams",
+            "catalog",
             "create",
             "delete",
             "info",

--- a/tests/cli/test_cli_repl.py
+++ b/tests/cli/test_cli_repl.py
@@ -573,3 +573,47 @@ class TestImplicitHumanInputReplyRouting:
         session._render_event(data)
         assert session._pending_reply_id == "msg-str-sender"
         assert session._pending_agent_name == "SimpleAgent"
+
+    def test_pending_not_set_when_id_is_none(self) -> None:
+        """Verify that a None id in the outer event data does not set pending state."""
+        renderer, buf = _captured_renderer()
+        session = _make_session(renderer=renderer)
+        data = {
+            "id": None,
+            "sender": {"name": "AgentX"},
+            "event": {
+                "__model__": "EventMessage",
+                "event": {
+                    "__model__": "HumanInputRequest",
+                    "prompt": "question?",
+                },
+            },
+        }
+        session._render_event(data)
+        assert session._pending_reply_id is None
+        assert session._pending_agent_name is None
+
+    def test_pending_not_set_when_id_missing(self) -> None:
+        """Verify that a missing id in the outer event data does not set pending state."""
+        renderer, buf = _captured_renderer()
+        session = _make_session(renderer=renderer)
+        data = {
+            "sender": {"name": "AgentX"},
+            "event": {
+                "__model__": "EventMessage",
+                "event": {
+                    "__model__": "HumanInputRequest",
+                    "prompt": "question?",
+                },
+            },
+        }
+        session._render_event(data)
+        assert session._pending_reply_id is None
+        assert session._pending_agent_name is None
+
+    def test_prompt_fallback_when_agent_name_is_none(self) -> None:
+        """Verify prompt uses 'Agent' fallback when _pending_agent_name is None."""
+        session = _make_session()
+        session._pending_reply_id = "some-id"
+        session._pending_agent_name = None
+        assert session._get_prompt() == "Reply to Agent: "

--- a/tests/cli/test_cli_repl.py
+++ b/tests/cli/test_cli_repl.py
@@ -12,7 +12,12 @@ from akgentic.infra.cli.client import EventInfo
 from akgentic.infra.cli.commands import build_default_registry
 from akgentic.infra.cli.formatters import OutputFormat
 from akgentic.infra.cli.renderers import RichRenderer
-from akgentic.infra.cli.repl import ChatSession, _print_event, _SlashCompleter
+from akgentic.infra.cli.repl import (
+    ChatSession,
+    _print_event,
+    _render_event_impl,
+    _SlashCompleter,
+)
 from tests.fixtures.events import (
     make_error_message,
     make_event_message,
@@ -431,3 +436,140 @@ class TestSlashCompleter:
         completer = _SlashCompleter(registry)
         completions = list(completer.get_completions(self._make_doc("/"), None))
         assert len(completions) == len(registry.commands)
+
+
+class TestImplicitHumanInputReplyRouting:
+    """Tests for story 10.2: implicit human-input reply routing."""
+
+    def _human_input_event(
+        self,
+        message_id: str = "msg-uuid-123",
+        agent_name: str = "AgentX",
+        model: str = "HumanInputRequest",
+        prompt: str = "What should I do?",
+    ) -> dict[str, Any]:
+        """Build a top-level event dict simulating a HumanInput WS event."""
+        return {
+            "id": message_id,
+            "sender": {"name": agent_name, "role": "helper"},
+            "event": {
+                "__model__": "EventMessage",
+                "event": {
+                    "__model__": model,
+                    "prompt": prompt,
+                },
+            },
+        }
+
+    # -- AC #1: pending state set on HumanInput event --
+
+    def test_pending_set_on_human_input_event(self) -> None:
+        renderer, buf = _captured_renderer()
+        session = _make_session(renderer=renderer)
+        data = self._human_input_event()
+        session._render_event(data)
+        assert session._pending_reply_id == "msg-uuid-123"
+        assert session._pending_agent_name == "AgentX"
+
+    def test_pending_set_on_request_input_event(self) -> None:
+        renderer, buf = _captured_renderer()
+        session = _make_session(renderer=renderer)
+        data = self._human_input_event(
+            model="RequestInputSomething",
+            message_id="req-456",
+            agent_name="BotY",
+        )
+        session._render_event(data)
+        assert session._pending_reply_id == "req-456"
+        assert session._pending_agent_name == "BotY"
+
+    # -- AC #2: dynamic prompt --
+
+    def test_prompt_changes_when_pending(self) -> None:
+        session = _make_session()
+        assert session._get_prompt() == "You: "
+        session._pending_reply_id = "some-id"
+        session._pending_agent_name = "AgentX"
+        assert session._get_prompt() == "Reply to AgentX: "
+
+    def test_prompt_returns_default_when_not_pending(self) -> None:
+        session = _make_session()
+        assert session._get_prompt() == "You: "
+
+    # -- AC #3, #4: plain text consumes pending reply --
+
+    async def test_plain_text_consumes_pending_reply(self) -> None:
+        renderer, buf = _captured_renderer()
+        client = _mock_client()
+        session = _make_session(client=client, renderer=renderer)
+        session._pending_reply_id = "msg-abc"
+        session._pending_agent_name = "AgentX"
+
+        with patch(_PROMPT_PATH, side_effect=["my answer", "/quit"]):
+            await session.run()
+
+        client.human_input.assert_called_once_with("t1", "my answer", "msg-abc")
+        client.send_message.assert_not_called()
+        # Pending cleared
+        assert session._pending_reply_id is None
+        assert session._pending_agent_name is None
+
+    # -- AC #5: no pending sends normal message --
+
+    async def test_no_pending_sends_normal_message(self) -> None:
+        renderer, buf = _captured_renderer()
+        client = _mock_client()
+        session = _make_session(client=client, renderer=renderer)
+
+        with patch(_PROMPT_PATH, side_effect=["hello world", "/quit"]):
+            await session.run()
+
+        client.send_message.assert_called_once_with("t1", "hello world")
+        client.human_input.assert_not_called()
+
+    # -- AC #6: slash commands do not consume pending --
+
+    async def test_slash_command_does_not_consume_pending(self) -> None:
+        renderer, buf = _captured_renderer()
+        client = _mock_client()
+        session = _make_session(client=client, renderer=renderer)
+        session._pending_reply_id = "msg-pending"
+        session._pending_agent_name = "AgentZ"
+
+        with patch(_PROMPT_PATH, side_effect=["/help", "/quit"]):
+            await session.run()
+
+        # Pending should still be set after slash command
+        assert session._pending_reply_id == "msg-pending"
+        assert session._pending_agent_name == "AgentZ"
+        client.human_input.assert_not_called()
+
+    # -- backward compat: _render_event_impl without callback --
+
+    def test_render_event_impl_without_callback(self) -> None:
+        renderer, buf = _captured_renderer()
+        data = self._human_input_event()
+        result = _render_event_impl(data, renderer, on_human_input=None)
+        assert result is True
+        out = buf.getvalue()
+        assert "Human Input Required" in out
+
+    # -- sender as string fallback --
+
+    def test_pending_set_with_string_sender(self) -> None:
+        renderer, buf = _captured_renderer()
+        session = _make_session(renderer=renderer)
+        data = {
+            "id": "msg-str-sender",
+            "sender": "SimpleAgent",
+            "event": {
+                "__model__": "EventMessage",
+                "event": {
+                    "__model__": "HumanInputRequest",
+                    "prompt": "question?",
+                },
+            },
+        }
+        session._render_event(data)
+        assert session._pending_reply_id == "msg-str-sender"
+        assert session._pending_agent_name == "SimpleAgent"


### PR DESCRIPTION
## Summary
- Implements implicit human input reply routing for the REPL
- Re-opened: PR #118 was auto-closed when its stacked base branch was merged

Relates to #117

## Original PR
Previously #118 (auto-closed by GitHub due to stacked branch merge)