### PR TITLE
refactor: separate event store and catalog paths from workspace root

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,7 +9,8 @@
 
 # --- Community Settings ---
 # AKGENTIC_WORKSPACES_ROOT=workspaces
-# AKGENTIC_CATALOG_PATH=
+# AKGENTIC_EVENT_STORE_PATH=data/event_store
+# AKGENTIC_CATALOG_PATH=data/catalog
 # AKGENTIC_CHANNEL_REGISTRY_PATH=          # Path to channel registry YAML; disabled when unset
 
 # --- LLM Provider Keys (at least one required for agents to function) ---

--- a/README.md
+++ b/README.md
@@ -376,8 +376,9 @@ All settings are loaded from environment variables prefixed with `AKGENTIC_`.
 
 | Variable                       | Default        | Description                        |
 |--------------------------------|----------------|------------------------------------|
-| `AKGENTIC_WORKSPACES_ROOT`     | `workspaces`   | Root directory for team storage    |
-| `AKGENTIC_CATALOG_PATH`        | `None`         | Catalog directory (auto-derived)   |
+| `AKGENTIC_WORKSPACES_ROOT`     | `workspaces`   | Root directory for team workspace storage |
+| `AKGENTIC_EVENT_STORE_PATH`    | `data/event_store` | Root directory for event store persistence |
+| `AKGENTIC_CATALOG_PATH`        | `data/catalog` | Catalog directory for team/agent/tool/template definitions |
 | `AKGENTIC_CHANNEL_REGISTRY_PATH` | `None`      | Path to channel registry YAML; disabled when unset |
 
 ## Installation

--- a/src/akgentic/infra/server/settings.py
+++ b/src/akgentic/infra/server/settings.py
@@ -70,9 +70,13 @@ class CommunitySettings(ServerSettings):
         default=Path("workspaces"),
         description="Root directory for team workspace storage",
     )
