### PR TITLE
Epic 11: REPL Resilience and UX Quality (stories 11-2, 11-3, 11-4)

### DIFF
--- a/src/akgentic/infra/cli/commands.py
+++ b/src/akgentic/infra/cli/commands.py
@@ -418,6 +418,16 @@ async def _switch_handler(args: str, session: ChatSession) -> None:
     session._receive_task = asyncio.create_task(session._receive_loop())
 
 
+async def _reconnect_handler(args: str, session: ChatSession) -> None:
+    """Manually trigger reconnection."""
+    session.renderer.render_connection_status("reconnecting")
+    try:
+        await session.conn.connect()
+        session.renderer.render_connection_status("connected")
+    except WsConnectionError as exc:
+        session.renderer.render_error(f"Reconnection failed: {exc.reason}")
+
+
 async def _catalog_handler(args: str, session: ChatSession) -> None:
     """List available team templates from the catalog."""
     loop = asyncio.get_running_loop()
@@ -458,4 +468,5 @@ def build_default_registry() -> CommandRegistry:
         "restore", _restore_handler, "Restore a stopped team", "/restore [team_id]"
     )
     registry.register("switch", _switch_handler, "Switch to another team", "/switch <team_id>")
+    registry.register("reconnect", _reconnect_handler, "Reconnect to server", "/reconnect")
     return registry

--- a/src/akgentic/infra/cli/commands.py
+++ b/src/akgentic/infra/cli/commands.py
@@ -11,7 +11,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from akgentic.infra.cli.client import ApiError
-from akgentic.infra.cli.ws_client import WsClient, WsConnectionError
+from akgentic.infra.cli.ws_client import WsConnectionError
 
 if TYPE_CHECKING:
     from akgentic.infra.cli.repl import ChatSession
@@ -394,39 +394,13 @@ async def _switch_handler(args: str, session: ChatSession) -> None:
         print("Usage: /switch <team_id>")
         return
 
-    old_team_id = session.team_id
-    old_ws = session.ws_client
-
-    # Close current WebSocket
-    await old_ws.close()
-
-    # Create new WsClient using stored server_url and api_key
-    new_ws = WsClient(
-        base_url=session.server_url,
-        team_id=new_team_id,
-        api_key=session.api_key,
-    )
-
     try:
-        await new_ws.connect()
-    except (ApiError, WsConnectionError, Exception):  # noqa: BLE001
-        session.renderer.render_error(f"Team {new_team_id} not found.")
-        # Restore previous connection
-        restored = WsClient(
-            base_url=session.server_url,
-            team_id=old_team_id,
-            api_key=session.api_key,
-        )
-        try:
-            await restored.connect()
-            session.ws_client = restored
-        except Exception:  # noqa: BLE001
-            session.renderer.render_error("Failed to restore previous connection.")
+        await session.conn.switch_team(new_team_id)
+    except WsConnectionError as exc:
+        session.renderer.render_error(f"Switch failed: {exc.reason}")
         return
 
-    # Update session state
     session.team_id = new_team_id
-    session.ws_client = new_ws
 
     # Cancel old receive loop before replaying history
     if session._receive_task is not None:

--- a/src/akgentic/infra/cli/connection.py
+++ b/src/akgentic/infra/cli/connection.py
@@ -1,0 +1,162 @@
+"""Connection manager with auto-reconnect for WebSocket event streaming."""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from enum import Enum
+from typing import Any
+
+from akgentic.infra.cli.ws_client import WsClient, WsConnectionError
+
+# Callback type for state change notifications
+type StateChangeCallback = Any  # Callable[[ConnectionState], None] | None
+
+
+class ConnectionState(Enum):
+    """WebSocket connection lifecycle states."""
+
+    CONNECTING = "connecting"
+    CONNECTED = "connected"
+    RECONNECTING = "reconnecting"
+    DISCONNECTED = "disconnected"
+
+
+class ConnectionManager:
+    """Manages WebSocket lifecycle with auto-reconnect and atomic team switching.
+
+    Composes WsClient instances internally. Provides exponential backoff
+    reconnection on unexpected disconnects.
+    """
+
+    def __init__(
+        self,
+        server_url: str,
+        team_id: str,
+        api_key: str | None = None,
+        on_state_change: StateChangeCallback = None,
+        max_retries: int = 10,
+    ) -> None:
+        self._server_url = server_url
+        self._team_id = team_id
+        self._api_key = api_key
+        self._on_state_change = on_state_change
+        self._max_retries = max_retries
+        self._ws_client: WsClient | None = None
+        self._state: ConnectionState = ConnectionState.DISCONNECTED
+        self._last_event_time: float = 0.0
+
+    @property
+    def state(self) -> ConnectionState:
+        """Current connection state."""
+        return self._state
+
+    @property
+    def team_id(self) -> str:
+        """Currently connected team ID."""
+        return self._team_id
+
+    def _set_state(self, new_state: ConnectionState) -> None:
+        """Update state and fire callback if set."""
+        self._state = new_state
+        if self._on_state_change is not None:
+            self._on_state_change(new_state)
+
+    async def connect(self) -> None:
+        """Single connection attempt. Raises WsConnectionError on failure."""
+        self._set_state(ConnectionState.CONNECTING)
+        ws = WsClient(
+            base_url=self._server_url,
+            team_id=self._team_id,
+            api_key=self._api_key,
+        )
+        try:
+            await ws.connect()
+        except WsConnectionError:
+            self._set_state(ConnectionState.DISCONNECTED)
+            raise
+        self._ws_client = ws
+        self._set_state(ConnectionState.CONNECTED)
+        self._last_event_time = time.monotonic()
+
+    async def _reconnect(self) -> None:
+        """Reconnect with exponential backoff. Raises WsConnectionError after max_retries."""
+        self._set_state(ConnectionState.RECONNECTING)
+        for attempt in range(self._max_retries):
+            delay = min(2**attempt, 30)
+            try:
+                await self.connect()
+                return  # Success — state is now CONNECTED
+            except WsConnectionError:
+                await asyncio.sleep(delay)
+        self._set_state(ConnectionState.DISCONNECTED)
+        raise WsConnectionError(
+            f"Reconnection failed after {self._max_retries} attempts",
+            retryable=False,
+        )
+
+    async def receive_event(self) -> dict[str, Any]:
+        """Read next event. Triggers reconnect on disconnect.
+
+        Raises WsConnectionError only after max_retries exhausted.
+        """
+        if self._ws_client is None:
+            raise WsConnectionError("Not connected", retryable=False)
+        try:
+            event = await self._ws_client.receive_event()
+            self._last_event_time = time.monotonic()
+            return event
+        except Exception:  # noqa: BLE001
+            # Any receive failure triggers reconnect
+            await self._reconnect()
+            return await self.receive_event()
+
+    async def close(self) -> None:
+        """Graceful shutdown."""
+        if self._ws_client is not None:
+            await self._ws_client.close()
+            self._ws_client = None
+        self._set_state(ConnectionState.DISCONNECTED)
+
+    async def switch_team(self, new_team_id: str) -> None:
+        """Atomic team switch: connect new WebSocket before closing old.
+
+        On failure, old connection remains untouched.
+        """
+        new_ws = WsClient(
+            base_url=self._server_url,
+            team_id=new_team_id,
+            api_key=self._api_key,
+        )
+        try:
+            await new_ws.connect()
+        except WsConnectionError:
+            raise  # Old connection untouched
+        old_ws = self._ws_client
+        self._ws_client = new_ws
+        self._team_id = new_team_id
+        self._last_event_time = time.monotonic()
+        if old_ws is not None:
+            await old_ws.close()
+
+    async def check_health(self) -> None:
+        """Ping if no event received for 60s. Trigger reconnect on failure."""
+        if (
+            self._state == ConnectionState.CONNECTED
+            and time.monotonic() - self._last_event_time > 60.0
+            and self._ws_client is not None
+            and self._ws_client._ws is not None  # noqa: SLF001
+        ):
+            try:
+                await self._ws_client._ws.ping()  # noqa: SLF001
+            except Exception:  # noqa: BLE001
+                await self._reconnect()
+
+    async def __aenter__(self) -> ConnectionManager:
+        """Connect on context manager entry."""
+        await self.connect()
+        return self
+
+    async def __aexit__(self, *_args: object) -> None:
+        """Close on context manager exit."""
+        await self.close()

--- a/src/akgentic/infra/cli/connection.py
+++ b/src/akgentic/infra/cli/connection.py
@@ -4,13 +4,13 @@ from __future__ import annotations
 
 import asyncio
 import time
+from collections.abc import Callable
 from enum import Enum
 from typing import Any
 
-from akgentic.infra.cli.ws_client import WsClient, WsConnectionError
+import websockets.exceptions
 
-# Callback type for state change notifications
-type StateChangeCallback = Any  # Callable[[ConnectionState], None] | None
+from akgentic.infra.cli.ws_client import WsClient, WsConnectionError
 
 
 class ConnectionState(Enum):
@@ -34,7 +34,7 @@ class ConnectionManager:
         server_url: str,
         team_id: str,
         api_key: str | None = None,
-        on_state_change: StateChangeCallback = None,
+        on_state_change: Callable[[ConnectionState], None] | None = None,
         max_retries: int = 10,
     ) -> None:
         self._server_url = server_url