-    catalog_path: Path | None = Field(
-        default=None,
-        description="Catalog directory; defaults to workspaces_root / 'catalog'",
+    event_store_path: Path = Field(
+        default=Path("data/event_store"),
+        description="Root directory for event store persistence",
+    )
+    catalog_path: Path = Field(
+        default=Path("data/catalog"),
+        description="Catalog directory for team/agent/tool/template definitions",
     )
     channel_registry_path: Path | None = Field(
         default=None,

--- a/src/akgentic/infra/wiring.py
+++ b/src/akgentic/infra/wiring.py
@@ -48,7 +48,7 @@ def wire_community(settings: CommunitySettings) -> CommunityServices:
         Fully wired CommunityServices container
     """
     logger.info("Wiring community services")
-    event_store = YamlEventStore(data_dir=settings.workspaces_root)
+    event_store = YamlEventStore(data_dir=settings.event_store_path)
     service_registry = NullServiceRegistry()
     actor_system, team_manager = _build_actor_layer(event_store, service_registry)
     catalogs = _build_catalogs(settings)
@@ -109,7 +109,7 @@ def _build_catalogs(
     settings: CommunitySettings,
 ) -> tuple[TeamCatalog, AgentCatalog, ToolCatalog, TemplateCatalog]:
     """Build YAML-backed catalog services."""
-    catalog_root = settings.catalog_path or settings.workspaces_root / "catalog"
+    catalog_root = settings.catalog_path
     logger.debug("Building catalogs from %s", catalog_root)
     template_catalog = TemplateCatalog(
         repository=YamlTemplateCatalogRepository(catalog_dir=catalog_root / "templates"),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -94,14 +94,22 @@ def _ensure_openai_key(monkeypatch: pytest.MonkeyPatch) -> None:
 @pytest.fixture()
 def server_settings(tmp_path: Path) -> CommunitySettings:
     """Server settings with tmp_path-based workspaces."""
-    return CommunitySettings(workspaces_root=tmp_path / "workspaces")
+    return CommunitySettings(
+        workspaces_root=tmp_path / "workspaces",
+        event_store_path=tmp_path / "event_store",
+        catalog_path=tmp_path / "catalog",
+    )
 
 
 @pytest.fixture()
 def seeded_settings(tmp_path: Path) -> CommunitySettings:
     """Server settings with pre-seeded catalog YAML files."""
-    settings = CommunitySettings(workspaces_root=tmp_path / "workspaces")
-    _seed_catalog(settings.workspaces_root / "catalog")
+    settings = CommunitySettings(
+        workspaces_root=tmp_path / "workspaces",
+        event_store_path=tmp_path / "event_store",
+        catalog_path=tmp_path / "catalog",
+    )
+    _seed_catalog(settings.catalog_path)
     return settings
 
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -104,8 +104,12 @@ def integration_settings(tmp_path: Path, openai_api_key: str) -> CommunitySettin
 
     Depends on ``openai_api_key`` so LLM-dependent tests are skipped when absent.
     """
-    settings = CommunitySettings(workspaces_root=tmp_path / "workspaces")
-    seed_integration_catalog(settings.workspaces_root / "catalog")
+    settings = CommunitySettings(
+        workspaces_root=tmp_path / "workspaces",
+        event_store_path=tmp_path / "event_store",
+        catalog_path=tmp_path / "catalog",
+    )
+    seed_integration_catalog(settings.catalog_path)
     return settings
 
 
@@ -155,9 +159,11 @@ def v1_adapter_settings(tmp_path: Path) -> CommunitySettings:
     """CommunitySettings with V1 frontend adapter enabled."""
     settings = CommunitySettings(
         workspaces_root=tmp_path / "workspaces",
+        event_store_path=tmp_path / "event_store",
+        catalog_path=tmp_path / "catalog",
         frontend_adapter=V1_ADAPTER_FQDN,
     )
-    seed_integration_catalog(settings.workspaces_root / "catalog")
+    seed_integration_catalog(settings.catalog_path)
     return settings
 
 
@@ -260,10 +266,11 @@ def smoke_settings(tmp_path: Path) -> CommunitySettings:
     Explicitly sets ``catalog_path`` so the env var ``AKGENTIC_CATALOG_PATH``
     (loaded from .env) does not override the seeded test catalog.
     """
-    catalog_dir = tmp_path / "workspaces" / "catalog"
+    catalog_dir = tmp_path / "catalog"
     seed_integration_catalog(catalog_dir)
     return CommunitySettings(
         workspaces_root=tmp_path / "workspaces",
+        event_store_path=tmp_path / "event_store",
         catalog_path=catalog_dir,
     )
 

--- a/tests/integration/test_adr003_tier_agnostic.py
+++ b/tests/integration/test_adr003_tier_agnostic.py
@@ -72,8 +72,12 @@ class TestTierAgnosticFixturePattern:
         """AC #2: Full inline pattern in one test."""
         from ._helpers import seed_integration_catalog
 
-        settings = CommunitySettings(workspaces_root=tmp_path / "workspaces")
-        seed_integration_catalog(settings.workspaces_root / "catalog")
+        settings = CommunitySettings(
+            workspaces_root=tmp_path / "workspaces",
+            event_store_path=tmp_path / "event_store",
+            catalog_path=tmp_path / "catalog",
+        )
+        seed_integration_catalog(settings.catalog_path)
         services = wire_community(settings)
         try:
             app = create_app(services, settings)

--- a/tests/integration/test_spec_compliance.py
+++ b/tests/integration/test_spec_compliance.py
@@ -42,8 +42,12 @@ class TestAppFactory:
         """AC #1: Demonstrate the fixture pattern works end-to-end."""
         from tests.integration.conftest import _seed_integration_catalog
 
-        settings = CommunitySettings(workspaces_root=tmp_path / "workspaces")
-        _seed_integration_catalog(settings.workspaces_root / "catalog")
+        settings = CommunitySettings(
+            workspaces_root=tmp_path / "workspaces",
+            event_store_path=tmp_path / "event_store",
+            catalog_path=tmp_path / "catalog",
+        )
+        _seed_integration_catalog(settings.catalog_path)
         services = wire_community(settings)
         try:
             app = create_app(services, settings)

--- a/tests/server/models/test_server_settings.py
+++ b/tests/server/models/test_server_settings.py
@@ -143,6 +143,7 @@ class TestSettingsHierarchy:
             ServerSettings.model_fields.keys()
         )
         assert "workspaces_root" in community_own_fields
+        assert "event_store_path" in community_own_fields
         assert "catalog_path" in community_own_fields
 
     def test_community_settings_no_literal_fields(self) -> None:
@@ -164,9 +165,13 @@ class TestSettingsHierarchy:
         from akgentic.infra.server.app import create_app
         from akgentic.infra.wiring import wire_community
 
-        settings = CommunitySettings(workspaces_root=tmp_path / "workspaces")
+        settings = CommunitySettings(
+            workspaces_root=tmp_path / "workspaces",
+            event_store_path=tmp_path / "event_store",
+            catalog_path=tmp_path / "catalog",
+        )
         # Seed a minimal catalog
-        _seed_minimal_catalog(settings.workspaces_root / "catalog")
+        _seed_minimal_catalog(settings.catalog_path)
         services = wire_community(settings)
         try:
             from fastapi.testclient import TestClient
@@ -249,10 +254,15 @@ class TestCommunitySettingsDefaults:
         settings = CommunitySettings()
         assert settings.workspaces_root == Path("workspaces")
 
-    def test_default_catalog_path(self) -> None:
-        """Default catalog_path is None."""
+    def test_default_event_store_path(self) -> None:
+        """Default event_store_path is Path('data/event_store')."""
         settings = CommunitySettings()
-        assert settings.catalog_path is None
+        assert settings.event_store_path == Path("data/event_store")
+
+    def test_default_catalog_path(self) -> None:
+        """Default catalog_path is Path('data/catalog')."""
+        settings = CommunitySettings()
+        assert settings.catalog_path == Path("data/catalog")
 
     def test_inherits_base_fields(self) -> None:
         """CommunitySettings inherits host, port, cors_origins from ServerSettings."""
@@ -260,6 +270,24 @@ class TestCommunitySettingsDefaults:
         assert settings.host == "0.0.0.0"
         assert settings.port == 8000
         assert settings.cors_origins == ["*"]
+
+    def test_event_store_path_from_env(self) -> None:
+        """AKGENTIC_EVENT_STORE_PATH overrides event_store_path field."""
+        os.environ["AKGENTIC_EVENT_STORE_PATH"] = "/tmp/events"
+        try:
+            settings = CommunitySettings()
+            assert settings.event_store_path == Path("/tmp/events")
+        finally:
+            del os.environ["AKGENTIC_EVENT_STORE_PATH"]
+
+    def test_catalog_path_from_env(self) -> None:
+        """AKGENTIC_CATALOG_PATH overrides catalog_path field."""
+        os.environ["AKGENTIC_CATALOG_PATH"] = "/tmp/catalog"
+        try:
+            settings = CommunitySettings()
+            assert settings.catalog_path == Path("/tmp/catalog")
+        finally:
+            del os.environ["AKGENTIC_CATALOG_PATH"]
 
     def test_workspaces_root_from_env(self) -> None:
         """AKGENTIC_WORKSPACES_ROOT overrides workspaces_root field."""

--- a/tests/test_wiring.py
+++ b/tests/test_wiring.py
@@ -30,7 +30,11 @@ class TestWireCommunityLogging:
         caplog: pytest.LogCaptureFixture,
     ) -> None:
         """wire_community() emits 'Wiring community services' INFO log."""