@@ -100,16 +100,15 @@ class ConnectionManager:
 
         Raises WsConnectionError only after max_retries exhausted.
         """
-        if self._ws_client is None:
-            raise WsConnectionError("Not connected", retryable=False)
-        try:
-            event = await self._ws_client.receive_event()
-            self._last_event_time = time.monotonic()
-            return event
-        except Exception:  # noqa: BLE001
-            # Any receive failure triggers reconnect
-            await self._reconnect()
-            return await self.receive_event()
+        while True:
+            if self._ws_client is None:
+                raise WsConnectionError("Not connected", retryable=False)
+            try:
+                event = await self._ws_client.receive_event()
+                self._last_event_time = time.monotonic()
+                return event
+            except websockets.exceptions.ConnectionClosed:
+                await self._reconnect()
 
     async def close(self) -> None:
         """Graceful shutdown."""
@@ -145,10 +144,9 @@ class ConnectionManager:
             self._state == ConnectionState.CONNECTED
             and time.monotonic() - self._last_event_time > 60.0
             and self._ws_client is not None
-            and self._ws_client._ws is not None  # noqa: SLF001
         ):
             try:
-                await self._ws_client._ws.ping()  # noqa: SLF001
+                await self._ws_client.ping()
             except Exception:  # noqa: BLE001
                 await self._reconnect()
 

--- a/src/akgentic/infra/cli/event_router.py
+++ b/src/akgentic/infra/cli/event_router.py
@@ -1,0 +1,135 @@
+"""Event routing and dispatch for chat events."""
+
+from __future__ import annotations
+
+import json
+import logging
+from collections.abc import Callable
+from typing import Any
+
+from akgentic.infra.cli.renderers import RichRenderer
+
+# Event types to display vs skip
+_DISPLAY_EVENTS = {"SentMessage", "ErrorMessage", "EventMessage"}
+
+
+class EventRouter:
+    """Parse raw event dicts and dispatch to the renderer."""
+
+    def __init__(
+        self,
+        renderer: RichRenderer,
+        on_human_input: Callable[[str, str], None] | None = None,
+        logger: logging.Logger | None = None,
+    ) -> None:
+        self._renderer = renderer
+        self._on_human_input = on_human_input
+        self._log = logger or logging.getLogger(__name__)
+
+    def route(self, data: dict[str, Any]) -> bool:
+        """Parse, classify, and render an event. Returns True if rendered.
+
+        Malformed events are logged at DEBUG and skipped -- never raised.
+        """
+        try:
+            return self._route_inner(data)
+        except (KeyError, json.JSONDecodeError, TypeError) as exc:
+            self._log.debug("Malformed event skipped: %s", exc)
+            return False
+
+    def _route_inner(self, data: dict[str, Any]) -> bool:
+        """Core dispatch logic -- classify by __model__ suffix and delegate."""
+        event = data.get("event", data)
+        if isinstance(event, str):
+            event = json.loads(event)
+
+        model = event.get("__model__", "")
+        short_model = model.rsplit(".", 1)[-1] if model else ""
+        if short_model not in _DISPLAY_EVENTS:
+            return False
+
+        if short_model == "ErrorMessage":
+            return self._handle_error_message(event)
+
+        if short_model == "EventMessage":
+            return self._handle_event_message(event, data)
+
+        # SentMessage
+        return self._handle_sent_message(event)
+
+    def _handle_error_message(self, event: dict[str, Any]) -> bool:
+        """Render an ErrorMessage event."""
+        content = event.get("exception_value", event.get("content", event.get("error", "")))
+        self._renderer.render_error(str(content))
+        return True
+
+    def _handle_sent_message(self, event: dict[str, Any]) -> bool:
+        """Render a SentMessage -- agent response with sender and content."""
+        raw_sender = event.get("sender", "agent")
+        sender = (
+            raw_sender.get("name", "agent") if isinstance(raw_sender, dict) else str(raw_sender)
+        )
+        message = event.get("message", {})
+        content = message.get("content", "") if isinstance(message, dict) else ""
+        if content:
+            self._renderer.render_agent_message(sender, str(content))
+            return True
+        return False
+
+    def _handle_event_message(self, event: dict[str, Any], outer_data: dict[str, Any]) -> bool:
+        """Handle EventMessage -- inspect nested event for tool calls / human input."""
+        nested = event.get("event", {})
+        if isinstance(nested, str):
+            try:
+                nested = json.loads(nested)
+            except (json.JSONDecodeError, TypeError):
+                return False
+
+        if not isinstance(nested, dict):
+            return False
+
+        nested_model = nested.get("__model__", "")
+
+        if "tool_name" in nested:
+            self._handle_tool_call(nested)
+            return True
+
+        if "HumanInput" in nested_model or "RequestInput" in nested_model:
+            prompt_text = str(nested.get("prompt", nested.get("content", "Input requested")))
+            self._renderer.render_human_input_request(prompt_text)
+            if self._on_human_input is not None:
+                self._notify_human_input(outer_data)
+            return True
+
+        return False
+
+    def _handle_tool_call(self, nested: dict[str, Any]) -> None:
+        """Extract and render a tool call event."""
+        tool_name = str(nested["tool_name"])
+        raw_input = nested.get("arguments", nested.get("args", nested.get("input", "")))
+        if isinstance(raw_input, dict | list):
+            tool_input = json.dumps(raw_input, indent=2)
+        else:
+            tool_input = str(raw_input)
+        raw_output = nested.get("result")
+        if raw_output is None:
+            tool_output = None
+        elif isinstance(raw_output, dict | list):
+            tool_output = json.dumps(raw_output, indent=2)
+        else:
+            tool_output = str(raw_output)
+        self._renderer.render_tool_call(tool_name, tool_input, tool_output)
+
+    def _notify_human_input(self, outer_data: dict[str, Any]) -> None:
+        """Extract message_id and agent_name from outer event data and invoke callback."""
+        raw_id = outer_data.get("id")
+        if not raw_id:
+            return
+        message_id = str(raw_id)
+        raw_sender = outer_data.get("sender", "Agent")
+        if isinstance(raw_sender, dict):
+            agent_name = str(raw_sender.get("name", "Agent"))
+        else:
+            agent_name = str(raw_sender)
+        if self._on_human_input is not None:
+            self._on_human_input(message_id, agent_name)

--- a/src/akgentic/infra/cli/main.py
+++ b/src/akgentic/infra/cli/main.py
@@ -11,10 +11,11 @@ import typer
 from pydantic import BaseModel
 
 from akgentic.infra.cli.client import ApiClient, ApiError
+from akgentic.infra.cli.connection import ConnectionManager
 from akgentic.infra.cli.formatters import OutputFormat, format_output
 from akgentic.infra.cli.renderers import RichRenderer
 from akgentic.infra.cli.repl import ChatSession, TeamSelector
-from akgentic.infra.cli.ws_client import WsClient, WsConnectionError
+from akgentic.infra.cli.ws_client import WsConnectionError
 
 app = typer.Typer(name="ak-infra", help="Akgentic Infrastructure CLI")
 team_app = typer.Typer(name="team", help="Manage agent teams")
@@ -176,14 +177,14 @@ def chat(
         if team_id is None:
             raise typer.Exit(code=0)
 
-    ws = WsClient(
-        base_url=_state.server,
+    conn = ConnectionManager(
+        server_url=_state.server,
         team_id=team_id,
         api_key=_state.api_key,
     )
     session = ChatSession(
         _state.client,
-        ws,
+        conn,
         team_id,
         _state.fmt,
         server_url=_state.server,

--- a/src/akgentic/infra/cli/main.py
+++ b/src/akgentic/infra/cli/main.py
@@ -14,7 +14,8 @@ from akgentic.infra.cli.client import ApiClient, ApiError
 from akgentic.infra.cli.connection import ConnectionManager
 from akgentic.infra.cli.formatters import OutputFormat, format_output
 from akgentic.infra.cli.renderers import RichRenderer
-from akgentic.infra.cli.repl import ChatSession, TeamSelector
+from akgentic.infra.cli.repl import ChatSession
+from akgentic.infra.cli.team_selector import TeamSelector
 from akgentic.infra.cli.ws_client import WsConnectionError
 
 app = typer.Typer(name="ak-infra", help="Akgentic Infrastructure CLI")

--- a/src/akgentic/infra/cli/renderers.py
+++ b/src/akgentic/infra/cli/renderers.py
@@ -155,6 +155,16 @@ class RichRenderer:
             parts.append("[s] stopped teams")
         self._console.print(f"  [dim]{'  '.join(parts)}[/dim]")
 
+    def render_connection_status(self, status: str) -> None:
+        """Render connection state changes with appropriate styling."""
+        styles = {
+            "connected": ("green", "Connected"),
+            "reconnecting": ("yellow", "Reconnecting..."),
+            "disconnected": ("red", "Disconnected"),
+        }
+        color, label = styles.get(status, ("dim", status))
+        self._console.print(f"[{color}]{label}[/{color}]")
+
     def render_pagination_hints(self, has_next: bool) -> None:
         """Render pagination hints for stopped teams list."""
         parts = ["[number] restore & connect"]

--- a/src/akgentic/infra/cli/repl.py
+++ b/src/akgentic/infra/cli/repl.py
@@ -5,21 +5,50 @@ from __future__ import annotations
 import asyncio
 import json
 from collections.abc import Callable
+from enum import Enum
 from typing import Any
 
 from prompt_toolkit import PromptSession
 from prompt_toolkit.completion import Completer, Completion
 from prompt_toolkit.history import InMemoryHistory
+from pydantic import BaseModel
 
 from akgentic.infra.cli.client import ApiClient, ApiError, TeamInfo
 from akgentic.infra.cli.commands import CommandRegistry, build_default_registry
-from akgentic.infra.cli.connection import ConnectionManager
+from akgentic.infra.cli.connection import ConnectionManager, ConnectionState
 from akgentic.infra.cli.formatters import OutputFormat
 from akgentic.infra.cli.renderers import RichRenderer
 from akgentic.infra.cli.ws_client import WsConnectionError
 
 # Event types to display vs skip
 _DISPLAY_EVENTS = {"SentMessage", "ErrorMessage", "EventMessage"}
+
+
+class InputMode(Enum):
+    """Input mode for the REPL session."""
+
+    CHAT = "chat"
+    REPLY = "reply"
+
+
+class ReplyContext(BaseModel):
+    """Context for an in-progress reply to an agent."""
+
+    reply_id: str
+    agent_name: str
+    prompt: str
+
+
+class SessionState(BaseModel):
+    """Structured session state for the chat REPL."""
+
+    team_id: str
+    team_name: str = "(unknown)"
+    team_status: str = "?"
+    input_mode: InputMode = InputMode.CHAT
+    reply_context: ReplyContext | None = None
+    connection_state: ConnectionState = ConnectionState.CONNECTING
+
 
 _STOPPED_PAGE_SIZE = 5
 
@@ -186,32 +215,45 @@ class ChatSession:
     ) -> None:
         self.client = client
         self.conn = conn
-        self.team_id = team_id
+        self._state = SessionState(team_id=team_id)
         self.fmt = fmt
         self.server_url = server_url
         self.api_key = api_key
         self.renderer = renderer or RichRenderer()
         self.command_registry: CommandRegistry = build_default_registry()
         self._running = True
-        self._pending_reply_id: str | None = None
-        self._pending_agent_name: str | None = None
         self._receive_task: asyncio.Task[None] | None = None
-        self._team_name: str = ""
-        self._team_status: str = ""
+        self._message_buffer: list[str] = []
         self._prompt_session: PromptSession[str] = PromptSession(
             history=InMemoryHistory(),
             completer=_SlashCompleter(self.command_registry),
         )
 
+        def _on_conn_state_change(new_state: ConnectionState) -> None:
+            self._state = self._state.model_copy(update={"connection_state": new_state})
+            if new_state == ConnectionState.CONNECTED and self._message_buffer:
+                self._flush_message_buffer()
+
+        self.conn._on_state_change = _on_conn_state_change
+
+    @property
+    def team_id(self) -> str:
+        """Team ID from session state."""
+        return self._state.team_id
+
+    @team_id.setter
+    def team_id(self, value: str) -> None:
+        self._state = self._state.model_copy(update={"team_id": value})
+
     def _fetch_team_info(self) -> None:
         """Fetch and cache team name and status for the status bar."""
         try:
-            team = self.client.get_team(self.team_id)
-            self._team_name = team.name
-            self._team_status = team.status
+            team = self.client.get_team(self._state.team_id)
+            self._state = self._state.model_copy(
+                update={"team_name": team.name, "team_status": team.status}
+            )
         except ApiError:
-            self._team_name = "(unknown)"
-            self._team_status = "?"
+            pass  # Keep defaults "(unknown)" and "?"
 
     async def run(self) -> None:
         """Main REPL loop: connect WS, replay history, read input, stream events."""
@@ -236,17 +278,60 @@ class ChatSession:
                 self.renderer.render_border()
                 self.renderer.render_system_message("Session closed.")
 
+    def _get_prompt(self) -> str:
+        """Build dynamic prompt based on connection state and input mode."""
+        if self._state.connection_state == ConnectionState.DISCONNECTED:
+            return "[disconnected] > "
+        if self._state.connection_state == ConnectionState.RECONNECTING:
+            return "[reconnecting...] > "
+        if self._state.input_mode == InputMode.REPLY and self._state.reply_context:
+            return f"Reply to {self._state.reply_context.agent_name}: "
+        return "> "
+
     def _read_input(self) -> str:
         """Render bottom border, prompt for input, then status bar below."""
         self.renderer.render_border()
-        line = self._prompt_session.prompt("> ")
+        line = self._prompt_session.prompt(self._get_prompt())
         self.renderer.render_border()
         self.renderer.render_status_bar(
-            self._team_name or "(unknown)",
-            self.team_id,
-            self._team_status or "?",
+            self._state.team_name,
+            self._state.team_id,
+            self._state.team_status,
         )
         return line
+
+    def _check_connection_gate(self, line: str) -> bool:
+        """Check connection state and handle DISCONNECTED/RECONNECTING. Returns True if blocked."""
+        conn_state = self._state.connection_state
+        if conn_state == ConnectionState.DISCONNECTED:
+            self.renderer.render_error(
+                "Not connected. Use /reconnect to restore connection."
+            )
+            return True
+        if conn_state == ConnectionState.RECONNECTING:
+            self.renderer.render_system_message(
+                "Reconnecting... message will be sent when connection is restored."
+            )
+            self._message_buffer.append(line)
+            return True
+        return False
+
+    async def _handle_reply(self, line: str) -> None:
+        """Send a reply to the pending human-input request."""
+        loop = asyncio.get_running_loop()
+        ctx = self._state.reply_context
+        if ctx is None:
+            return
+        try:
+            await loop.run_in_executor(
+                None, self.client.human_input, self._state.team_id, line, ctx.reply_id
+            )
+            # Clear only after successful send
+            self._state = self._state.model_copy(
+                update={"input_mode": InputMode.CHAT, "reply_context": None}
+            )
+        except ApiError:
+            self.renderer.render_error("Error sending reply. Try again.")
 
     async def _input_loop(self) -> None:
         """Read user input and send messages."""
@@ -268,22 +353,21 @@ class ChatSession:
                 continue
 
             # Route as human-input reply if pending
-            if self._pending_reply_id:
-                try:
-                    reply_id = self._pending_reply_id
-                    await loop.run_in_executor(
-                        None, self.client.human_input, self.team_id, line, reply_id
-                    )
-                    # Clear only after successful send
-                    self._pending_reply_id = None
-                    self._pending_agent_name = None
-                except ApiError:
-                    self.renderer.render_error("Error sending reply. Try again.")
+            if self._state.input_mode == InputMode.REPLY and self._state.reply_context:
+                if self._check_connection_gate(line):
+                    continue
+                await self._handle_reply(line)
+                continue
+
+            # Connection-aware message sending
+            if self._check_connection_gate(line):
                 continue
 
             # Send message via REST API (run in executor to avoid blocking)
             try:
-                await loop.run_in_executor(None, self.client.send_message, self.team_id, line)
+                await loop.run_in_executor(
+                    None, self.client.send_message, self._state.team_id, line
+                )
             except ApiError:
                 self.renderer.render_error("Error sending message.")
 
@@ -299,10 +383,19 @@ class ChatSession:
                 self.renderer.render_error(f"Connection lost: {exc.reason}")
                 break
 
+    def _flush_message_buffer(self) -> None:
+        """Send all buffered messages that were queued during RECONNECTING state."""
+        while self._message_buffer:
+            msg = self._message_buffer.pop(0)
+            try:
+                self.client.send_message(self._state.team_id, msg)
+            except ApiError:
+                self.renderer.render_error(f"Failed to send buffered message: {msg[:50]}")
+
     def _replay_history(self) -> None:
         """Fetch and display past events before starting the REPL."""
         try:
-            events = self.client.get_events(self.team_id)
+            events = self.client.get_events(self._state.team_id)
         except ApiError:
             return
         self._display_events([e.model_dump() for e in events])
@@ -311,7 +404,9 @@ class ChatSession:
         """Async version of _replay_history — uses run_in_executor to avoid blocking."""
         loop = asyncio.get_running_loop()
         try:
-            events = await loop.run_in_executor(None, self.client.get_events, self.team_id)
+            events = await loop.run_in_executor(
+                None, self.client.get_events, self._state.team_id
+            )
         except ApiError:
             return
         self._display_events([e.model_dump() for e in events])
@@ -329,8 +424,14 @@ class ChatSession:
         """Format and render a single event. Returns True if something was rendered."""
 
         def _set_pending(message_id: str, agent_name: str) -> None:
-            self._pending_reply_id = message_id
-            self._pending_agent_name = agent_name
+            self._state = self._state.model_copy(
+                update={
+                    "input_mode": InputMode.REPLY,
+                    "reply_context": ReplyContext(
+                        reply_id=message_id, agent_name=agent_name, prompt=""
+                    ),
+                }
+            )
 
         return _render_event_impl(data, self.renderer, on_human_input=_set_pending)
 

--- a/src/akgentic/infra/cli/repl.py
+++ b/src/akgentic/infra/cli/repl.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import asyncio
-import json
 from collections.abc import Callable
 from enum import Enum
 from typing import Any
@@ -13,15 +12,14 @@ from prompt_toolkit.completion import Completer, Completion
 from prompt_toolkit.history import InMemoryHistory
 from pydantic import BaseModel
 
-from akgentic.infra.cli.client import ApiClient, ApiError, TeamInfo
+from akgentic.infra.cli.client import ApiClient, ApiError
 from akgentic.infra.cli.commands import CommandRegistry, build_default_registry
 from akgentic.infra.cli.connection import ConnectionManager, ConnectionState
+from akgentic.infra.cli.event_router import EventRouter
 from akgentic.infra.cli.formatters import OutputFormat
 from akgentic.infra.cli.renderers import RichRenderer
+from akgentic.infra.cli.team_selector import TeamSelector as TeamSelector  # re-export
 from akgentic.infra.cli.ws_client import WsConnectionError
-
-# Event types to display vs skip
-_DISPLAY_EVENTS = {"SentMessage", "ErrorMessage", "EventMessage"}
 
 
 class InputMode(Enum):
@@ -48,155 +46,6 @@ class SessionState(BaseModel):
     input_mode: InputMode = InputMode.CHAT
     reply_context: ReplyContext | None = None
     connection_state: ConnectionState = ConnectionState.CONNECTING
-
-
-_STOPPED_PAGE_SIZE = 5
-
-
-def _short_id(team_id: str) -> str:
-    """Truncate a UUID to the first 13 characters."""
-    return team_id[:13] if len(team_id) > 13 else team_id
-
-
-class TeamSelector:
-    """Interactive team selection / creation flow before entering chat."""
-
-    def __init__(self, client: ApiClient, renderer: RichRenderer) -> None:
-        self._client = client
-        self._renderer = renderer
-
-    def run(self) -> str | None:
-        """Show the startup menu and return the selected/created team_id, or None to quit."""
-        while True:
-            teams = self._fetch_teams()
-            running = [t for t in teams if t.status == "running"]
-            stopped = [t for t in teams if t.status == "stopped"]
-
-            self._render_menu(running)
-            choice = input("\n  > ").strip()
-
-            result = self._handle_choice(choice, running, stopped)
-            if result is not None:
-                return result if result != "" else None
-
-    def _render_menu(self, running: list[TeamInfo]) -> None:
-        """Display the welcome screen with running teams and catalog."""
-        catalog = self._fetch_catalog()
-        self._renderer.render_border()
-        self._renderer.render_welcome_header()
-        if running:
-            numbered = [
-                (i + 1, t.name, _short_id(t.team_id), t.status)
-                for i, t in enumerate(running)
-            ]
-            self._renderer.render_team_list(numbered, title="Running teams:")
-        if catalog:
-            self._renderer.render_catalog_list(catalog)
-        self._renderer.render_border()
-        self._renderer.render_startup_hints(len(running), has_stopped=True)
-
-    def _handle_choice(
-        self,
-        choice: str,
-        running: list[TeamInfo],
-        stopped: list[TeamInfo],
-    ) -> str | None:
-        """Process a user choice. Returns team_id, empty string for quit, or None to loop."""
-        if not choice or choice in ("/quit", "q"):
-            return ""  # signal quit
-
-        if choice.isdigit():
-            idx = int(choice) - 1
-            if 0 <= idx < len(running):
-                return running[idx].team_id
-            self._renderer.render_error(f"Invalid selection: {choice}")
-            return None
-
-        if choice.startswith("c "):
-            return self._handle_create(choice[2:].strip())
-
-        if choice == "s":
-            return self._browse_stopped(stopped)
-
-        self._renderer.render_error(f"Unknown choice: {choice}")
-        return None
-
-    def _handle_create(self, entry_id: str) -> str | None:
-        """Create a team from a catalog entry. Returns team_id or None on failure."""
-        if not entry_id:
-            self._renderer.render_error("Usage: c <catalog_entry>")
-            return None
-        try:
-            team = self._client.create_team(entry_id)
-            return team.team_id
-        except ApiError:
-            self._renderer.render_error(f"Failed to create team from '{entry_id}'")
-            return None
-
-    def _fetch_teams(self) -> list[TeamInfo]:
-        """Fetch all teams from the server."""
-        try:
-            return self._client.list_teams()
-        except ApiError:
-            return []
-
-    def _fetch_catalog(self) -> list[tuple[str, str]]:
-        """Fetch catalog entries as (id, description) tuples."""
-        try:
-            entries = self._client.list_catalog_teams()
-            return [(e.id, e.description) for e in entries]
-        except (ApiError, Exception):  # noqa: BLE001
-            return []
-
-    def _browse_stopped(self, stopped: list[TeamInfo]) -> str | None:
-        """Paginated browser for stopped teams. Returns team_id or None to go back."""
-        if not stopped:
-            self._renderer.render_system_message("No stopped teams.")
-            return None
-
-        page = 0
-        while True:
-            start = page * _STOPPED_PAGE_SIZE
-            page_teams = stopped[start : start + _STOPPED_PAGE_SIZE]
-            if not page_teams:
-                page = 0
-                continue
-
-            has_next = start + _STOPPED_PAGE_SIZE < len(stopped)
-
-            self._renderer.render_border()
-            numbered = [
-                (i + 1, t.name, _short_id(t.team_id), t.status)
-                for i, t in enumerate(page_teams)
-            ]
-            title = f"Stopped teams ({len(stopped)} total):"
-            self._renderer.render_team_list(numbered, title=title)
-            self._renderer.render_border()
-            self._renderer.render_pagination_hints(has_next)
-
-            choice = input("\n  > ").strip()
-
-            if not choice or choice == "b":
-                return None
-
-            if choice == "n" and has_next:
-                page += 1
-                continue
-
-            if choice.isdigit():
-                idx = int(choice) - 1
-                if 0 <= idx < len(page_teams):
-                    team = page_teams[idx]
-                    try:
-                        self._client.restore_team(team.team_id)
-                        return team.team_id
-                    except ApiError:
-                        self._renderer.render_error(f"Failed to restore team {team.name}")
-                        continue
-                self._renderer.render_error(f"Invalid selection: {choice}")
-                continue
-
-            self._renderer.render_error(f"Unknown choice: {choice}")
 
 
 class ChatSession:
@@ -228,6 +77,9 @@ class ChatSession:
             history=InMemoryHistory(),
             completer=_SlashCompleter(self.command_registry),
         )
+        import logging
+
+        self._event_router = EventRouter(self.renderer, logger=logging.getLogger(__name__))
 
         def _on_conn_state_change(new_state: ConnectionState) -> None:
             self._state = self._state.model_copy(update={"connection_state": new_state})
@@ -304,9 +156,7 @@ class ChatSession:
         """Check connection state and handle DISCONNECTED/RECONNECTING. Returns True if blocked."""
         conn_state = self._state.connection_state
         if conn_state == ConnectionState.DISCONNECTED:
-            self.renderer.render_error(
-                "Not connected. Use /reconnect to restore connection."
-            )
+            self.renderer.render_error("Not connected. Use /reconnect to restore connection.")
             return True
         if conn_state == ConnectionState.RECONNECTING:
             self.renderer.render_system_message(
@@ -404,9 +254,7 @@ class ChatSession:
         """Async version of _replay_history — uses run_in_executor to avoid blocking."""
         loop = asyncio.get_running_loop()
         try:
-            events = await loop.run_in_executor(
-                None, self.client.get_events, self._state.team_id
-            )
+            events = await loop.run_in_executor(None, self.client.get_events, self._state.team_id)
         except ApiError:
             return
         self._display_events([e.model_dump() for e in events])
@@ -433,7 +281,8 @@ class ChatSession:
                 }
             )
 
-        return _render_event_impl(data, self.renderer, on_human_input=_set_pending)
+        self._event_router._on_human_input = _set_pending
+        return self._event_router.route(data)
 
 
 class _SlashCompleter(Completer):
@@ -442,9 +291,7 @@ class _SlashCompleter(Completer):
     def __init__(self, registry: CommandRegistry) -> None:
         self._registry = registry
 
-    def get_completions(
-        self, document: Any, complete_event: Any
-    ) -> Any:  # noqa: ANN401
+    def get_completions(self, document: Any, complete_event: Any) -> Any:  # noqa: ANN401
         text = document.text_before_cursor
         if not text.startswith("/"):
             return
@@ -459,120 +306,23 @@ class _SlashCompleter(Completer):
                 )
 
 
+# -- Backward-compatible re-exports and wrappers --
+
+
 def _render_event_impl(
     data: dict[str, Any],
     renderer: RichRenderer,
     on_human_input: Callable[[str, str], None] | None = None,
 ) -> bool:
-    """Shared event rendering logic used by both ChatSession and _print_event."""
-    event = data.get("event", data)
-    if isinstance(event, str):
-        try:
-            event = json.loads(event)
-        except (json.JSONDecodeError, TypeError):
-            return False
-
-    model = event.get("__model__", "")
-    # Match short suffix (e.g. "SentMessage") from fully qualified model names
-    short_model = model.rsplit(".", 1)[-1] if model else ""
-    if short_model not in _DISPLAY_EVENTS:
-        return False
-
-    if short_model == "ErrorMessage":
-        content = event.get("exception_value", event.get("content", event.get("error", "")))
-        renderer.render_error(str(content))
-        return True
-
-    if short_model == "EventMessage":
-        return _render_event_message_impl(
-            event, renderer, on_human_input=on_human_input, outer_data=data
-        )
-
-    # SentMessage — agent response; content lives inside nested "message"
-    raw_sender = event.get("sender", "agent")
-    sender = raw_sender.get("name", "agent") if isinstance(raw_sender, dict) else str(raw_sender)
-    message = event.get("message", {})
-    content = message.get("content", "") if isinstance(message, dict) else ""
-    if content:
-        renderer.render_agent_message(sender, str(content))
-        return True
-    return False
-
-
-def _render_tool_call(nested: dict[str, Any], renderer: RichRenderer) -> None:
-    """Extract and render a tool call event."""
-    tool_name = str(nested["tool_name"])
-    raw_input = nested.get("arguments", nested.get("args", nested.get("input", "")))
-    if isinstance(raw_input, dict | list):
-        tool_input = json.dumps(raw_input, indent=2)
-    else:
-        tool_input = str(raw_input)
-    raw_output = nested.get("result")
-    if raw_output is None:
-        tool_output = None
-    elif isinstance(raw_output, dict | list):
-        tool_output = json.dumps(raw_output, indent=2)
-    else:
-        tool_output = str(raw_output)
-    renderer.render_tool_call(tool_name, tool_input, tool_output)
-
-
-def _notify_human_input(
-    outer_data: dict[str, Any],
-    on_human_input: Callable[[str, str], None],
-) -> None:
-    """Extract message_id and agent_name from outer event data and invoke callback."""
-    raw_id = outer_data.get("id")
-    if not raw_id:
-        return
-    message_id = str(raw_id)
-    raw_sender = outer_data.get("sender", "Agent")
-    if isinstance(raw_sender, dict):
-        agent_name = str(raw_sender.get("name", "Agent"))
-    else:
-        agent_name = str(raw_sender)
-    on_human_input(message_id, agent_name)
-
-
-def _render_event_message_impl(
-    event: dict[str, Any],
-    renderer: RichRenderer,
-    on_human_input: Callable[[str, str], None] | None = None,
-    outer_data: dict[str, Any] | None = None,
-) -> bool:
-    """Handle EventMessage — inspect nested event for tool calls / human input."""
-    nested = event.get("event", {})
-    if isinstance(nested, str):
-        try:
-            nested = json.loads(nested)
-        except (json.JSONDecodeError, TypeError):
-            return False
-
-    if not isinstance(nested, dict):
-        return False
-
-    nested_model = nested.get("__model__", "")
-
-    if "tool_name" in nested:
-        _render_tool_call(nested, renderer)
-        return True
-
-    if "HumanInput" in nested_model or "RequestInput" in nested_model:
-        prompt_text = str(nested.get("prompt", nested.get("content", "Input requested")))
-        renderer.render_human_input_request(prompt_text)
-        if on_human_input is not None and outer_data is not None:
-            _notify_human_input(outer_data, on_human_input)
-        return True
-
-    return False
-
-
-def _print_event(data: dict[str, Any]) -> bool:
-    """Backward-compatible module-level event printer.
-
-    Delegates to the shared rendering logic with a default RichRenderer.
-    """
-    return _render_event_impl(data, _default_renderer)
+    """Backward-compatible wrapper -- delegates to EventRouter."""
+    router = EventRouter(renderer, on_human_input=on_human_input)
+    return router.route(data)
 
 
 _default_renderer = RichRenderer()
+_default_event_router = EventRouter(_default_renderer)
+
+
+def _print_event(data: dict[str, Any]) -> bool:
+    """Backward-compatible module-level event printer."""
+    return _default_event_router.route(data)

--- a/src/akgentic/infra/cli/repl.py
+++ b/src/akgentic/infra/cli/repl.py
@@ -7,16 +7,16 @@ import json
 from collections.abc import Callable
 from typing import Any
 
-import websockets.exceptions
 from prompt_toolkit import PromptSession
 from prompt_toolkit.completion import Completer, Completion
 from prompt_toolkit.history import InMemoryHistory
 
 from akgentic.infra.cli.client import ApiClient, ApiError, TeamInfo
 from akgentic.infra.cli.commands import CommandRegistry, build_default_registry
+from akgentic.infra.cli.connection import ConnectionManager
 from akgentic.infra.cli.formatters import OutputFormat
 from akgentic.infra.cli.renderers import RichRenderer
-from akgentic.infra.cli.ws_client import WsClient
+from akgentic.infra.cli.ws_client import WsConnectionError
 
 # Event types to display vs skip
 _DISPLAY_EVENTS = {"SentMessage", "ErrorMessage", "EventMessage"}
@@ -176,7 +176,7 @@ class ChatSession:
     def __init__(
         self,
         client: ApiClient,
-        ws_client: WsClient,
+        conn: ConnectionManager,
         team_id: str,
         fmt: OutputFormat,
         *,
@@ -185,7 +185,7 @@ class ChatSession:
         renderer: RichRenderer | None = None,
     ) -> None:
         self.client = client
-        self.ws_client = ws_client
+        self.conn = conn
         self.team_id = team_id
         self.fmt = fmt
         self.server_url = server_url
@@ -215,7 +215,7 @@ class ChatSession:
 
     async def run(self) -> None:
         """Main REPL loop: connect WS, replay history, read input, stream events."""
-        async with self.ws_client:
+        async with self.conn:
             self._fetch_team_info()
             self.renderer.render_border()
             self._replay_history()
@@ -271,13 +271,14 @@ class ChatSession:
             if self._pending_reply_id:
                 try:
                     reply_id = self._pending_reply_id
-                    self._pending_reply_id = None
-                    self._pending_agent_name = None
                     await loop.run_in_executor(
                         None, self.client.human_input, self.team_id, line, reply_id
                     )
+                    # Clear only after successful send
+                    self._pending_reply_id = None
+                    self._pending_agent_name = None
                 except ApiError:
-                    self.renderer.render_error("Error sending reply.")
+                    self.renderer.render_error("Error sending reply. Try again.")
                 continue
 
             # Send message via REST API (run in executor to avoid blocking)
@@ -290,21 +291,13 @@ class ChatSession:
         """Background coroutine: read WebSocket events and render them."""
         while self._running:
             try:
-                event = await self.ws_client.receive_event()
+                event = await self.conn.receive_event()
                 self._render_event(event)
             except asyncio.CancelledError:
                 raise
-            except websockets.exceptions.ConnectionClosed as exc:
-                if exc.rcvd is not None and exc.rcvd.code == 4004:
-                    self.renderer.render_error("team not found")
-                elif exc.rcvd is not None and exc.rcvd.code not in (1000, 1001):
-                    self.renderer.render_system_message(
-                        f"Connection closed: {exc.rcvd.reason or exc.rcvd.code}"
-                    )
+            except WsConnectionError as exc:
+                self.renderer.render_error(f"Connection lost: {exc.reason}")
                 break
-            except Exception:  # noqa: BLE001
-                if self._running:
-                    break
 
     def _replay_history(self) -> None:
         """Fetch and display past events before starting the REPL."""

--- a/src/akgentic/infra/cli/repl.py
+++ b/src/akgentic/infra/cli/repl.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 from collections.abc import Callable
 from enum import Enum
 from typing import Any
@@ -77,8 +78,6 @@ class ChatSession:
             history=InMemoryHistory(),
             completer=_SlashCompleter(self.command_registry),
         )
-        import logging
-
         self._event_router = EventRouter(self.renderer, logger=logging.getLogger(__name__))
 
         def _on_conn_state_change(new_state: ConnectionState) -> None:

--- a/src/akgentic/infra/cli/team_selector.py
+++ b/src/akgentic/infra/cli/team_selector.py
@@ -1,0 +1,152 @@
+"""Team selection and creation flow for the REPL startup menu."""
+
+from __future__ import annotations
+
+from akgentic.infra.cli.client import ApiClient, ApiError, TeamInfo
+from akgentic.infra.cli.renderers import RichRenderer
+
+_STOPPED_PAGE_SIZE = 5
+
+
+def _short_id(team_id: str) -> str:
+    """Truncate a UUID to the first 13 characters."""
+    return team_id[:13] if len(team_id) > 13 else team_id
+
+
+class TeamSelector:
+    """Interactive team selection / creation flow before entering chat."""
+
+    def __init__(self, client: ApiClient, renderer: RichRenderer) -> None:
+        self._client = client
+        self._renderer = renderer
+
+    def run(self) -> str | None:
+        """Show the startup menu and return the selected/created team_id, or None to quit."""
+        while True:
+            teams = self._fetch_teams()
+            running = [t for t in teams if t.status == "running"]
+            stopped = [t for t in teams if t.status == "stopped"]
+
+            self._render_menu(running)
+            choice = input("\n  > ").strip()
+
+            result = self._handle_choice(choice, running, stopped)
+            if result is not None:
+                return result if result != "" else None
+
+    def _render_menu(self, running: list[TeamInfo]) -> None:
+        """Display the welcome screen with running teams and catalog."""
+        catalog = self._fetch_catalog()
+        self._renderer.render_border()
+        self._renderer.render_welcome_header()
+        if running:
+            numbered = [
+                (i + 1, t.name, _short_id(t.team_id), t.status) for i, t in enumerate(running)
+            ]
+            self._renderer.render_team_list(numbered, title="Running teams:")
+        if catalog:
+            self._renderer.render_catalog_list(catalog)
+        self._renderer.render_border()
+        self._renderer.render_startup_hints(len(running), has_stopped=True)
+
+    def _handle_choice(
+        self,
+        choice: str,
+        running: list[TeamInfo],
+        stopped: list[TeamInfo],
+    ) -> str | None:
+        """Process a user choice. Returns team_id, empty string for quit, or None to loop."""
+        if not choice or choice in ("/quit", "q"):
+            return ""  # signal quit
+
+        if choice.isdigit():
+            idx = int(choice) - 1
+            if 0 <= idx < len(running):
+                return running[idx].team_id
+            self._renderer.render_error(f"Invalid selection: {choice}")
+            return None
+
+        if choice.startswith("c "):
+            return self._handle_create(choice[2:].strip())
+
+        if choice == "s":
+            return self._browse_stopped(stopped)
+
+        self._renderer.render_error(f"Unknown choice: {choice}")
+        return None
+
+    def _handle_create(self, entry_id: str) -> str | None:
+        """Create a team from a catalog entry. Returns team_id or None on failure."""
+        if not entry_id:
+            self._renderer.render_error("Usage: c <catalog_entry>")
+            return None
+        try:
+            team = self._client.create_team(entry_id)
+            return team.team_id
+        except ApiError:
+            self._renderer.render_error(f"Failed to create team from '{entry_id}'")
+            return None
+
+    def _fetch_teams(self) -> list[TeamInfo]:
+        """Fetch all teams from the server."""
+        try:
+            return self._client.list_teams()
+        except ApiError:
+            return []
+
+    def _fetch_catalog(self) -> list[tuple[str, str]]:
+        """Fetch catalog entries as (id, description) tuples."""
+        try:
+            entries = self._client.list_catalog_teams()
+            return [(e.id, e.description) for e in entries]
+        except (ApiError, Exception):  # noqa: BLE001
+            return []
+
+    def _browse_stopped(self, stopped: list[TeamInfo]) -> str | None:
+        """Paginated browser for stopped teams. Returns team_id or None to go back."""
+        if not stopped:
+            self._renderer.render_system_message("No stopped teams.")
+            return None
+
+        page = 0
+        while True:
+            start = page * _STOPPED_PAGE_SIZE
+            page_teams = stopped[start : start + _STOPPED_PAGE_SIZE]
+            if not page_teams:
+                page = 0
+                continue
+
+            has_next = start + _STOPPED_PAGE_SIZE < len(stopped)
+
+            self._renderer.render_border()
+            numbered = [
+                (i + 1, t.name, _short_id(t.team_id), t.status) for i, t in enumerate(page_teams)
+            ]
+            title = f"Stopped teams ({len(stopped)} total):"
+            self._renderer.render_team_list(numbered, title=title)
+            self._renderer.render_border()
+            self._renderer.render_pagination_hints(has_next)
+
+            choice = input("\n  > ").strip()
+
+            if not choice or choice == "b":
+                return None
+
+            if choice == "n" and has_next:
+                page += 1
+                continue
+
+            if choice.isdigit():
+                idx = int(choice) - 1
+                if 0 <= idx < len(page_teams):
+                    team = page_teams[idx]
+                    try:
+                        self._client.restore_team(team.team_id)
+                        return team.team_id
+                    except ApiError:
+                        self._renderer.render_error(f"Failed to restore team {team.name}")
+                        continue
+                self._renderer.render_error(f"Invalid selection: {choice}")
+                continue
+
+            self._renderer.render_error(f"Unknown choice: {choice}")

--- a/src/akgentic/infra/cli/team_selector.py
+++ b/src/akgentic/infra/cli/team_selector.py
@@ -99,7 +99,7 @@ class TeamSelector:
         try:
             entries = self._client.list_catalog_teams()
             return [(e.id, e.description) for e in entries]
-        except (ApiError, Exception):  # noqa: BLE001
+        except Exception:  # noqa: BLE001
             return []
 
     def _browse_stopped(self, stopped: list[TeamInfo]) -> str | None:

--- a/src/akgentic/infra/cli/ws_client.py
+++ b/src/akgentic/infra/cli/ws_client.py
@@ -68,6 +68,12 @@ class WsClient:
         text = raw if isinstance(raw, str) else raw.decode("utf-8")
         return json.loads(text)  # type: ignore[no-any-return]
 
+    async def ping(self) -> None:
+        """Send a WebSocket ping frame. Raises if not connected."""
+        if self._ws is None:
+            raise RuntimeError("Not connected")
+        await self._ws.ping()
+
     async def close(self) -> None:
         """Close WebSocket connection."""
         if self._ws is not None:

--- a/tests/cli/conftest.py
+++ b/tests/cli/conftest.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import asyncio
 import io
 from typing import Any
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, PropertyMock
 
 from rich.console import Console
 
@@ -16,6 +16,7 @@ from akgentic.infra.cli.client import (
     WorkspaceTreeInfo,
     WorkspaceUploadInfo,
 )
+from akgentic.infra.cli.connection import ConnectionState
 from akgentic.infra.cli.formatters import OutputFormat
 from akgentic.infra.cli.renderers import RichRenderer
 from akgentic.infra.cli.repl import ChatSession
@@ -86,7 +87,7 @@ def mock_client(**overrides: Any) -> MagicMock:
 
 
 def mock_ws() -> AsyncMock:
-    """Build a mock WsClient for CLI tests."""
+    """Build a mock WsClient for CLI tests (legacy helper)."""
     ws = AsyncMock()
     ws.__aenter__ = AsyncMock(return_value=ws)
     ws.__aexit__ = AsyncMock(return_value=None)
@@ -95,6 +96,21 @@ def mock_ws() -> AsyncMock:
     ws.close = AsyncMock()
     ws.connect = AsyncMock(return_value=ws)
     return ws
+
+
+def mock_conn(team_id: str = "t1") -> AsyncMock:
+    """Build a mock ConnectionManager for CLI tests."""
+    conn = AsyncMock()
+    conn.__aenter__ = AsyncMock(return_value=conn)
+    conn.__aexit__ = AsyncMock(return_value=None)
+    conn.receive_event = AsyncMock(side_effect=asyncio.CancelledError)
+    conn.close = AsyncMock()
+    conn.connect = AsyncMock()
+    conn.switch_team = AsyncMock()
+    # Use PropertyMock for properties
+    type(conn).state = PropertyMock(return_value=ConnectionState.CONNECTED)
+    type(conn).team_id = PropertyMock(return_value=team_id)
+    return conn
 
 
 def captured_renderer() -> tuple[RichRenderer, io.StringIO]:
@@ -106,18 +122,18 @@ def captured_renderer() -> tuple[RichRenderer, io.StringIO]:
 
 def make_session(
     client: MagicMock | None = None,
-    ws: AsyncMock | None = None,
+    conn: AsyncMock | None = None,
     team_id: str = "t1",
     renderer: RichRenderer | None = None,
 ) -> ChatSession:
     """Create a ChatSession with mocked dependencies."""
     if client is None:
         client = mock_client()
-    if ws is None:
-        ws = mock_ws()
+    if conn is None:
+        conn = mock_conn(team_id)
     return ChatSession(
         client,
-        ws,
+        conn,
         team_id,
         OutputFormat.table,
         server_url="http://localhost:8000",

--- a/tests/cli/test_cli_commands.py
+++ b/tests/cli/test_cli_commands.py
@@ -177,7 +177,7 @@ class TestChat:
         mock = _mock_client()
         with (
             patch("akgentic.infra.cli.main.ChatSession") as mock_session_cls,
-            patch("akgentic.infra.cli.main.WsClient") as mock_ws_cls,
+            patch("akgentic.infra.cli.main.ConnectionManager") as mock_ws_cls,
             patch("akgentic.infra.cli.main.asyncio.run") as mock_run,
         ):
             mock_session = MagicMock()
@@ -192,7 +192,7 @@ class TestChat:
         mock = _mock_client()
         with (
             patch("akgentic.infra.cli.main.ChatSession") as mock_session_cls,
-            patch("akgentic.infra.cli.main.WsClient"),
+            patch("akgentic.infra.cli.main.ConnectionManager"),
             patch("akgentic.infra.cli.main.asyncio.run"),
         ):
             mock_session_cls.return_value = MagicMock()

--- a/tests/cli/test_cli_commands_insession.py
+++ b/tests/cli/test_cli_commands_insession.py
@@ -37,14 +37,11 @@ from akgentic.infra.cli.commands import (
     _upload_handler,
     build_default_registry,
 )
-from akgentic.infra.cli.formatters import OutputFormat
 from akgentic.infra.cli.ws_client import WsConnectionError
-from akgentic.infra.cli.repl import ChatSession
 from tests.fixtures.events import _make_proxy, make_sent_message, make_start_message
 
 from .conftest import captured_renderer as _captured_renderer
 from .conftest import make_session as _make_session
-from .conftest import mock_ws as _mock_ws
 
 _PROMPT_PATH = "prompt_toolkit.PromptSession.prompt"
 
@@ -262,16 +259,15 @@ class TestCreateHandler:
         session = _make_session(client=client)
         session._receive_task = asyncio.create_task(asyncio.sleep(100))
 
-        new_ws_mock = _mock_ws()
-        with patch("akgentic.infra.cli.commands.WsClient", return_value=new_ws_mock):
-            await _create_handler("my-catalog-entry", session)
+        await _create_handler("my-catalog-entry", session)
 
         out = capsys.readouterr().out
         assert "Created team: New Team" in out
         assert "new-t" in out
         client.create_team.assert_called_once_with("my-catalog-entry")
-        # Should have auto-switched
+        # Should have auto-switched via conn.switch_team
         assert session.team_id == "new-t"
+        session.conn.switch_team.assert_called_once_with("new-t")
 
     async def test_missing_arg_shows_usage(self, capsys: pytest.CaptureFixture[str]) -> None:
         session = _make_session()
@@ -763,18 +759,16 @@ class TestRestoreHandler:
         self, capsys: pytest.CaptureFixture[str]
     ) -> None:
         client = _mock_client()
-        old_ws = _mock_ws()
-        session = _make_session(client=client, ws=old_ws)
+        session = _make_session(client=client)
         session._receive_task = asyncio.create_task(asyncio.sleep(100))
 
-        new_ws_mock = _mock_ws()
-        with patch("akgentic.infra.cli.commands.WsClient", return_value=new_ws_mock):
-            await _restore_handler("", session)
+        await _restore_handler("", session)
 
         out = capsys.readouterr().out
         assert "Team t1 restored. Live events resumed." in out
         client.restore_team.assert_called_once_with("t1")
-        # WebSocket reconnected via switch for the same team
+        # WebSocket reconnected via conn.switch_team for the same team
+        session.conn.switch_team.assert_called_once_with("t1")
         assert session.team_id == "t1"
 
     async def test_restores_different_team_and_switches(
@@ -784,32 +778,29 @@ class TestRestoreHandler:
         session = _make_session(client=client)
         session._receive_task = asyncio.create_task(asyncio.sleep(100))
 
-        new_ws_mock = _mock_ws()
-        with patch("akgentic.infra.cli.commands.WsClient", return_value=new_ws_mock):
-            await _restore_handler("t2", session)
+        await _restore_handler("t2", session)
 
         out = capsys.readouterr().out
         assert "Team t2 restored. Live events resumed." in out
         client.restore_team.assert_called_once_with("t2")
-        # Should have auto-switched
+        # Should have auto-switched via conn.switch_team
+        session.conn.switch_team.assert_called_once_with("t2")
         assert session.team_id == "t2"
 
     async def test_restores_same_team_id_reconnects_ws(
         self, capsys: pytest.CaptureFixture[str]
     ) -> None:
         client = _mock_client()
-        old_ws = _mock_ws()
-        session = _make_session(client=client, ws=old_ws)
+        session = _make_session(client=client)
         session._receive_task = asyncio.create_task(asyncio.sleep(100))
 
-        new_ws_mock = _mock_ws()
-        with patch("akgentic.infra.cli.commands.WsClient", return_value=new_ws_mock):
-            await _restore_handler("t1", session)
+        await _restore_handler("t1", session)
 
         out = capsys.readouterr().out
         assert "Team t1 restored. Live events resumed." in out
         client.restore_team.assert_called_once_with("t1")
         # WebSocket reconnected even for same team
+        session.conn.switch_team.assert_called_once_with("t1")
         assert session.team_id == "t1"
 
     async def test_handles_api_error(self) -> None:
@@ -826,23 +817,13 @@ class TestRestoreHandler:
 class TestSwitchHandler:
     async def test_switches_team(self, capsys: pytest.CaptureFixture[str]) -> None:
         client = _mock_client()
-        old_ws = _mock_ws()
-        session = _make_session(client=client, ws=old_ws)
+        session = _make_session(client=client)
         session._receive_task = asyncio.create_task(asyncio.sleep(100))
 
-        new_ws_mock = _mock_ws()
-        with patch("akgentic.infra.cli.commands.WsClient", return_value=new_ws_mock) as ws_cls:
-            await _switch_handler("t2", session)
+        await _switch_handler("t2", session)
 
-        old_ws.close.assert_called_once()
+        session.conn.switch_team.assert_called_once_with("t2")
         assert session.team_id == "t2"
-        assert session.ws_client is new_ws_mock
-        # Verify server_url and api_key are passed to new WsClient
-        ws_cls.assert_called_once_with(
-            base_url="http://localhost:8000",
-            team_id="t2",
-            api_key="test-key",
-        )
         # After switch, team info should be refreshed
         assert session._team_name == "Test Team"
         assert session._team_status == "running"
@@ -855,26 +836,17 @@ class TestSwitchHandler:
         out = capsys.readouterr().out
         assert "Usage" in out
 
-    async def test_switch_fails_restores_old(self) -> None:
+    async def test_switch_fails_old_connection_untouched(self) -> None:
         client = _mock_client()
-        old_ws = _mock_ws()
         renderer, buf = _captured_renderer()
-        session = _make_session(client=client, ws=old_ws, renderer=renderer)
+        session = _make_session(client=client, renderer=renderer)
+        session.conn.switch_team = AsyncMock(
+            side_effect=WsConnectionError("test error")
+        )
 
-        # First call creates the new WsClient (connect will fail),
-        # second call creates the restored WsClient for the old team
-        new_ws_mock = _mock_ws()
-        new_ws_mock.connect = AsyncMock(side_effect=WsConnectionError("test error"))
-        restored_ws_mock = _mock_ws()
-        with patch(
-            "akgentic.infra.cli.commands.WsClient",
-            side_effect=[new_ws_mock, restored_ws_mock],
-        ):
-            await _switch_handler("bad-team", session)
+        await _switch_handler("bad-team", session)
 
-        assert "not found" in buf.getvalue()
-        # Session ws should be the restored connection
-        assert session.ws_client is restored_ws_mock
+        assert "Switch failed" in buf.getvalue()
         assert session.team_id == "t1"  # unchanged
 
 
@@ -886,8 +858,7 @@ class TestSwitchHandler:
 class TestChatSessionCommandIntegration:
     async def test_info_dispatched_not_sent(self, capsys: pytest.CaptureFixture[str]) -> None:
         client = _mock_client()
-        ws = _mock_ws()
-        session = ChatSession(client, ws, "t1", OutputFormat.table)
+        session = _make_session(client=client)
 
         with patch(
             _PROMPT_PATH,
@@ -902,8 +873,7 @@ class TestChatSessionCommandIntegration:
 
     async def test_regular_text_sent_as_message(self, capsys: pytest.CaptureFixture[str]) -> None:
         client = _mock_client()
-        ws = _mock_ws()
-        session = ChatSession(client, ws, "t1", OutputFormat.table)
+        session = _make_session(client=client)
 
         with patch(
             _PROMPT_PATH,
@@ -915,8 +885,7 @@ class TestChatSessionCommandIntegration:
 
     async def test_quit_still_exits(self, capsys: pytest.CaptureFixture[str]) -> None:
         client = _mock_client()
-        ws = _mock_ws()
-        session = ChatSession(client, ws, "t1", OutputFormat.table)
+        session = _make_session(client=client)
 
         with patch(
             _PROMPT_PATH,
@@ -929,8 +898,7 @@ class TestChatSessionCommandIntegration:
 
     async def test_unknown_slash_command_not_sent(self, capsys: pytest.CaptureFixture[str]) -> None:
         client = _mock_client()
-        ws = _mock_ws()
-        session = ChatSession(client, ws, "t1", OutputFormat.table)
+        session = _make_session(client=client)
 
         with patch(
             _PROMPT_PATH,

--- a/tests/cli/test_cli_commands_insession.py
+++ b/tests/cli/test_cli_commands_insession.py
@@ -30,6 +30,7 @@ from akgentic.infra.cli.commands import (
     _history_handler,
     _info_handler,
     _read_handler,
+    _reconnect_handler,
     _restore_handler,
     _stop_handler,
     _switch_handler,
@@ -825,8 +826,8 @@ class TestSwitchHandler:
         session.conn.switch_team.assert_called_once_with("t2")
         assert session.team_id == "t2"
         # After switch, team info should be refreshed
-        assert session._team_name == "Test Team"
-        assert session._team_status == "running"
+        assert session._state.team_name == "Test Team"
+        assert session._state.team_status == "running"
 
     async def test_no_arg_shows_usage(self, capsys: pytest.CaptureFixture[str]) -> None:
         session = _make_session()
@@ -1024,6 +1025,7 @@ class TestBuildDefaultRegistry:
             "stop",
             "restore",
             "switch",
+            "reconnect",
         }
         assert set(registry.commands.keys()) == expected
 
@@ -1034,3 +1036,70 @@ class TestBuildDefaultRegistry:
     def test_restore_usage_updated(self) -> None:
         registry = build_default_registry()
         assert "[team_id]" in registry.commands["restore"].usage
+
+    def test_reconnect_registered(self) -> None:
+        registry = build_default_registry()
+        assert "reconnect" in registry.commands
+
+
+# =============================================================================
+# Story 11.3: /reconnect command tests
+# =============================================================================
+
+
+class TestReconnectHandler:
+    async def test_successful_reconnect(self) -> None:
+        renderer, buf = _captured_renderer()
+        session = _make_session(renderer=renderer)
+
+        await _reconnect_handler("", session)
+
+        session.conn.connect.assert_called_once()
+        out = buf.getvalue()
+        assert "Reconnecting" in out
+        assert "Connected" in out
+
+    async def test_reconnect_failure(self) -> None:
+        renderer, buf = _captured_renderer()
+        session = _make_session(renderer=renderer)
+        session.conn.connect = AsyncMock(
+            side_effect=WsConnectionError("server down", retryable=False)
+        )
+
+        await _reconnect_handler("", session)
+
+        out = buf.getvalue()
+        assert "Reconnecting" in out
+        assert "Reconnection failed" in out
+        assert "server down" in out
+
+
+# =============================================================================
+# Story 11.3: render_connection_status tests
+# =============================================================================
+
+
+class TestRenderConnectionStatus:
+    def test_connected_green(self) -> None:
+        renderer, buf = _captured_renderer()
+        renderer.render_connection_status("connected")
+        out = buf.getvalue()
+        assert "Connected" in out
+
+    def test_reconnecting_yellow(self) -> None:
+        renderer, buf = _captured_renderer()
+        renderer.render_connection_status("reconnecting")
+        out = buf.getvalue()
+        assert "Reconnecting..." in out
+
+    def test_disconnected_red(self) -> None:
+        renderer, buf = _captured_renderer()
+        renderer.render_connection_status("disconnected")
+        out = buf.getvalue()
+        assert "Disconnected" in out
+
+    def test_unknown_status(self) -> None:
+        renderer, buf = _captured_renderer()
+        renderer.render_connection_status("custom-state")
+        out = buf.getvalue()
+        assert "custom-state" in out

--- a/tests/cli/test_cli_connection.py
+++ b/tests/cli/test_cli_connection.py
@@ -1,0 +1,339 @@
+"""Tests for ConnectionManager with auto-reconnect."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+import websockets.exceptions
+
+from akgentic.infra.cli.connection import ConnectionManager, ConnectionState
+from akgentic.infra.cli.ws_client import WsConnectionError
+
+_WS_CLIENT_PATH = "akgentic.infra.cli.connection.WsClient"
+
+
+class TestConnectionStateEnum:
+    """AC #1: ConnectionState enum values."""
+
+    def test_all_states_exist(self) -> None:
+        assert ConnectionState.CONNECTING.value == "connecting"
+        assert ConnectionState.CONNECTED.value == "connected"
+        assert ConnectionState.RECONNECTING.value == "reconnecting"
+        assert ConnectionState.DISCONNECTED.value == "disconnected"
+
+    def test_four_members(self) -> None:
+        assert len(ConnectionState) == 4
+
+
+class TestConnectionManagerInit:
+    """AC #2: ConnectionManager construction."""
+
+    def test_initial_state_is_disconnected(self) -> None:
+        cm = ConnectionManager(server_url="http://localhost:8000", team_id="t1")
+        assert cm.state == ConnectionState.DISCONNECTED
+        assert cm.team_id == "t1"
+
+    def test_default_max_retries(self) -> None:
+        cm = ConnectionManager(server_url="http://localhost:8000", team_id="t1")
+        assert cm._max_retries == 10
+
+
+class TestConnect:
+    """AC #2: connect() method."""
+
+    async def test_connect_success(self) -> None:
+        """AC #2, #4: Successful connect transitions DISCONNECTED -> CONNECTING -> CONNECTED."""
+        states: list[ConnectionState] = []
+
+        def on_change(s: ConnectionState) -> None:
+            states.append(s)
+
+        mock_ws = AsyncMock()
+        mock_ws.connect = AsyncMock(return_value=mock_ws)
+
+        with patch(_WS_CLIENT_PATH, return_value=mock_ws):
+            cm = ConnectionManager(
+                server_url="http://localhost:8000",
+                team_id="t1",
+                on_state_change=on_change,
+            )
+            await cm.connect()
+
+        assert cm.state == ConnectionState.CONNECTED
+        assert states == [ConnectionState.CONNECTING, ConnectionState.CONNECTED]
+        assert cm._last_event_time > 0
+
+    async def test_connect_failure(self) -> None:
+        """AC #4: Failed connect transitions DISCONNECTED -> CONNECTING -> DISCONNECTED."""
+        states: list[ConnectionState] = []
+
+        def on_change(s: ConnectionState) -> None:
+            states.append(s)
+
+        mock_ws = AsyncMock()
+        mock_ws.connect = AsyncMock(side_effect=WsConnectionError("refused"))
+
+        with patch(_WS_CLIENT_PATH, return_value=mock_ws):
+            cm = ConnectionManager(
+                server_url="http://localhost:8000",
+                team_id="t1",
+                on_state_change=on_change,
+            )
+            with pytest.raises(WsConnectionError):
+                await cm.connect()
+
+        assert cm.state == ConnectionState.DISCONNECTED
+        assert states == [ConnectionState.CONNECTING, ConnectionState.DISCONNECTED]
+
+
+class TestReconnect:
+    """AC #3: Exponential backoff reconnection."""
+
+    async def test_exponential_backoff_sequence(self) -> None:
+        """AC #3: Verify delay sequence 1, 2, 4, 8, 16, 30, 30, ..."""
+        mock_ws = AsyncMock()
+        # Fail 7 times, then succeed
+        effects: list[Exception | AsyncMock] = [
+            WsConnectionError("fail") for _ in range(7)
+        ]
+        effects.append(AsyncMock())  # success on 8th
+
+        call_idx = 0
+
+        async def connect_side_effect() -> AsyncMock:
+            nonlocal call_idx
+            effect = effects[call_idx]
+            call_idx += 1
+            if isinstance(effect, Exception):
+                raise effect
+            return effect
+
+        mock_ws.connect = AsyncMock(side_effect=connect_side_effect)
+
+        sleep_calls: list[float] = []
+
+        async def mock_sleep(delay: float) -> None:
+            sleep_calls.append(delay)
+
+        with (
+            patch(_WS_CLIENT_PATH, return_value=mock_ws),
+            patch("akgentic.infra.cli.connection.asyncio.sleep", side_effect=mock_sleep),
+        ):
+            cm = ConnectionManager(
+                server_url="http://localhost:8000",
+                team_id="t1",
+                max_retries=10,
+            )
+            cm._ws_client = mock_ws  # pretend we were connected
+            await cm._reconnect()
+
+        # 7 failures before success, so 7 sleeps
+        assert sleep_calls == [1, 2, 4, 8, 16, 30, 30]
+        assert cm.state == ConnectionState.CONNECTED
+
+    async def test_reconnect_exhaustion(self) -> None:
+        """AC #3, #5: After max_retries, raise WsConnectionError(retryable=False)."""
+        mock_ws = AsyncMock()
+        mock_ws.connect = AsyncMock(side_effect=WsConnectionError("fail"))
+
+        sleep_calls: list[float] = []
+
+        async def mock_sleep(delay: float) -> None:
+            sleep_calls.append(delay)
+
+        with (
+            patch(_WS_CLIENT_PATH, return_value=mock_ws),
+            patch("akgentic.infra.cli.connection.asyncio.sleep", side_effect=mock_sleep),
+        ):
+            cm = ConnectionManager(
+                server_url="http://localhost:8000",
+                team_id="t1",
+                max_retries=3,
+            )
+            with pytest.raises(WsConnectionError, match="Reconnection failed after 3 attempts"):
+                await cm._reconnect()
+
+        assert cm.state == ConnectionState.DISCONNECTED
+        assert len(sleep_calls) == 3
+
+
+class TestReceiveEvent:
+    """AC #5: receive_event()."""
+
+    async def test_receive_success(self) -> None:
+        """AC #5: Successful event updates _last_event_time."""
+        cm = ConnectionManager(server_url="http://localhost:8000", team_id="t1")
+        mock_ws = AsyncMock()
+        mock_ws.receive_event = AsyncMock(return_value={"type": "test"})
+        cm._ws_client = mock_ws
+        cm._state = ConnectionState.CONNECTED
+
+        event = await cm.receive_event()
+
+        assert event == {"type": "test"}
+        assert cm._last_event_time > 0
+
+    async def test_receive_not_connected_raises(self) -> None:
+        """AC #5: receive_event() raises WsConnectionError when not connected."""
+        cm = ConnectionManager(server_url="http://localhost:8000", team_id="t1")
+
+        with pytest.raises(WsConnectionError, match="Not connected"):
+            await cm.receive_event()
+
+    async def test_receive_triggers_reconnect_on_failure(self) -> None:
+        """AC #5: ConnectionClosed triggers reconnect, then resumes streaming."""
+        cm = ConnectionManager(server_url="http://localhost:8000", team_id="t1")
+        mock_ws = AsyncMock()
+
+        call_count = 0
+
+        async def recv_side_effect() -> dict:
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                raise websockets.exceptions.ConnectionClosedError(
+                    rcvd=None, sent=None
+                )
+            return {"type": "after_reconnect"}
+
+        mock_ws.receive_event = AsyncMock(side_effect=recv_side_effect)
+        cm._ws_client = mock_ws
+        cm._state = ConnectionState.CONNECTED
+
+        # Mock _reconnect to succeed without actual reconnection
+        cm._reconnect = AsyncMock()  # type: ignore[method-assign]
+
+        event = await cm.receive_event()
+
+        cm._reconnect.assert_called_once()
+        assert event == {"type": "after_reconnect"}
+
+
+class TestSwitchTeam:
+    """AC #7: Atomic team switch."""
+
+    async def test_switch_success(self) -> None:
+        """AC #7: New WS connects first, old WS closed after."""
+        old_ws = AsyncMock()
+        new_ws = AsyncMock()
+        new_ws.connect = AsyncMock(return_value=new_ws)
+
+        cm = ConnectionManager(server_url="http://localhost:8000", team_id="t1")
+        cm._ws_client = old_ws
+        cm._state = ConnectionState.CONNECTED
+
+        with patch(_WS_CLIENT_PATH, return_value=new_ws):
+            await cm.switch_team("t2")
+
+        assert cm.team_id == "t2"
+        assert cm._ws_client is new_ws
+        old_ws.close.assert_called_once()
+
+    async def test_switch_failure_preserves_old(self) -> None:
+        """AC #7: Failed switch leaves old connection untouched."""
+        old_ws = AsyncMock()
+        new_ws = AsyncMock()
+        new_ws.connect = AsyncMock(side_effect=WsConnectionError("refused"))
+
+        cm = ConnectionManager(server_url="http://localhost:8000", team_id="t1")
+        cm._ws_client = old_ws
+        cm._state = ConnectionState.CONNECTED
+
+        with patch(_WS_CLIENT_PATH, return_value=new_ws):
+            with pytest.raises(WsConnectionError):
+                await cm.switch_team("bad-team")
+
+        assert cm.team_id == "t1"
+        assert cm._ws_client is old_ws
+        old_ws.close.assert_not_called()
+
+
+class TestClose:
+    """AC #2: close() method."""
+
+    async def test_close(self) -> None:
+        cm = ConnectionManager(server_url="http://localhost:8000", team_id="t1")
+        mock_ws = AsyncMock()
+        cm._ws_client = mock_ws
+        cm._state = ConnectionState.CONNECTED
+
+        await cm.close()
+
+        mock_ws.close.assert_called_once()
+        assert cm._ws_client is None
+        assert cm.state == ConnectionState.DISCONNECTED
+
+    async def test_close_when_not_connected(self) -> None:
+        cm = ConnectionManager(server_url="http://localhost:8000", team_id="t1")
+
+        await cm.close()  # Should not raise
+
+        assert cm.state == ConnectionState.DISCONNECTED
+
+
+class TestContextManager:
+    """Context manager support."""
+
+    async def test_context_manager(self) -> None:
+        mock_ws = AsyncMock()
+        mock_ws.connect = AsyncMock(return_value=mock_ws)
+
+        with patch(_WS_CLIENT_PATH, return_value=mock_ws):
+            cm = ConnectionManager(server_url="http://localhost:8000", team_id="t1")
+            async with cm as conn:
+                assert conn is cm
+                assert cm.state == ConnectionState.CONNECTED
+
+        assert cm.state == ConnectionState.DISCONNECTED
+
+
+class TestCheckHealth:
+    """AC #6: Health monitoring."""
+
+    async def test_ping_when_idle(self) -> None:
+        """AC #6: Ping sent when no event for 60+ seconds."""
+        cm = ConnectionManager(server_url="http://localhost:8000", team_id="t1")
+        mock_ws_internal = AsyncMock()
+        mock_ws = MagicMock()
+        mock_ws._ws = mock_ws_internal
+        cm._ws_client = mock_ws
+        cm._state = ConnectionState.CONNECTED
+        cm._last_event_time = 0.0  # long ago
+
+        await cm.check_health()
+
+        mock_ws_internal.ping.assert_called_once()
+
+    async def test_no_ping_when_recent_event(self) -> None:
+        """AC #6: No ping when events are recent."""
+        import time
+
+        cm = ConnectionManager(server_url="http://localhost:8000", team_id="t1")
+        mock_ws_internal = AsyncMock()
+        mock_ws = MagicMock()
+        mock_ws._ws = mock_ws_internal
+        cm._ws_client = mock_ws
+        cm._state = ConnectionState.CONNECTED
+        cm._last_event_time = time.monotonic()  # just now
+
+        await cm.check_health()
+
+        mock_ws_internal.ping.assert_not_called()
+
+    async def test_ping_failure_triggers_reconnect(self) -> None:
+        """AC #6: Failed ping triggers reconnect."""
+        cm = ConnectionManager(server_url="http://localhost:8000", team_id="t1")
+        mock_ws_internal = AsyncMock()
+        mock_ws_internal.ping = AsyncMock(side_effect=ConnectionError("dead"))
+        mock_ws = MagicMock()
+        mock_ws._ws = mock_ws_internal
+        cm._ws_client = mock_ws
+        cm._state = ConnectionState.CONNECTED
+        cm._last_event_time = 0.0
+
+        cm._reconnect = AsyncMock()  # type: ignore[method-assign]
+
+        await cm.check_health()
+
+        cm._reconnect.assert_called_once()