-        settings = CommunitySettings(workspaces_root=tmp_path)
+        settings = CommunitySettings(
+            workspaces_root=tmp_path / "workspaces",
+            event_store_path=tmp_path / "event_store",
+            catalog_path=tmp_path / "catalog",
+        )
         with caplog.at_level(logging.INFO, logger="akgentic.infra.wiring"):
             services = wire_community(settings)
         try:
@@ -45,7 +49,11 @@ class TestWireCommunity:
     @pytest.fixture()
     def services(self, tmp_path: Path) -> Generator[CommunityServices, None, None]:
         """Wire community services with a temp workspace root and cleanup ActorSystem."""
-        settings = CommunitySettings(workspaces_root=tmp_path)
+        settings = CommunitySettings(
+            workspaces_root=tmp_path / "workspaces",
+            event_store_path=tmp_path / "event_store",
+            catalog_path=tmp_path / "catalog",
+        )
         svc = wire_community(settings)
         yield svc
         svc.team_manager._actor_system.shutdown(timeout=5)
@@ -78,12 +86,17 @@ class TestWireCommunity:
         """TeamManager is present and correctly typed."""
         assert isinstance(services.team_manager, TeamManager)
 
-    def test_uses_settings_workspaces_root(self, tmp_path: Path) -> None:
-        """wire_community passes settings.workspaces_root to YamlEventStore."""
-        settings = CommunitySettings(workspaces_root=tmp_path)
+    def test_uses_settings_event_store_path(self, tmp_path: Path) -> None:
+        """wire_community passes settings.event_store_path to YamlEventStore."""
+        settings = CommunitySettings(
+            workspaces_root=tmp_path / "workspaces",
+            event_store_path=tmp_path / "event_store",
+            catalog_path=tmp_path / "catalog",
+        )
         services = wire_community(settings)
         try:
             assert isinstance(services.event_store, YamlEventStore)
+            assert services.event_store._data_dir == settings.event_store_path
         finally:
             services.team_manager._actor_system.shutdown(timeout=5)
 
@@ -105,7 +118,8 @@ class TestWireCommunity:
         for sub in ("teams", "agents", "tools", "templates"):
             (custom_catalog / sub).mkdir()
         settings = CommunitySettings(
-            workspaces_root=tmp_path,
+            workspaces_root=tmp_path / "workspaces",
+            event_store_path=tmp_path / "event_store",
             catalog_path=custom_catalog,
         )
         services = wire_community(settings)
@@ -125,7 +139,9 @@ class TestWireCommunity:
         """When channel_registry_path is set, uses YamlChannelRegistry."""
         reg_path = tmp_path / "registry.yaml"
         settings = CommunitySettings(
-            workspaces_root=tmp_path,
+            workspaces_root=tmp_path / "workspaces",
+            event_store_path=tmp_path / "event_store",
+            catalog_path=tmp_path / "catalog",
             channel_registry_path=reg_path,
         )
         services = wire_community(settings)


### PR DESCRIPTION
## Summary
- Add `event_store_path` field to `CommunitySettings` (default: `data/event_store`)
- Change `catalog_path` from `Path | None` to `Path` with standalone default (`data/catalog`)
- Wire `YamlEventStore` to `event_store_path` instead of `workspaces_root`
- Remove catalog fallback to `workspaces_root / "catalog"`

Relates to #128

## Test plan
- [x] All existing tests pass (725 passed)
- [x] New tests cover `event_store_path` default, env override, and wiring verification
- [x] New test for `catalog_path` env override
- [x] Lint (`ruff check`) and type checks (`mypy`) pass