--- a/tests/cli/test_cli_connection.py
+++ b/tests/cli/test_cli_connection.py
@@ -209,6 +209,28 @@ class TestReceiveEvent:
         cm._reconnect.assert_called_once()
         assert event == {"type": "after_reconnect"}
 
+    async def test_receive_propagates_reconnect_failure(self) -> None:
+        """AC #5: WsConnectionError propagates when reconnect exhausted."""
+        cm = ConnectionManager(server_url="http://localhost:8000", team_id="t1")
+        mock_ws = AsyncMock()
+        mock_ws.receive_event = AsyncMock(
+            side_effect=websockets.exceptions.ConnectionClosedError(
+                rcvd=None, sent=None
+            )
+        )
+        cm._ws_client = mock_ws
+        cm._state = ConnectionState.CONNECTED
+
+        # Mock _reconnect to raise (retries exhausted)
+        cm._reconnect = AsyncMock(  # type: ignore[method-assign]
+            side_effect=WsConnectionError(
+                "Reconnection failed after 10 attempts", retryable=False
+            )
+        )
+
+        with pytest.raises(WsConnectionError, match="Reconnection failed"):
+            await cm.receive_event()
+
 
 class TestSwitchTeam:
     """AC #7: Atomic team switch."""
@@ -294,40 +316,36 @@ class TestCheckHealth:
     async def test_ping_when_idle(self) -> None:
         """AC #6: Ping sent when no event for 60+ seconds."""
         cm = ConnectionManager(server_url="http://localhost:8000", team_id="t1")
-        mock_ws_internal = AsyncMock()
-        mock_ws = MagicMock()
-        mock_ws._ws = mock_ws_internal
+        mock_ws = AsyncMock()
+        mock_ws.ping = AsyncMock()
         cm._ws_client = mock_ws
         cm._state = ConnectionState.CONNECTED
         cm._last_event_time = 0.0  # long ago
 
         await cm.check_health()
 
-        mock_ws_internal.ping.assert_called_once()
+        mock_ws.ping.assert_called_once()
 
     async def test_no_ping_when_recent_event(self) -> None:
         """AC #6: No ping when events are recent."""
         import time
 
         cm = ConnectionManager(server_url="http://localhost:8000", team_id="t1")
-        mock_ws_internal = AsyncMock()
-        mock_ws = MagicMock()
-        mock_ws._ws = mock_ws_internal
+        mock_ws = AsyncMock()
+        mock_ws.ping = AsyncMock()
         cm._ws_client = mock_ws
         cm._state = ConnectionState.CONNECTED
         cm._last_event_time = time.monotonic()  # just now
 
         await cm.check_health()
 
-        mock_ws_internal.ping.assert_not_called()
+        mock_ws.ping.assert_not_called()
 
     async def test_ping_failure_triggers_reconnect(self) -> None:
         """AC #6: Failed ping triggers reconnect."""
         cm = ConnectionManager(server_url="http://localhost:8000", team_id="t1")
-        mock_ws_internal = AsyncMock()
-        mock_ws_internal.ping = AsyncMock(side_effect=ConnectionError("dead"))
-        mock_ws = MagicMock()
-        mock_ws._ws = mock_ws_internal
+        mock_ws = AsyncMock()
+        mock_ws.ping = AsyncMock(side_effect=ConnectionError("dead"))
         cm._ws_client = mock_ws
         cm._state = ConnectionState.CONNECTED
         cm._last_event_time = 0.0

--- a/tests/cli/test_cli_event_router.py
+++ b/tests/cli/test_cli_event_router.py
@@ -1,0 +1,245 @@
+"""Tests for EventRouter -- event routing and dispatch."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+from unittest.mock import MagicMock
+
+from akgentic.infra.cli.event_router import EventRouter
+from tests.fixtures.events import (
+    make_error_message,
+    make_event_message,
+    make_sent_message,
+    make_start_message,
+    make_tool_call_event,
+)
+
+from .conftest import captured_renderer as _captured_renderer
+
+
+def _make_router(
+    renderer: Any = None,
+    on_human_input: Any = None,
+) -> tuple[EventRouter, Any]:
+    """Build an EventRouter with a captured renderer."""
+    if renderer is None:
+        renderer, buf = _captured_renderer()
+    else:
+        buf = None
+    router = EventRouter(renderer, on_human_input=on_human_input)
+    return router, buf
+
+
+class TestRouteSentMessage:
+    def test_valid_sent_message_renders(self) -> None:
+        renderer, buf = _captured_renderer()
+        router = EventRouter(renderer)
+        result = router.route({"event": make_sent_message(content="hello")})
+        assert result is True
+        out = buf.getvalue()
+        assert "sender" in out
+        assert "hello" in out
+
+    def test_sent_message_empty_content_returns_false(self) -> None:
+        renderer, buf = _captured_renderer()
+        router = EventRouter(renderer)
+        result = router.route({"event": make_sent_message(content="")})
+        assert result is False
+
+    def test_sent_message_dict_sender(self) -> None:
+        renderer, buf = _captured_renderer()
+        router = EventRouter(renderer)
+        result = router.route({"event": make_sent_message(content="from dict sender")})
+        assert result is True
+        out = buf.getvalue()
+        assert "sender" in out
+        assert "from dict sender" in out
+
+
+class TestRouteErrorMessage:
+    def test_valid_error_message_renders(self) -> None:
+        renderer, buf = _captured_renderer()
+        router = EventRouter(renderer)
+        result = router.route(
+            {"event": make_error_message(exception_value="something broke")}
+        )
+        assert result is True
+        out = buf.getvalue()
+        assert "error" in out
+        assert "something broke" in out
+
+
+class TestRouteToolCall:
+    def test_tool_call_renders(self) -> None:
+        renderer, buf = _captured_renderer()
+        router = EventRouter(renderer)
+        result = router.route(
+            {"event": make_event_message(event=make_tool_call_event(tool_name="search"))}
+        )
+        assert result is True
+        out = buf.getvalue()
+        assert "search" in out
+
+
+class TestRouteHumanInput:
+    def test_human_input_invokes_callback(self) -> None:
+        renderer, buf = _captured_renderer()
+        callback = MagicMock()
+        router = EventRouter(renderer, on_human_input=callback)
+        data = {
+            "id": "msg-123",
+            "sender": {"name": "Agent"},
+            "event": {
+                "__model__": "EventMessage",
+                "event": {
+                    "__model__": "HumanInputRequest",
+                    "prompt": "Enter your name",
+                },
+            },
+        }
+        result = router.route(data)
+        assert result is True
+        out = buf.getvalue()
+        assert "Human Input Required" in out
+        assert "Enter your name" in out
+        callback.assert_called_once_with("msg-123", "Agent")
+
+    def test_human_input_renders_without_callback(self) -> None:
+        renderer, buf = _captured_renderer()
+        router = EventRouter(renderer, on_human_input=None)
+        data = {
+            "event": {
+                "__model__": "EventMessage",
+                "event": {
+                    "__model__": "HumanInputRequest",
+                    "prompt": "Please provide input",
+                },
+            },
+        }
+        result = router.route(data)
+        assert result is True
+        out = buf.getvalue()
+        assert "Human Input Required" in out
+
+
+class TestRouteUnknownModel:
+    def test_unknown_model_returns_false(self) -> None:
+        renderer, buf = _captured_renderer()
+        router = EventRouter(renderer)
+        result = router.route({"event": make_start_message()})
+        assert result is False
+
+
+class TestRouteMalformedEvents:
+    def test_missing_model_returns_false(self) -> None:
+        renderer, buf = _captured_renderer()
+        logger = logging.getLogger("test.event_router")
+        router = EventRouter(renderer, logger=logger)
+        result = router.route({"event": {"data": "no model"}})
+        assert result is False
+
+    def test_empty_dict_returns_false(self) -> None:
+        renderer, buf = _captured_renderer()
+        router = EventRouter(renderer)
+        result = router.route({})
+        assert result is False
+
+
+class TestRouteJsonStringEvent:
+    def test_json_string_event_payload(self) -> None:
+        renderer, buf = _captured_renderer()
+        router = EventRouter(renderer)
+        import json
+
+        event_payload = json.dumps(
+            {
+                "__model__": "some.module.SentMessage",
+                "sender": "Agent",
+                "message": {"content": "hi"},
+            }
+        )
+        result = router.route({"event": event_payload})
+        assert result is True
+        out = buf.getvalue()
+        assert "hi" in out
+
+    def test_invalid_json_string_returns_false(self) -> None:
+        renderer, buf = _captured_renderer()
+        logger = logging.getLogger("test.event_router")
+        router = EventRouter(renderer, logger=logger)
+        result = router.route({"event": "not valid json {{"})
+        assert result is False
+
+
+class TestNotifyHumanInput:
+    def test_extracts_id_and_sender(self) -> None:
+        renderer, buf = _captured_renderer()
+        callback = MagicMock()
+        router = EventRouter(renderer, on_human_input=callback)
+        data = {
+            "id": "msg-456",
+            "sender": {"name": "BotX"},
+            "event": {
+                "__model__": "EventMessage",
+                "event": {
+                    "__model__": "HumanInputRequest",
+                    "prompt": "question?",
+                },
+            },
+        }
+        router.route(data)
+        callback.assert_called_once_with("msg-456", "BotX")
+
+    def test_missing_id_callback_not_invoked(self) -> None:
+        renderer, buf = _captured_renderer()
+        callback = MagicMock()
+        router = EventRouter(renderer, on_human_input=callback)
+        data = {
+            "sender": {"name": "BotX"},
+            "event": {
+                "__model__": "EventMessage",
+                "event": {
+                    "__model__": "HumanInputRequest",
+                    "prompt": "question?",
+                },
+            },
+        }
+        router.route(data)
+        callback.assert_not_called()
+
+    def test_none_id_callback_not_invoked(self) -> None:
+        renderer, buf = _captured_renderer()
+        callback = MagicMock()
+        router = EventRouter(renderer, on_human_input=callback)
+        data = {
+            "id": None,
+            "sender": {"name": "BotX"},
+            "event": {
+                "__model__": "EventMessage",
+                "event": {
+                    "__model__": "HumanInputRequest",
+                    "prompt": "question?",
+                },
+            },
+        }
+        router.route(data)
+        callback.assert_not_called()
+
+    def test_string_sender_extracted(self) -> None:
+        renderer, buf = _captured_renderer()
+        callback = MagicMock()
+        router = EventRouter(renderer, on_human_input=callback)
+        data = {
+            "id": "msg-789",
+            "sender": "SimpleAgent",
+            "event": {
+                "__model__": "EventMessage",
+                "event": {
+                    "__model__": "HumanInputRequest",
+                    "prompt": "q?",
+                },
+            },
+        }
+        router.route(data)
+        callback.assert_called_once_with("msg-789", "SimpleAgent")

--- a/tests/cli/test_cli_event_router.py
+++ b/tests/cli/test_cli_event_router.py
@@ -61,9 +61,7 @@ class TestRouteErrorMessage:
     def test_valid_error_message_renders(self) -> None:
         renderer, buf = _captured_renderer()
         router = EventRouter(renderer)
-        result = router.route(
-            {"event": make_error_message(exception_value="something broke")}
-        )
+        result = router.route({"event": make_error_message(exception_value="something broke")})
         assert result is True
         out = buf.getvalue()
         assert "error" in out
@@ -243,3 +241,88 @@ class TestNotifyHumanInput:
         }
         router.route(data)
         callback.assert_called_once_with("msg-789", "SimpleAgent")
+
+
+class TestToolCallArgFormats:
+    def test_dict_arguments_rendered_as_json(self) -> None:
+        renderer, buf = _captured_renderer()
+        router = EventRouter(renderer)
+        data = {
+            "event": {
+                "__model__": "EventMessage",
+                "event": {
+                    "tool_name": "search",
+                    "arguments": {"query": "test", "limit": 10},
+                    "result": {"items": ["a", "b"]},
+                },
+            },
+        }
+        result = router.route(data)
+        assert result is True
+        out = buf.getvalue()
+        assert "search" in out
+
+    def test_list_arguments_rendered_as_json(self) -> None:
+        renderer, buf = _captured_renderer()
+        router = EventRouter(renderer)
+        data = {
+            "event": {
+                "__model__": "EventMessage",
+                "event": {
+                    "tool_name": "multi_search",
+                    "arguments": ["query1", "query2"],
+                    "result": None,
+                },
+            },
+        }
+        result = router.route(data)
+        assert result is True
+        out = buf.getvalue()
+        assert "multi_search" in out
+
+
+class TestNestedEventJsonString:
+    def test_nested_event_json_string_parsed(self) -> None:
+        """EventMessage with a JSON-string nested event should be parsed."""
+        import json
+
+        renderer, buf = _captured_renderer()
+        router = EventRouter(renderer)
+        nested = json.dumps({"tool_name": "calc", "arguments": "2+2", "result": "4"})
+        data = {
+            "event": {
+                "__model__": "EventMessage",
+                "event": nested,
+            },
+        }
+        result = router.route(data)
+        assert result is True
+        out = buf.getvalue()
+        assert "calc" in out
+
+    def test_nested_event_invalid_json_string_returns_false(self) -> None:
+        renderer, buf = _captured_renderer()
+        router = EventRouter(renderer)
+        data = {
+            "event": {
+                "__model__": "EventMessage",
+                "event": "not valid json {{",
+            },
+        }
+        result = router.route(data)
+        assert result is False
+
+    def test_nested_event_non_dict_returns_false(self) -> None:
+        """If nested event parses to a non-dict (e.g., list), return False."""
+        import json
+
+        renderer, buf = _captured_renderer()
+        router = EventRouter(renderer)
+        data = {
+            "event": {
+                "__model__": "EventMessage",
+                "event": json.dumps([1, 2, 3]),
+            },
+        }
+        result = router.route(data)
+        assert result is False

--- a/tests/cli/test_cli_main.py
+++ b/tests/cli/test_cli_main.py
@@ -23,29 +23,29 @@ def _mock_state() -> MagicMock:
 
 
 @pytest.fixture()
-def _mock_ws() -> AsyncMock:
-    """Patch WsClient constructor."""
-    ws = AsyncMock()
-    ws.__aenter__ = AsyncMock(return_value=ws)
-    ws.__aexit__ = AsyncMock(return_value=None)
-    with patch("akgentic.infra.cli.main.WsClient", return_value=ws):
-        yield ws
+def _mock_conn() -> AsyncMock:
+    """Patch ConnectionManager constructor."""
+    conn = AsyncMock()
+    conn.__aenter__ = AsyncMock(return_value=conn)
+    conn.__aexit__ = AsyncMock(return_value=None)
+    with patch("akgentic.infra.cli.main.ConnectionManager", return_value=conn):
+        yield conn
 
 
 class TestChatErrorBoundary:
     """Test the top-level error boundary in chat()."""
 
     def test_api_error_renders_error_and_exits(
-        self, _mock_state: MagicMock, _mock_ws: AsyncMock
+        self, _mock_state: MagicMock, _mock_conn: AsyncMock
     ) -> None:
         """ApiError during session.run() renders error and exits cleanly."""
         error = ApiError(500, "internal server error")
         with (
-            patch("akgentic.infra.cli.main.RichRenderer") as MockRenderer,
+            patch("akgentic.infra.cli.main.RichRenderer") as mock_renderer_cls,
             patch("akgentic.infra.cli.main.ChatSession"),
             patch("akgentic.infra.cli.main.asyncio") as mock_asyncio,
         ):
-            renderer_instance = MockRenderer.return_value
+            renderer_instance = mock_renderer_cls.return_value
             mock_asyncio.run.side_effect = error
 
             from akgentic.infra.cli.main import chat
@@ -59,16 +59,16 @@ class TestChatErrorBoundary:
             _mock_state.client.close.assert_called_once()
 
     def test_ws_connection_error_renders_error_and_exits(
-        self, _mock_state: MagicMock, _mock_ws: AsyncMock
+        self, _mock_state: MagicMock, _mock_conn: AsyncMock
     ) -> None:
         """WsConnectionError during session.run() renders error and exits cleanly."""
         error = WsConnectionError("refused")
         with (
-            patch("akgentic.infra.cli.main.RichRenderer") as MockRenderer,
+            patch("akgentic.infra.cli.main.RichRenderer") as mock_renderer_cls,
             patch("akgentic.infra.cli.main.ChatSession"),
             patch("akgentic.infra.cli.main.asyncio") as mock_asyncio,
         ):
-            renderer_instance = MockRenderer.return_value
+            renderer_instance = mock_renderer_cls.return_value
             mock_asyncio.run.side_effect = error
 
             from akgentic.infra.cli.main import chat
@@ -82,16 +82,16 @@ class TestChatErrorBoundary:
             _mock_state.client.close.assert_called_once()
 
     def test_generic_exception_renders_error_and_exits(
-        self, _mock_state: MagicMock, _mock_ws: AsyncMock
+        self, _mock_state: MagicMock, _mock_conn: AsyncMock
     ) -> None:
         """Generic Exception during session.run() renders error and exits cleanly."""
         error = RuntimeError("something broke")
         with (
-            patch("akgentic.infra.cli.main.RichRenderer") as MockRenderer,
+            patch("akgentic.infra.cli.main.RichRenderer") as mock_renderer_cls,
             patch("akgentic.infra.cli.main.ChatSession"),
             patch("akgentic.infra.cli.main.asyncio") as mock_asyncio,
         ):
-            renderer_instance = MockRenderer.return_value
+            renderer_instance = mock_renderer_cls.return_value
             mock_asyncio.run.side_effect = error
 
             from akgentic.infra.cli.main import chat
@@ -105,15 +105,15 @@ class TestChatErrorBoundary:
             _mock_state.client.close.assert_called_once()
 
     def test_keyboard_interrupt_exits_cleanly(
-        self, _mock_state: MagicMock, _mock_ws: AsyncMock
+        self, _mock_state: MagicMock, _mock_conn: AsyncMock
     ) -> None:
         """KeyboardInterrupt during session.run() exits without error message."""
         with (
-            patch("akgentic.infra.cli.main.RichRenderer") as MockRenderer,
+            patch("akgentic.infra.cli.main.RichRenderer") as mock_renderer_cls,
             patch("akgentic.infra.cli.main.ChatSession"),
             patch("akgentic.infra.cli.main.asyncio") as mock_asyncio,
         ):
-            renderer_instance = MockRenderer.return_value
+            renderer_instance = mock_renderer_cls.return_value
             mock_asyncio.run.side_effect = KeyboardInterrupt
 
             from akgentic.infra.cli.main import chat
@@ -125,7 +125,7 @@ class TestChatErrorBoundary:
             _mock_state.client.close.assert_called_once()
 
     def test_client_close_called_on_success(
-        self, _mock_state: MagicMock, _mock_ws: AsyncMock
+        self, _mock_state: MagicMock, _mock_conn: AsyncMock
     ) -> None:
         """client.close() is called even on successful exit."""
         with (

--- a/tests/cli/test_cli_repl.py
+++ b/tests/cli/test_cli_repl.py
@@ -6,8 +6,6 @@ import asyncio
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
-import websockets.exceptions
-
 from akgentic.infra.cli.client import ApiError, EventInfo
 from akgentic.infra.cli.commands import build_default_registry
 from akgentic.infra.cli.formatters import OutputFormat
@@ -18,6 +16,7 @@ from akgentic.infra.cli.repl import (
     _render_event_impl,
     _SlashCompleter,
 )
+from akgentic.infra.cli.ws_client import WsConnectionError
 from tests.fixtures.events import (
     make_error_message,
     make_event_message,
@@ -30,7 +29,7 @@ from tests.fixtures.events import (
 
 from .conftest import captured_renderer as _captured_renderer
 from .conftest import mock_client as _shared_mock_client
-from .conftest import mock_ws as _mock_ws
+from .conftest import mock_conn as _mock_conn
 
 _PROMPT_PATH = "prompt_toolkit.PromptSession.prompt"
 
@@ -44,15 +43,15 @@ def _mock_client(**overrides: Any) -> MagicMock:
 
 def _make_session(
     client: MagicMock | None = None,
-    ws: AsyncMock | None = None,
+    conn: AsyncMock | None = None,
     renderer: RichRenderer | None = None,
 ) -> ChatSession:
     """Create a ChatSession with mocked dependencies and optional captured renderer."""
     if client is None:
         client = _mock_client()
-    if ws is None:
-        ws = _mock_ws()
-    return ChatSession(client, ws, "t1", OutputFormat.table, renderer=renderer)
+    if conn is None:
+        conn = _mock_conn()
+    return ChatSession(client, conn, "t1", OutputFormat.table, renderer=renderer)
 
 
 class TestReplayHistory:
@@ -178,7 +177,7 @@ class TestReceiveLoop:
             {"event": make_sent_message(content="hi there")},
         ]
         client = _mock_client()
-        ws = _mock_ws()
+        conn = _mock_conn()
         call_count = 0
 
         async def recv_events() -> dict[str, Any]:
@@ -190,8 +189,8 @@ class TestReceiveLoop:
             await asyncio.sleep(10)
             return {}
 
-        ws.receive_event = AsyncMock(side_effect=recv_events)
-        session = _make_session(client=client, ws=ws, renderer=renderer)
+        conn.receive_event = AsyncMock(side_effect=recv_events)
+        session = _make_session(client=client, conn=conn, renderer=renderer)
 
         with patch(
             _PROMPT_PATH,
@@ -209,7 +208,7 @@ class TestReceiveLoop:
             {"event": {"__model__": "StateChangedMessage", "state": "running"}},
         ]
         client = _mock_client()
-        ws = _mock_ws()
+        conn = _mock_conn()
         call_count = 0
 
         async def recv_events() -> dict[str, Any]:
@@ -221,8 +220,8 @@ class TestReceiveLoop:
             await asyncio.sleep(10)
             return {}
 
-        ws.receive_event = AsyncMock(side_effect=recv_events)
-        session = _make_session(client=client, ws=ws, renderer=renderer)
+        conn.receive_event = AsyncMock(side_effect=recv_events)
+        session = _make_session(client=client, conn=conn, renderer=renderer)
 
         with patch(
             _PROMPT_PATH,
@@ -234,41 +233,23 @@ class TestReceiveLoop:
         assert "StateChanged" not in out
 
 
-class TestReceiveLoopCloseCode:
-    async def test_close_code_4004_prints_error(self) -> None:
+class TestReceiveLoopConnectionError:
+    async def test_ws_connection_error_prints_error(self) -> None:
+        """WsConnectionError (reconnection exhausted) renders error and breaks loop."""
         renderer, buf = _captured_renderer()
-        close_frame = MagicMock()
-        close_frame.code = 4004
-        close_frame.reason = "Team not found"
-        exc = websockets.exceptions.ConnectionClosedError(rcvd=close_frame, sent=None)
         client = _mock_client()
-        ws = _mock_ws()
-        ws.receive_event = AsyncMock(side_effect=exc)
-        session = _make_session(client=client, ws=ws, renderer=renderer)
+        conn = _mock_conn()
+        conn.receive_event = AsyncMock(
+            side_effect=WsConnectionError("Reconnection failed after 10 attempts", retryable=False)
+        )
+        session = _make_session(client=client, conn=conn, renderer=renderer)
 
         with patch(_PROMPT_PATH, side_effect=["/quit"]):
             await session.run()
 
         out = buf.getvalue()
-        assert "team not found" in out
-
-    async def test_close_code_1000_no_error(self) -> None:
-        renderer, buf = _captured_renderer()
-        close_frame = MagicMock()
-        close_frame.code = 1000
-        close_frame.reason = "OK"
-        exc = websockets.exceptions.ConnectionClosedOK(rcvd=close_frame, sent=None)
-        client = _mock_client()
-        ws = _mock_ws()
-        ws.receive_event = AsyncMock(side_effect=exc)
-        session = _make_session(client=client, ws=ws, renderer=renderer)
-
-        with patch(_PROMPT_PATH, side_effect=["/quit"]):
-            await session.run()
-
-        out = buf.getvalue()
-        # Should NOT contain connection error — only system messages (Connected, Session closed)
-        assert "Connection closed" not in out
+        assert "Connection lost" in out
+        assert "Reconnection failed" in out
 
 
 class TestRenderEvent:

--- a/tests/cli/test_cli_repl.py
+++ b/tests/cli/test_cli_repl.py
@@ -493,6 +493,25 @@ class TestImplicitHumanInputReplyRouting:
         assert session._pending_reply_id is None
         assert session._pending_agent_name is None
 
+    async def test_pending_preserved_on_api_error(self) -> None:
+        """Safe reply clearing: pending state preserved when human_input() fails."""
+        renderer, buf = _captured_renderer()
+        client = _mock_client()
+        client.human_input.side_effect = ApiError(500, "server error")
+        session = _make_session(client=client, renderer=renderer)
+        session._pending_reply_id = "msg-abc"
+        session._pending_agent_name = "AgentX"
+
+        with patch(_PROMPT_PATH, side_effect=["my answer", "/quit"]):
+            await session.run()
+
+        client.human_input.assert_called_once_with("t1", "my answer", "msg-abc")
+        # Pending should still be set — not cleared on error
+        assert session._pending_reply_id == "msg-abc"
+        assert session._pending_agent_name == "AgentX"
+        out = buf.getvalue()
+        assert "Error sending reply" in out
+
     # -- AC #5: no pending sends normal message --
 
     async def test_no_pending_sends_normal_message(self) -> None:

--- a/tests/cli/test_cli_repl.py
+++ b/tests/cli/test_cli_repl.py
@@ -10,8 +10,12 @@ from akgentic.infra.cli.client import ApiError, EventInfo
 from akgentic.infra.cli.commands import build_default_registry
 from akgentic.infra.cli.formatters import OutputFormat
 from akgentic.infra.cli.renderers import RichRenderer
+from akgentic.infra.cli.connection import ConnectionState
 from akgentic.infra.cli.repl import (
     ChatSession,
+    InputMode,
+    ReplyContext,
+    SessionState,
     _print_event,
     _render_event_impl,
     _SlashCompleter,
@@ -114,7 +118,7 @@ class TestQuitHandling:
         out = buf.getvalue()
         assert "Session closed." in out
         # Team info fetched for status bar
-        assert session._team_name != ""
+        assert session._state.team_name != "(unknown)"
 
     async def test_ctrl_c_exits(self) -> None:
         renderer, buf = _captured_renderer()
@@ -450,8 +454,10 @@ class TestImplicitHumanInputReplyRouting:
         session = _make_session(renderer=renderer)
         data = self._human_input_event()
         session._render_event(data)
-        assert session._pending_reply_id == "msg-uuid-123"
-        assert session._pending_agent_name == "AgentX"
+        assert session._state.input_mode == InputMode.REPLY
+        assert session._state.reply_context is not None
+        assert session._state.reply_context.reply_id == "msg-uuid-123"
+        assert session._state.reply_context.agent_name == "AgentX"
 
     def test_pending_set_on_request_input_event(self) -> None:
         renderer, buf = _captured_renderer()
@@ -462,18 +468,29 @@ class TestImplicitHumanInputReplyRouting:
             agent_name="BotY",
         )
         session._render_event(data)
-        assert session._pending_reply_id == "req-456"
-        assert session._pending_agent_name == "BotY"
+        assert session._state.input_mode == InputMode.REPLY
+        assert session._state.reply_context is not None
+        assert session._state.reply_context.reply_id == "req-456"
+        assert session._state.reply_context.agent_name == "BotY"
 
     # -- AC #2: pending reply state --
 
     def test_pending_state_tracks_reply_info(self) -> None:
         session = _make_session()
-        assert session._pending_reply_id is None
-        session._pending_reply_id = "some-id"
-        session._pending_agent_name = "AgentX"
-        assert session._pending_reply_id == "some-id"
-        assert session._pending_agent_name == "AgentX"
+        assert session._state.input_mode == InputMode.CHAT
+        assert session._state.reply_context is None
+        session._state = session._state.model_copy(
+            update={
+                "input_mode": InputMode.REPLY,
+                "reply_context": ReplyContext(
+                    reply_id="some-id", agent_name="AgentX", prompt=""
+                ),
+            }
+        )
+        assert session._state.input_mode == InputMode.REPLY
+        assert session._state.reply_context is not None
+        assert session._state.reply_context.reply_id == "some-id"
+        assert session._state.reply_context.agent_name == "AgentX"
 
     # -- AC #3, #4: plain text consumes pending reply --
 
@@ -481,8 +498,14 @@ class TestImplicitHumanInputReplyRouting:
         renderer, buf = _captured_renderer()
         client = _mock_client()
         session = _make_session(client=client, renderer=renderer)
-        session._pending_reply_id = "msg-abc"
-        session._pending_agent_name = "AgentX"
+        session._state = session._state.model_copy(
+            update={
+                "input_mode": InputMode.REPLY,
+                "reply_context": ReplyContext(
+                    reply_id="msg-abc", agent_name="AgentX", prompt=""
+                ),
+            }
+        )
 
         with patch(_PROMPT_PATH, side_effect=["my answer", "/quit"]):
             await session.run()
@@ -490,8 +513,8 @@ class TestImplicitHumanInputReplyRouting:
         client.human_input.assert_called_once_with("t1", "my answer", "msg-abc")
         client.send_message.assert_not_called()
         # Pending cleared
-        assert session._pending_reply_id is None
-        assert session._pending_agent_name is None
+        assert session._state.input_mode == InputMode.CHAT
+        assert session._state.reply_context is None
 
     async def test_pending_preserved_on_api_error(self) -> None:
         """Safe reply clearing: pending state preserved when human_input() fails."""
@@ -499,16 +522,24 @@ class TestImplicitHumanInputReplyRouting:
         client = _mock_client()
         client.human_input.side_effect = ApiError(500, "server error")
         session = _make_session(client=client, renderer=renderer)
-        session._pending_reply_id = "msg-abc"
-        session._pending_agent_name = "AgentX"
+        session._state = session._state.model_copy(
+            update={
+                "input_mode": InputMode.REPLY,
+                "reply_context": ReplyContext(
+                    reply_id="msg-abc", agent_name="AgentX", prompt=""
+                ),
+            }
+        )
 
         with patch(_PROMPT_PATH, side_effect=["my answer", "/quit"]):
             await session.run()
 
         client.human_input.assert_called_once_with("t1", "my answer", "msg-abc")
         # Pending should still be set — not cleared on error
-        assert session._pending_reply_id == "msg-abc"
-        assert session._pending_agent_name == "AgentX"
+        assert session._state.input_mode == InputMode.REPLY
+        assert session._state.reply_context is not None
+        assert session._state.reply_context.reply_id == "msg-abc"
+        assert session._state.reply_context.agent_name == "AgentX"
         out = buf.getvalue()
         assert "Error sending reply" in out
 
@@ -531,15 +562,23 @@ class TestImplicitHumanInputReplyRouting:
         renderer, buf = _captured_renderer()
         client = _mock_client()
         session = _make_session(client=client, renderer=renderer)
-        session._pending_reply_id = "msg-pending"
-        session._pending_agent_name = "AgentZ"
+        session._state = session._state.model_copy(
+            update={
+                "input_mode": InputMode.REPLY,
+                "reply_context": ReplyContext(
+                    reply_id="msg-pending", agent_name="AgentZ", prompt=""
+                ),
+            }
+        )
 
         with patch(_PROMPT_PATH, side_effect=["/help", "/quit"]):
             await session.run()
 
         # Pending should still be set after slash command
-        assert session._pending_reply_id == "msg-pending"
-        assert session._pending_agent_name == "AgentZ"
+        assert session._state.input_mode == InputMode.REPLY
+        assert session._state.reply_context is not None
+        assert session._state.reply_context.reply_id == "msg-pending"
+        assert session._state.reply_context.agent_name == "AgentZ"
         client.human_input.assert_not_called()
 
     # -- backward compat: _render_event_impl without callback --
@@ -569,8 +608,10 @@ class TestImplicitHumanInputReplyRouting:
             },
         }
         session._render_event(data)
-        assert session._pending_reply_id == "msg-str-sender"
-        assert session._pending_agent_name == "SimpleAgent"
+        assert session._state.input_mode == InputMode.REPLY
+        assert session._state.reply_context is not None
+        assert session._state.reply_context.reply_id == "msg-str-sender"
+        assert session._state.reply_context.agent_name == "SimpleAgent"
 
     def test_pending_not_set_when_id_is_none(self) -> None:
         """Verify that a None id in the outer event data does not set pending state."""
@@ -588,8 +629,8 @@ class TestImplicitHumanInputReplyRouting:
             },
         }
         session._render_event(data)
-        assert session._pending_reply_id is None
-        assert session._pending_agent_name is None
+        assert session._state.input_mode == InputMode.CHAT
+        assert session._state.reply_context is None
 
     def test_pending_not_set_when_id_missing(self) -> None:
         """Verify that a missing id in the outer event data does not set pending state."""
@@ -606,13 +647,237 @@ class TestImplicitHumanInputReplyRouting:
             },
         }
         session._render_event(data)
-        assert session._pending_reply_id is None
-        assert session._pending_agent_name is None
+        assert session._state.input_mode == InputMode.CHAT
+        assert session._state.reply_context is None
 
-    def test_pending_agent_name_can_be_none(self) -> None:
-        """Verify pending state works when agent name is None."""
+    def test_session_state_defaults(self) -> None:
+        """Verify SessionState default values."""
         session = _make_session()
-        session._pending_reply_id = "some-id"
-        session._pending_agent_name = None
-        assert session._pending_reply_id == "some-id"
-        assert session._pending_agent_name is None
+        assert session._state.team_name == "(unknown)"
+        assert session._state.team_status == "?"
+        assert session._state.input_mode == InputMode.CHAT
+        assert session._state.reply_context is None
+        assert session._state.connection_state == ConnectionState.CONNECTING
+
+
+# =============================================================================
+# Story 11.3: Session State Model tests
+# =============================================================================
+
+
+class TestSessionStateModels:
+    """Tests for InputMode, ReplyContext, and SessionState models."""
+
+    def test_input_mode_values(self) -> None:
+        assert InputMode.CHAT.value == "chat"
+        assert InputMode.REPLY.value == "reply"
+
+    def test_reply_context_creation(self) -> None:
+        ctx = ReplyContext(reply_id="r1", agent_name="Bot", prompt="Say hi")
+        assert ctx.reply_id == "r1"
+        assert ctx.agent_name == "Bot"
+        assert ctx.prompt == "Say hi"
+
+    def test_session_state_defaults(self) -> None:
+        state = SessionState(team_id="t1")
+        assert state.team_id == "t1"
+        assert state.team_name == "(unknown)"
+        assert state.team_status == "?"
+        assert state.input_mode == InputMode.CHAT
+        assert state.reply_context is None
+        assert state.connection_state == ConnectionState.CONNECTING
+
+    def test_session_state_model_copy_transitions(self) -> None:
+        state = SessionState(team_id="t1")
+        updated = state.model_copy(
+            update={
+                "input_mode": InputMode.REPLY,
+                "reply_context": ReplyContext(reply_id="r1", agent_name="A", prompt=""),
+            }
+        )
+        assert updated.input_mode == InputMode.REPLY
+        assert updated.reply_context is not None
+        assert updated.reply_context.reply_id == "r1"
+        # Original unchanged
+        assert state.input_mode == InputMode.CHAT
+
+    def test_session_state_connection_state_update(self) -> None:
+        state = SessionState(team_id="t1")
+        updated = state.model_copy(update={"connection_state": ConnectionState.CONNECTED})
+        assert updated.connection_state == ConnectionState.CONNECTED
+
+
+class TestGetPrompt:
+    """Tests for ChatSession._get_prompt() dynamic prompt."""
+
+    def test_normal_chat_connected(self) -> None:
+        session = _make_session()
+        session._state = session._state.model_copy(
+            update={"connection_state": ConnectionState.CONNECTED}
+        )
+        assert session._get_prompt() == "> "
+
+    def test_disconnected(self) -> None:
+        session = _make_session()
+        session._state = session._state.model_copy(
+            update={"connection_state": ConnectionState.DISCONNECTED}
+        )
+        assert session._get_prompt() == "[disconnected] > "
+
+    def test_reconnecting(self) -> None:
+        session = _make_session()
+        session._state = session._state.model_copy(
+            update={"connection_state": ConnectionState.RECONNECTING}
+        )
+        assert session._get_prompt() == "[reconnecting...] > "
+
+    def test_reply_mode(self) -> None:
+        session = _make_session()
+        session._state = session._state.model_copy(
+            update={
+                "connection_state": ConnectionState.CONNECTED,
+                "input_mode": InputMode.REPLY,
+                "reply_context": ReplyContext(
+                    reply_id="r1", agent_name="AgentX", prompt=""
+                ),
+            }
+        )
+        assert session._get_prompt() == "Reply to AgentX: "
+
+    def test_disconnected_overrides_reply_mode(self) -> None:
+        """Disconnected state takes priority over reply mode."""
+        session = _make_session()
+        session._state = session._state.model_copy(
+            update={
+                "connection_state": ConnectionState.DISCONNECTED,
+                "input_mode": InputMode.REPLY,
+                "reply_context": ReplyContext(
+                    reply_id="r1", agent_name="AgentX", prompt=""
+                ),
+            }
+        )
+        assert session._get_prompt() == "[disconnected] > "
+
+
+class TestConnectionAwareSending:
+    """Tests for connection-aware message sending behavior."""
+
+    async def test_connected_sends_normally(self) -> None:
+        renderer, buf = _captured_renderer()
+        client = _mock_client()
+        session = _make_session(client=client, renderer=renderer)
+        session._state = session._state.model_copy(
+            update={"connection_state": ConnectionState.CONNECTED}
+        )
+
+        with patch(_PROMPT_PATH, side_effect=["hello", "/quit"]):
+            await session.run()
+
+        client.send_message.assert_called_once_with("t1", "hello")
+
+    async def test_disconnected_blocks_send(self) -> None:
+        renderer, buf = _captured_renderer()
+        client = _mock_client()
+        session = _make_session(client=client, renderer=renderer)
+        session._state = session._state.model_copy(
+            update={"connection_state": ConnectionState.DISCONNECTED}
+        )
+
+        with patch(_PROMPT_PATH, side_effect=["hello", "/quit"]):
+            await session.run()
+
+        client.send_message.assert_not_called()
+        out = buf.getvalue()
+        assert "Not connected" in out
+        assert "/reconnect" in out
+
+    async def test_reconnecting_buffers_message(self) -> None:
+        renderer, buf = _captured_renderer()
+        client = _mock_client()
+        session = _make_session(client=client, renderer=renderer)
+        session._state = session._state.model_copy(
+            update={"connection_state": ConnectionState.RECONNECTING}
+        )
+
+        with patch(_PROMPT_PATH, side_effect=["buffered msg", "/quit"]):
+            await session.run()
+
+        client.send_message.assert_not_called()
+        assert "buffered msg" in session._message_buffer
+        out = buf.getvalue()
+        assert "Reconnecting" in out
+        assert "connection is restored" in out
+
+    async def test_buffer_flushed_on_connected(self) -> None:
+        """Buffered messages are flushed when connection state transitions to CONNECTED."""
+        client = _mock_client()
+        session = _make_session(client=client)
+        session._message_buffer = ["msg1", "msg2"]
+        # Trigger the on_state_change callback with CONNECTED
+        session.conn._on_state_change(ConnectionState.CONNECTED)
+        assert session._message_buffer == []
+        assert client.send_message.call_count == 2
+        client.send_message.assert_any_call("t1", "msg1")
+        client.send_message.assert_any_call("t1", "msg2")
+
+    async def test_disconnected_blocks_reply_send(self) -> None:
+        renderer, buf = _captured_renderer()
+        client = _mock_client()
+        session = _make_session(client=client, renderer=renderer)
+        session._state = session._state.model_copy(
+            update={
+                "connection_state": ConnectionState.DISCONNECTED,
+                "input_mode": InputMode.REPLY,
+                "reply_context": ReplyContext(
+                    reply_id="r1", agent_name="Agent", prompt=""
+                ),
+            }
+        )
+
+        with patch(_PROMPT_PATH, side_effect=["my reply", "/quit"]):
+            await session.run()
+
+        client.human_input.assert_not_called()
+        out = buf.getvalue()
+        assert "Not connected" in out
+
+    async def test_reconnecting_buffers_reply(self) -> None:
+        renderer, buf = _captured_renderer()
+        client = _mock_client()
+        session = _make_session(client=client, renderer=renderer)
+        session._state = session._state.model_copy(
+            update={
+                "connection_state": ConnectionState.RECONNECTING,
+                "input_mode": InputMode.REPLY,
+                "reply_context": ReplyContext(
+                    reply_id="r1", agent_name="Agent", prompt=""
+                ),
+            }
+        )
+
+        with patch(_PROMPT_PATH, side_effect=["my reply", "/quit"]):
+            await session.run()
+
+        client.human_input.assert_not_called()
+        assert "my reply" in session._message_buffer
+
+    def test_flush_buffer_handles_api_error(self) -> None:
+        renderer, buf = _captured_renderer()
+        client = _mock_client()
+        client.send_message.side_effect = ApiError(500, "fail")
+        session = _make_session(client=client, renderer=renderer)
+        session._message_buffer = ["msg1"]
+        session._flush_message_buffer()
+        assert session._message_buffer == []
+        out = buf.getvalue()
+        assert "Failed to send buffered message" in out
+
+    def test_team_id_property_getter(self) -> None:
+        session = _make_session()
+        assert session.team_id == "t1"
+
+    def test_team_id_property_setter(self) -> None:
+        session = _make_session()
+        session.team_id = "t2"
+        assert session._state.team_id == "t2"
+        assert session.team_id == "t2"

--- a/tests/cli/test_cli_repl.py
+++ b/tests/cli/test_cli_repl.py
@@ -8,9 +8,9 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 from akgentic.infra.cli.client import ApiError, EventInfo
 from akgentic.infra.cli.commands import build_default_registry
+from akgentic.infra.cli.connection import ConnectionState
 from akgentic.infra.cli.formatters import OutputFormat
 from akgentic.infra.cli.renderers import RichRenderer
-from akgentic.infra.cli.connection import ConnectionState
 from akgentic.infra.cli.repl import (
     ChatSession,
     InputMode,
@@ -650,14 +650,6 @@ class TestImplicitHumanInputReplyRouting:
         assert session._state.input_mode == InputMode.CHAT
         assert session._state.reply_context is None
 
-    def test_session_state_defaults(self) -> None:
-        """Verify SessionState default values."""
-        session = _make_session()
-        assert session._state.team_name == "(unknown)"
-        assert session._state.team_status == "?"
-        assert session._state.input_mode == InputMode.CHAT
-        assert session._state.reply_context is None
-        assert session._state.connection_state == ConnectionState.CONNECTING
 
 
 # =============================================================================

--- a/tests/cli/test_cli_team_selector.py
+++ b/tests/cli/test_cli_team_selector.py
@@ -156,3 +156,133 @@ class TestTeamSelectorBrowseStopped:
 
         assert result == "stopped-1"
         client.restore_team.assert_called_once_with("stopped-1")
+
+    def test_next_page_navigation(self) -> None:
+        renderer, buf = _captured_renderer()
+        client = _mock_client()
+        selector = TeamSelector(client, renderer)
+        stopped = _make_stopped_teams(8)  # more than _STOPPED_PAGE_SIZE
+
+        # Navigate to next page then back
+        with patch("builtins.input", side_effect=["n", "b"]):
+            result = selector._browse_stopped(stopped)
+
+        assert result is None
+
+    def test_invalid_digit_renders_error(self) -> None:
+        renderer, buf = _captured_renderer()
+        client = _mock_client()
+        selector = TeamSelector(client, renderer)
+        stopped = _make_stopped_teams(2)
+
+        with patch("builtins.input", side_effect=["9", "b"]):
+            result = selector._browse_stopped(stopped)
+
+        assert result is None
+        out = buf.getvalue()
+        assert "Invalid selection" in out
+
+    def test_unknown_choice_renders_error(self) -> None:
+        renderer, buf = _captured_renderer()
+        client = _mock_client()
+        selector = TeamSelector(client, renderer)
+        stopped = _make_stopped_teams(2)
+
+        with patch("builtins.input", side_effect=["x", "b"]):
+            result = selector._browse_stopped(stopped)
+
+        assert result is None
+        out = buf.getvalue()
+        assert "Unknown choice" in out
+
+    def test_restore_api_error_continues(self) -> None:
+        renderer, buf = _captured_renderer()
+        client = _mock_client()
+        client.restore_team.side_effect = ApiError(500, "fail")
+        selector = TeamSelector(client, renderer)
+        stopped = _make_stopped_teams(2)
+
+        with patch("builtins.input", side_effect=["1", "b"]):
+            result = selector._browse_stopped(stopped)
+
+        assert result is None
+        out = buf.getvalue()
+        assert "Failed to restore team" in out
+
+
+class TestTeamSelectorQuit:
+    def test_slash_quit_returns_none(self) -> None:
+        renderer, buf = _captured_renderer()
+        client = _mock_client()
+        selector = TeamSelector(client, renderer)
+
+        with patch("builtins.input", return_value="/quit"):
+            result = selector.run()
+
+        assert result is None
+
+
+class TestTeamSelectorInvalidDigit:
+    def test_invalid_digit_renders_error_and_loops(self) -> None:
+        renderer, buf = _captured_renderer()
+        client = _mock_client()
+        selector = TeamSelector(client, renderer)
+
+        with patch("builtins.input", side_effect=["99", "q"]):
+            result = selector.run()
+
+        assert result is None
+        out = buf.getvalue()
+        assert "Invalid selection" in out
+
+
+class TestTeamSelectorUnknownChoice:
+    def test_unknown_choice_renders_error_and_loops(self) -> None:
+        renderer, buf = _captured_renderer()
+        client = _mock_client()
+        selector = TeamSelector(client, renderer)
+
+        with patch("builtins.input", side_effect=["xyz", "q"]):
+            result = selector.run()
+
+        assert result is None
+        out = buf.getvalue()
+        assert "Unknown choice" in out
+
+
+class TestTeamSelectorBrowseStopped2:
+    def test_s_browses_stopped(self) -> None:
+        renderer, buf = _captured_renderer()
+        running = _make_running_teams(1)
+        stopped = _make_stopped_teams(2)
+        client = _mock_client(list_teams=MagicMock(return_value=running + stopped))
+        selector = TeamSelector(client, renderer)
+
+        with patch("builtins.input", side_effect=["s", "b", "q"]):
+            result = selector.run()
+
+        assert result is None
+
+
+class TestFetchTeamsError:
+    def test_fetch_teams_api_error_returns_empty(self) -> None:
+        renderer, buf = _captured_renderer()
+        client = _mock_client()
+        client.list_teams.side_effect = ApiError(500, "fail")
+        selector = TeamSelector(client, renderer)
+
+        with patch("builtins.input", return_value="q"):
+            result = selector.run()
+
+        assert result is None
+
+    def test_fetch_catalog_error_returns_empty(self) -> None:
+        renderer, buf = _captured_renderer()
+        client = _mock_client()
+        client.list_catalog_teams.side_effect = Exception("network error")
+        selector = TeamSelector(client, renderer)
+
+        with patch("builtins.input", return_value="q"):
+            result = selector.run()
+
+        assert result is None

--- a/tests/cli/test_cli_team_selector.py
+++ b/tests/cli/test_cli_team_selector.py
@@ -1,0 +1,158 @@
+"""Tests for TeamSelector -- team selection and creation flow."""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+from akgentic.infra.cli.client import ApiError, TeamInfo
+from akgentic.infra.cli.team_selector import TeamSelector, _short_id
+
+from .conftest import captured_renderer as _captured_renderer
+from .conftest import mock_client as _shared_mock_client
+
+
+def _mock_client(**overrides: Any) -> MagicMock:
+    """Build a mock ApiClient with defaults for team selector tests."""
+    return _shared_mock_client(**overrides)
+
+
+def _make_running_teams(n: int = 2) -> list[TeamInfo]:
+    """Create a list of running TeamInfo instances."""
+    return [
+        TeamInfo(
+            team_id=f"team-{i}",
+            name=f"Team {i}",
+            status="running",
+            user_id="u1",
+            created_at="2025-01-01",
+            updated_at="2025-01-01",
+        )
+        for i in range(1, n + 1)
+    ]
+
+
+def _make_stopped_teams(n: int = 2) -> list[TeamInfo]:
+    """Create a list of stopped TeamInfo instances."""
+    return [
+        TeamInfo(
+            team_id=f"stopped-{i}",
+            name=f"Stopped Team {i}",
+            status="stopped",
+            user_id="u1",
+            created_at="2025-01-01",
+            updated_at="2025-01-01",
+        )
+        for i in range(1, n + 1)
+    ]
+
+
+class TestShortId:
+    def test_truncates_long_uuid(self) -> None:
+        assert _short_id("abcdefghijklmn") == "abcdefghijklm"
+
+    def test_short_id_unchanged(self) -> None:
+        assert _short_id("abc") == "abc"
+
+    def test_exactly_13_chars(self) -> None:
+        assert _short_id("1234567890123") == "1234567890123"
+
+
+class TestTeamSelectorRun:
+    def test_digit_selection_returns_team_id(self) -> None:
+        renderer, buf = _captured_renderer()
+        running = _make_running_teams(2)
+        client = _mock_client(list_teams=MagicMock(return_value=running))
+        selector = TeamSelector(client, renderer)
+
+        with patch("builtins.input", return_value="1"):
+            result = selector.run()
+
+        assert result == "team-1"
+
+    def test_quit_returns_none(self) -> None:
+        renderer, buf = _captured_renderer()
+        client = _mock_client()
+        selector = TeamSelector(client, renderer)
+
+        with patch("builtins.input", return_value="q"):
+            result = selector.run()
+
+        assert result is None
+
+    def test_empty_input_returns_none(self) -> None:
+        renderer, buf = _captured_renderer()
+        client = _mock_client()
+        selector = TeamSelector(client, renderer)
+
+        with patch("builtins.input", return_value=""):
+            result = selector.run()
+
+        assert result is None
+
+    def test_create_returns_team_id(self) -> None:
+        renderer, buf = _captured_renderer()
+        client = _mock_client()
+        selector = TeamSelector(client, renderer)
+
+        with patch("builtins.input", return_value="c my-entry"):
+            result = selector.run()
+
+        assert result == "new"
+        client.create_team.assert_called_once_with("my-entry")
+
+
+class TestTeamSelectorHandleCreate:
+    def test_empty_entry_renders_error(self) -> None:
+        renderer, buf = _captured_renderer()
+        client = _mock_client()
+        selector = TeamSelector(client, renderer)
+        result = selector._handle_create("")
+        assert result is None
+        out = buf.getvalue()
+        assert "Usage: c" in out
+        assert "catalog_entry" in out
+
+    def test_api_error_renders_error(self) -> None:
+        renderer, buf = _captured_renderer()
+        client = _mock_client()
+        client.create_team.side_effect = ApiError(500, "fail")
+        selector = TeamSelector(client, renderer)
+        result = selector._handle_create("my-entry")
+        assert result is None
+        out = buf.getvalue()
+        assert "Failed to create team" in out
+
+
+class TestTeamSelectorBrowseStopped:
+    def test_no_stopped_teams_renders_message(self) -> None:
+        renderer, buf = _captured_renderer()
+        client = _mock_client()
+        selector = TeamSelector(client, renderer)
+        result = selector._browse_stopped([])
+        assert result is None
+        out = buf.getvalue()
+        assert "No stopped teams" in out
+
+    def test_back_returns_none(self) -> None:
+        renderer, buf = _captured_renderer()
+        client = _mock_client()
+        selector = TeamSelector(client, renderer)
+        stopped = _make_stopped_teams(2)
+
+        with patch("builtins.input", return_value="b"):
+            result = selector._browse_stopped(stopped)
+
+        assert result is None
+
+    def test_digit_restores_and_returns_team_id(self) -> None:
+        renderer, buf = _captured_renderer()
+        client = _mock_client()
+        selector = TeamSelector(client, renderer)
+        stopped = _make_stopped_teams(2)
+
+        with patch("builtins.input", return_value="1"):
+            result = selector._browse_stopped(stopped)
+
+        assert result == "stopped-1"
+        client.restore_team.assert_called_once_with("stopped-1")

--- a/tests/integration/test_repl_commands.py
+++ b/tests/integration/test_repl_commands.py
@@ -22,6 +22,7 @@ from akgentic.infra.cli.commands import (
     _restore_handler,
     _teams_handler,
 )
+from akgentic.infra.cli.repl import InputMode
 
 from ._helpers import (
     CATALOG_ENTRY_ID,
@@ -358,8 +359,10 @@ class TestReplImplicitReply:
             }
 
             session._render_event(event_data)
-            assert session._pending_reply_id == event_id
-            assert session._pending_agent_name == "@Manager"
+            assert session._state.input_mode == InputMode.REPLY
+            assert session._state.reply_context is not None
+            assert session._state.reply_context.reply_id == event_id
+            assert session._state.reply_context.agent_name == "@Manager"
         finally:
             session.client.close()
             with httpx.Client(base_url=cli_server) as c:
@@ -393,8 +396,10 @@ class TestReplImplicitReply:
                 },
             }
             session._render_event(event_data)
-            assert session._pending_reply_id == pending_id
-            assert session._pending_agent_name == "@Manager"
+            assert session._state.input_mode == InputMode.REPLY
+            assert session._state.reply_context is not None
+            assert session._state.reply_context.reply_id == pending_id
+            assert session._state.reply_context.agent_name == "@Manager"
 
             # Call human_input via the client -- the endpoint returns an error
             # since the pending_id doesn't correspond to a real server-side event.
@@ -405,11 +410,12 @@ class TestReplImplicitReply:
                 pass  # Expected: server returns error since pending_id is synthetic
 
             # Simulate the clearing that _input_loop does after sending the reply
-            # (repl.py lines 110-111: clears pending state before run_in_executor)
-            session._pending_reply_id = None
-            session._pending_agent_name = None
-            assert session._pending_reply_id is None
-            assert session._pending_agent_name is None
+            # via model_copy (same pattern as ChatSession._handle_reply)
+            session._state = session._state.model_copy(
+                update={"input_mode": InputMode.CHAT, "reply_context": None}
+            )
+            assert session._state.input_mode == InputMode.CHAT
+            assert session._state.reply_context is None
         finally:
             session.client.close()
             with httpx.Client(base_url=cli_server) as c:

--- a/tests/integration/test_repl_e2e.py
+++ b/tests/integration/test_repl_e2e.py
@@ -28,6 +28,7 @@ from akgentic.infra.cli.commands import (
     _stop_handler,
     _switch_handler,
 )
+from akgentic.infra.cli.connection import ConnectionManager
 from akgentic.infra.cli.formatters import OutputFormat
 from akgentic.infra.cli.repl import ChatSession, TeamSelector
 from akgentic.infra.cli.ws_client import WsClient
@@ -51,10 +52,10 @@ def _make_session(
 ) -> ChatSession:
     """Build a ChatSession pointing at a real smoke_server."""
     api = ApiClient(base_url=server_url)
-    ws = WsClient(base_url=server_url, team_id=team_id)
+    conn = ConnectionManager(server_url=server_url, team_id=team_id)
     return ChatSession(
         api,
-        ws,
+        conn,
         team_id,
         OutputFormat.table,
         server_url=server_url,
@@ -108,11 +109,11 @@ def _cleanup_team(server_url: str, team_id: str) -> None:
 
 
 async def _wait_for_ws_event(
-    ws: WsClient,
+    conn: ConnectionManager | WsClient,
     timeout: float = POLL_TIMEOUT_S,
 ) -> dict[str, object]:
     """Wait for a single WebSocket event with timeout."""
-    return await asyncio.wait_for(ws.receive_event(), timeout=timeout)
+    return await asyncio.wait_for(conn.receive_event(), timeout=timeout)
 
 
 def _poll_events_have_content(server_url: str, team_id: str) -> bool:
@@ -153,9 +154,9 @@ class TestStateTransitionWS:
         team_id = _create_team(smoke_server)
         try:
             session = _make_session(smoke_server, team_id)
-            async with session.ws_client:
+            async with session.conn:
                 session.client.send_message(team_id, "hello")
-                event = await _wait_for_ws_event(session.ws_client)
+                event = await _wait_for_ws_event(session.conn)
                 assert event is not None
                 assert isinstance(event, dict)
         finally:
@@ -166,7 +167,7 @@ class TestStateTransitionWS:
         team_id = _create_team(smoke_server)
         try:
             session = _make_session(smoke_server, team_id)
-            async with session.ws_client:
+            async with session.conn:
                 # Start receive task so _stop_handler can work
                 session._receive_task = asyncio.create_task(session._receive_loop())
 
@@ -193,21 +194,20 @@ class TestStateTransitionWS:
         team_id = _create_team(smoke_server)
         try:
             session = _make_session(smoke_server, team_id)
-            original_ws = session.ws_client
-            async with session.ws_client:
+            async with session.conn:
                 session._receive_task = asyncio.create_task(session._receive_loop())
 
                 # Stop the team
                 await _stop_handler("", session)
                 await asyncio.sleep(0.5)
 
-                # Restore — this should reconnect the WebSocket
+                # Restore — this triggers conn.switch_team() which reconnects internally
                 await _restore_handler("", session)
                 await asyncio.sleep(0.5)
 
-                # Prove WS was reconnected (the core assertion)
-                assert session.ws_client is not original_ws
+                # Verify team_id preserved and team is running
                 assert session.team_id == team_id
+                assert session.conn.team_id == team_id
 
                 # Verify team is running again
                 team = session.client.get_team(team_id)
@@ -225,7 +225,7 @@ class TestStateTransitionWS:
             await asyncio.sleep(0.3)
 
             session = _make_session(smoke_server, team1_id)
-            async with session.ws_client:
+            async with session.conn:
                 session._receive_task = asyncio.create_task(session._receive_loop())
 
                 # Restore team2 from team1's session
@@ -248,18 +248,15 @@ class TestStateTransitionWS:
         team2_id = _create_team(smoke_server)
         try:
             session = _make_session(smoke_server, team1_id)
-            original_ws = session.ws_client
-            async with session.ws_client:
+            async with session.conn:
                 session._receive_task = asyncio.create_task(session._receive_loop())
 
                 await _switch_handler(team2_id, session)
                 await asyncio.sleep(0.3)
 
                 assert session.team_id == team2_id
-                assert session.ws_client is not original_ws
-
-                # Verify new WS is connected to team2
-                assert team2_id in session.ws_client.url
+                # ConnectionManager.switch_team() updates internal team_id
+                assert session.conn.team_id == team2_id
         finally:
             _cleanup_team(smoke_server, team1_id)
             _cleanup_team(smoke_server, team2_id)
@@ -270,7 +267,7 @@ class TestStateTransitionWS:
         original_team_id = session.team_id
         created_team_id: str | None = None
         try:
-            async with session.ws_client:
+            async with session.conn:
                 session._receive_task = asyncio.create_task(session._receive_loop())
 
                 await _create_handler(CATALOG_ENTRY_ID, session)
@@ -284,8 +281,8 @@ class TestStateTransitionWS:
                 team = session.client.get_team(created_team_id)
                 assert team.status == "running"
 
-                # WS should point to new team
-                assert created_team_id in session.ws_client.url
+                # ConnectionManager should point to new team
+                assert session.conn.team_id == created_team_id
         finally:
             _cleanup_team(smoke_server, original_team_id)
             if created_team_id:
@@ -298,7 +295,7 @@ class TestStateTransitionWS:
         team_id = _create_team(smoke_server)
         try:
             session = _make_session(smoke_server, team_id)
-            async with session.ws_client:
+            async with session.conn:
                 session._receive_task = asyncio.create_task(session._receive_loop())
 
                 # Switch to nonexistent team — should fail gracefully
@@ -309,7 +306,7 @@ class TestStateTransitionWS:
 
                 # Send and verify WS still works
                 session.client.send_message(team_id, "still here")
-                event = await _wait_for_ws_event(session.ws_client)
+                event = await _wait_for_ws_event(session.conn)
                 assert event is not None
         finally:
             _cleanup_team(smoke_server, team_id)

--- a/tests/integration/test_repl_e2e.py
+++ b/tests/integration/test_repl_e2e.py
@@ -304,7 +304,16 @@ class TestStateTransitionWS:
                 # Original team should still be connected
                 assert session.team_id == team_id
 
-                # Send and verify WS still works
+                # Cancel receive loop before verifying WS directly (avoids
+                # concurrent recv on the same websocket connection)
+                if session._receive_task is not None:
+                    session._receive_task.cancel()
+                    try:
+                        await session._receive_task
+                    except asyncio.CancelledError:
+                        pass
+
+                # Send and verify WS still works via direct receive
                 session.client.send_message(team_id, "still here")
                 event = await _wait_for_ws_event(session.conn)
                 assert event is not None


### PR DESCRIPTION
## Summary

Brings the remaining Epic 11 stories into master. Story 11-1 was already merged via PR #131.

- **11-2** ConnectionManager with auto-reconnect (#133)
- **11-3** Session state model and connection-aware input (#135)
- **11-4** Event routing extraction and module split (#137)

These PRs were originally stacked and merged into their parent feature branches rather than master. This PR consolidates them.

## Test plan
- CI must pass (unit, integration, lint)