### PR TITLE
TeamSelectScreen with pagination and ChatApp integration

### DIFF
--- a/src/akgentic/infra/cli/main.py
+++ b/src/akgentic/infra/cli/main.py
@@ -168,8 +168,8 @@ def chat(
         team = _state.client.create_team(create)
         team_id = team.team_id
 
-    if team_id is not None:
-        try:
+    try:
+        if team_id is not None:
             team_info = _state.client.get_team(team_id)
             tui_app = ChatApp(
                 team_name=team_info.name,
@@ -177,23 +177,9 @@ def chat(
                 team_status=team_info.status,
                 client=_state.client,
             )
-            tui_app.run()
-        except KeyboardInterrupt:
-            pass
-        except ApiError as exc:
-            renderer.render_error(f"Server error: {exc}")
-            raise typer.Exit(code=1) from exc
-        except Exception as exc:
-            renderer.render_error(f"Unexpected error: {exc}")
-            logging.getLogger(__name__).exception("Unhandled exception in TUI")
-            raise typer.Exit(code=1) from exc
-        finally:
-            _state.client.close()
-        return
-
-    # No team_id and no --create: let TeamSelectScreen handle it
-    try:
-        tui_app = ChatApp(client=_state.client)
+        else:
+            # No team_id and no --create: let TeamSelectScreen handle it
+            tui_app = ChatApp(client=_state.client)
         tui_app.run()
     except KeyboardInterrupt:
         pass

--- a/src/akgentic/infra/cli/main.py
+++ b/src/akgentic/infra/cli/main.py
@@ -12,7 +12,6 @@ from pydantic import BaseModel
 from akgentic.infra.cli.client import ApiClient, ApiError
 from akgentic.infra.cli.formatters import OutputFormat, format_output
 from akgentic.infra.cli.renderers import RichRenderer
-from akgentic.infra.cli.team_selector import TeamSelector
 from akgentic.infra.cli.tui.app import ChatApp
 
 app = typer.Typer(name="ak-infra", help="Akgentic Infrastructure CLI")
@@ -169,19 +168,32 @@ def chat(
         team = _state.client.create_team(create)
         team_id = team.team_id
 
-    if team_id is None:
-        selector = TeamSelector(_state.client, renderer)
-        team_id = selector.run()
-        if team_id is None:
-            raise typer.Exit(code=0)
+    if team_id is not None:
+        try:
+            team_info = _state.client.get_team(team_id)
+            tui_app = ChatApp(
+                team_name=team_info.name,
+                team_id=team_id,
+                team_status=team_info.status,
+                client=_state.client,
+            )
+            tui_app.run()
+        except KeyboardInterrupt:
+            pass
+        except ApiError as exc:
+            renderer.render_error(f"Server error: {exc}")
+            raise typer.Exit(code=1) from exc
+        except Exception as exc:
+            renderer.render_error(f"Unexpected error: {exc}")
+            logging.getLogger(__name__).exception("Unhandled exception in TUI")
+            raise typer.Exit(code=1) from exc
+        finally:
+            _state.client.close()
+        return
 
+    # No team_id and no --create: let TeamSelectScreen handle it
     try:
-        team_info = _state.client.get_team(team_id)
-        tui_app = ChatApp(
-            team_name=team_info.name,
-            team_id=team_id,
-            team_status=team_info.status,
-        )
+        tui_app = ChatApp(client=_state.client)
         tui_app.run()
     except KeyboardInterrupt:
         pass

--- a/src/akgentic/infra/cli/tui/app.py
+++ b/src/akgentic/infra/cli/tui/app.py
@@ -21,6 +21,7 @@ from akgentic.infra.cli.tui.widgets.status_header import StatusHeader
 _log = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
+    from akgentic.infra.cli.client import ApiClient
     from akgentic.infra.cli.commands import CommandRegistry
     from akgentic.infra.cli.connection import ConnectionManager
     from akgentic.infra.cli.event_router import EventRouter
@@ -42,6 +43,7 @@ class ChatApp(App[None]):
         connection_manager: ConnectionManager | None = None,
         event_router: EventRouter | None = None,
         command_registry: CommandRegistry | None = None,
+        client: ApiClient | None = None,
     ) -> None:
         super().__init__()
         self._team_name = team_name
@@ -50,6 +52,7 @@ class ChatApp(App[None]):
         self._connection_manager = connection_manager
         self._event_router = event_router
         self._command_registry = command_registry
+        self._client = client
         self._color_registry = AgentColorRegistry()
 
     def compose(self) -> ComposeResult:
@@ -71,6 +74,31 @@ class ChatApp(App[None]):
 
     def on_mount(self) -> None:
         """Wire connection manager callback and start streaming."""
+        if not self._team_id:
+            self._select_team()
+            return
+        if self._connection_manager is not None:
+            self._connection_manager._on_state_change = self._on_conn_state_change
+        self.stream_events()
+
+    @work(exclusive=True)
+    async def _select_team(self) -> None:
+        """Push TeamSelectScreen and wait for result."""
+        from akgentic.infra.cli.tui.screens.team_select import TeamSelectScreen
+
+        team_id = await self.push_screen_wait(TeamSelectScreen(client=self._client))
+        if team_id is None:
+            self.exit()
+            return
+        # Fetch team info and update header
+        if self._client is not None:
+            team_info = self._client.get_team(team_id)
+            self._team_id = team_id
+            self._team_name = team_info.name
+            self._team_status = team_info.status
+            self.query_one(StatusHeader).update_team(team_info.name, team_id, team_info.status)
+        else:
+            self._team_id = team_id
         if self._connection_manager is not None:
             self._connection_manager._on_state_change = self._on_conn_state_change
         self.stream_events()

--- a/src/akgentic/infra/cli/tui/screens/__init__.py
+++ b/src/akgentic/infra/cli/tui/screens/__init__.py
@@ -1,1 +1,6 @@
 """TUI screen definitions."""
+
+from akgentic.infra.cli.tui.screens.chat import ChatScreen
+from akgentic.infra.cli.tui.screens.team_select import TeamSelectScreen
+
+__all__ = ["ChatScreen", "TeamSelectScreen"]

--- a/src/akgentic/infra/cli/tui/screens/team_select.py
+++ b/src/akgentic/infra/cli/tui/screens/team_select.py
@@ -1,0 +1,301 @@
+"""Full-screen team selection menu with pagination."""
+
+from __future__ import annotations
+
+import logging
+import math
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from rich.text import Text
+from textual import work
+from textual.app import ComposeResult
+from textual.containers import VerticalScroll
+from textual.screen import Screen
+from textual.widgets import Input, Static
+
+if TYPE_CHECKING:
+    from akgentic.infra.cli.client import ApiClient, CatalogTeamInfo, TeamInfo
+
+_log = logging.getLogger(__name__)
+
+PAGE_SIZE = 5
+
+_CSS_PATH = Path(__file__).parent.parent / "styles" / "team_select.tcss"
+
+
+def _short_id(team_id: str) -> str:
+    """Truncate a UUID to the first 13 characters."""
+    return team_id[:13] if len(team_id) > 13 else team_id
+
+
+class TeamSelectScreen(Screen[str | None]):
+    """Full-screen team selection with pagination for running/stopped teams."""
+
+    CSS_PATH = _CSS_PATH
+
+    def __init__(self, client: ApiClient | None = None) -> None:
+        super().__init__()
+        self._client = client
+        self._page: int = 0
+        self._running_teams: list[TeamInfo] = []
+        self._stopped_teams: list[TeamInfo] = []
+        self._catalog: list[CatalogTeamInfo] = []
+
+    def compose(self) -> ComposeResult:
+        """Compose the team selection layout."""
+        yield Static("Akgentic -- Team Selection", id="team-header")
+        yield VerticalScroll(id="team-list")
+        yield Static("", id="team-hints")
+        yield Input(placeholder="> ", id="team-input")
+
+    def on_mount(self) -> None:
+        """Fetch data and render the first page."""
+        self._fetch_data_worker()
+
+    @work(thread=True)
+    def _fetch_data_worker(self) -> None:
+        """Fetch teams and catalog data in a background thread."""
+        running, stopped, catalog = self._fetch_data()
+        self.app.call_from_thread(self._on_data_loaded, running, stopped, catalog)
+
+    def _fetch_data(
+        self,
+    ) -> tuple[list[TeamInfo], list[TeamInfo], list[CatalogTeamInfo]]:
+        """Call API to get teams and catalog. Returns (running, stopped, catalog)."""
+        from akgentic.infra.cli.client import ApiError
+
+        running: list[TeamInfo] = []
+        stopped: list[TeamInfo] = []
+        catalog: list[CatalogTeamInfo] = []
+        if self._client is None:
+            return running, stopped, catalog
+        try:
+            teams = self._client.list_teams()
+            running = [t for t in teams if t.status == "running"]
+            stopped = [t for t in teams if t.status == "stopped"]
+        except ApiError:
+            _log.debug("Failed to fetch teams")
+        try:
+            catalog = self._client.list_catalog_teams()
+        except ApiError:
+            _log.debug("Failed to fetch catalog")
+        return running, stopped, catalog
+
+    def _on_data_loaded(
+        self,
+        running: list[TeamInfo],
+        stopped: list[TeamInfo],
+        catalog: list[CatalogTeamInfo],
+    ) -> None:
+        """Store fetched data and render."""
+        self._running_teams = running
+        self._stopped_teams = stopped
+        self._catalog = catalog
+        self._render_page()
+
+    def _max_pages(self) -> int:
+        """Return total number of pages based on running and stopped lists."""
+        max_items = max(len(self._running_teams), len(self._stopped_teams))
+        if max_items == 0:
+            return 1
+        return math.ceil(max_items / PAGE_SIZE)
+
+    def _render_page(self) -> None:
+        """Clear and re-render the team list for the current page."""
+        container = self.query_one("#team-list", VerticalScroll)
+        container.remove_children()
+
+        start = self._page * PAGE_SIZE
+        end = start + PAGE_SIZE
+
+        # -- Running teams --
+        if self._running_teams:
+            r_page = self._running_teams[start:end]
+            r_total = len(self._running_teams)
+            r_end = min(start + len(r_page), r_total)
+            header_text = f"Running teams ({start + 1}-{r_end} of {r_total}):"
+            container.mount(Static(header_text, classes="section-header"))
+            for i, team in enumerate(r_page):
+                global_idx = start + i + 1
+                line = Text()
+                line.append(f"  \\[{global_idx}]", style="bold cyan")
+                line.append(f"  {team.name}", style="bold")
+                line.append(f"  {_short_id(team.team_id)}", style="dim")
+                line.append("  > running", style="green")
+                container.mount(Static(line, classes="team-entry"))
+        else:
+            container.mount(Static("Running teams: (none)", classes="section-header"))
+
+        container.mount(Static(""))
+
+        # -- Stopped teams --
+        if self._stopped_teams:
+            s_page = self._stopped_teams[start:end]
+            s_total = len(self._stopped_teams)
+            s_end = min(start + len(s_page), s_total)
+            header_text = f"Stopped teams ({start + 1}-{s_end} of {s_total}):"
+            container.mount(Static(header_text, classes="section-header"))
+            for i, team in enumerate(s_page):
+                global_idx = start + i + 1
+                line = Text()
+                line.append(f"  \\[s{global_idx}]", style="bold yellow")
+                line.append(f"  {team.name}", style="bold")
+                line.append(f"  {_short_id(team.team_id)}", style="dim")
+                line.append("  || stopped", style="yellow")
+                container.mount(Static(line, classes="team-entry"))
+        else:
+            container.mount(Static("Stopped teams: (none)", classes="section-header"))
+
+        container.mount(Static(""))
+
+        # -- Catalog entries --
+        if self._catalog:
+            container.mount(Static("Create new:", classes="section-header"))
+            for entry in self._catalog:
+                line = Text()
+                line.append(f"  \\[c {entry.id}]", style="bold magenta")
+                line.append(f"  {entry.description}", style="dim")
+                container.mount(Static(line, classes="team-entry"))
+        else:
+            container.mount(Static("Create new: (none)", classes="section-header"))
+
+        # -- Update hints --
+        self._update_hints()
+
+    def _update_hints(self) -> None:
+        """Update the hint bar based on current page state."""
+        hints_parts: list[str] = []
+        if self._running_teams:
+            start = self._page * PAGE_SIZE + 1
+            end = min(start + PAGE_SIZE - 1, len(self._running_teams))
+            hints_parts.append(f"[{start}-{end}] connect")
+        if self._stopped_teams:
+            start = self._page * PAGE_SIZE + 1
+            end = min(start + PAGE_SIZE - 1, len(self._stopped_teams))
+            hints_parts.append(f"[s{start}-s{end}] restore")
+        if self._catalog:
+            hints_parts.append("[c <name>] create")
+        if self._max_pages() > 1:
+            hints_parts.append("<-> page")
+        hints_parts.append("[q] quit")
+        hint_text = "  ".join(hints_parts)
+        try:
+            self.query_one("#team-hints", Static).update(hint_text)
+        except Exception:  # noqa: BLE001
+            pass
+
+    def on_input_submitted(self, event: Input.Submitted) -> None:
+        """Handle user input from the Input widget."""
+        text = event.value.strip()
+        event.input.value = ""
+
+        if not text:
+            return
+
+        if text == "q":
+            self.dismiss(None)
+            return
+
+        if text == "n":
+            self._next_page()
+            return
+
+        if text == "p":
+            self._prev_page()
+            return
+
+        if text.isdigit():
+            self._select_running(int(text))
+            return
+
+        if text.startswith("s") and text[1:].isdigit():
+            self._select_stopped(int(text[1:]))
+            return
+
+        if text.startswith("c "):
+            name = text[2:].strip()
+            if name:
+                self._create_team(name)
+                return
+
+        self._show_error(f"Unknown command: {text}")
+
+    def on_key(self, event: object) -> None:
+        """Handle arrow key presses for pagination."""
+        from textual.events import Key
+
+        if not isinstance(event, Key):
+            return
+        if event.key == "right":
+            self._next_page()
+        elif event.key == "left":
+            self._prev_page()
+
+    def _next_page(self) -> None:
+        """Advance to the next page if available."""
+        if self._page < self._max_pages() - 1:
+            self._page += 1
+            self._render_page()
+
+    def _prev_page(self) -> None:
+        """Go back one page if not on the first page."""
+        if self._page > 0:
+            self._page -= 1
+            self._render_page()
+
+    def _select_running(self, number: int) -> None:
+        """Select a running team by global index."""
+        idx = number - 1
+        if 0 <= idx < len(self._running_teams):
+            self.dismiss(self._running_teams[idx].team_id)
+        else:
+            self._show_error(f"Invalid selection: {number}")
+
+    def _select_stopped(self, number: int) -> None:
+        """Select a stopped team by global index, restore it."""
+        idx = number - 1
+        if 0 <= idx < len(self._stopped_teams):
+            team = self._stopped_teams[idx]
+            self._restore_team_worker(team.team_id)
+        else:
+            self._show_error(f"Invalid selection: s{number}")
+
+    @work(thread=True)
+    def _restore_team_worker(self, team_id: str) -> None:
+        """Restore a stopped team in a background thread."""
+        from akgentic.infra.cli.client import ApiError
+
+        if self._client is None:
+            return
+        try:
+            self._client.restore_team(team_id)
+            self.app.call_from_thread(self.dismiss, team_id)
+        except ApiError as exc:
+            self.app.call_from_thread(self._show_error, f"Failed to restore team: {exc}")
+
+    def _create_team(self, catalog_entry_id: str) -> None:
+        """Create a team from a catalog entry."""
+        self._create_team_worker(catalog_entry_id)
+
+    @work(thread=True)
+    def _create_team_worker(self, catalog_entry_id: str) -> None:
+        """Create a team in a background thread."""
+        from akgentic.infra.cli.client import ApiError
+
+        if self._client is None:
+            return
+        try:
+            team = self._client.create_team(catalog_entry_id)
+            self.app.call_from_thread(self.dismiss, team.team_id)
+        except ApiError as exc:
+            self.app.call_from_thread(self._show_error, f"Failed to create team: {exc}")
+
+    def _show_error(self, message: str) -> None:
+        """Display an error message in the team list area."""
+        container = self.query_one("#team-list", VerticalScroll)
+        error_widget = Static(
+            Text(message, style="bold red"),
+            classes="error-message",
+        )
+        container.mount(error_widget)

--- a/src/akgentic/infra/cli/tui/screens/team_select.py
+++ b/src/akgentic/infra/cli/tui/screens/team_select.py
@@ -11,6 +11,7 @@ from rich.text import Text
 from textual import work
 from textual.app import ComposeResult
 from textual.containers import VerticalScroll
+from textual.events import Key
 from textual.screen import Screen
 from textual.widgets import Input, Static
 
@@ -169,21 +170,21 @@ class TeamSelectScreen(Screen[str | None]):
         if self._running_teams:
             start = self._page * PAGE_SIZE + 1
             end = min(start + PAGE_SIZE - 1, len(self._running_teams))
-            hints_parts.append(f"[{start}-{end}] connect")
+            hints_parts.append(f"\\[{start}-{end}] connect")
         if self._stopped_teams:
             start = self._page * PAGE_SIZE + 1
             end = min(start + PAGE_SIZE - 1, len(self._stopped_teams))
-            hints_parts.append(f"[s{start}-s{end}] restore")
+            hints_parts.append(f"\\[s{start}-s{end}] restore")
         if self._catalog:
-            hints_parts.append("[c <name>] create")
+            hints_parts.append("\\[c <name>] create")
         if self._max_pages() > 1:
             hints_parts.append("<-> page")
-        hints_parts.append("[q] quit")
+        hints_parts.append("\\[q] quit")
         hint_text = "  ".join(hints_parts)
         try:
             self.query_one("#team-hints", Static).update(hint_text)
-        except Exception:  # noqa: BLE001
-            pass
+        except LookupError:
+            _log.debug("team-hints widget not available for update")
 
     def on_input_submitted(self, event: Input.Submitted) -> None:
         """Handle user input from the Input widget."""
@@ -221,12 +222,8 @@ class TeamSelectScreen(Screen[str | None]):
 
         self._show_error(f"Unknown command: {text}")
 
-    def on_key(self, event: object) -> None:
+    def on_key(self, event: Key) -> None:
         """Handle arrow key presses for pagination."""
-        from textual.events import Key
-
-        if not isinstance(event, Key):
-            return
         if event.key == "right":
             self._next_page()
         elif event.key == "left":
@@ -292,8 +289,10 @@ class TeamSelectScreen(Screen[str | None]):
             self.app.call_from_thread(self._show_error, f"Failed to create team: {exc}")
 
     def _show_error(self, message: str) -> None:
-        """Display an error message in the team list area."""
+        """Display an error message in the team list area, replacing any previous error."""
         container = self.query_one("#team-list", VerticalScroll)
+        for old in container.query(".error-message"):
+            old.remove()
         error_widget = Static(
             Text(message, style="bold red"),
             classes="error-message",

--- a/src/akgentic/infra/cli/tui/styles/team_select.tcss
+++ b/src/akgentic/infra/cli/tui/styles/team_select.tcss
@@ -1,0 +1,37 @@
+#team-header {
+    dock: top;
+    height: 1;
+    background: $surface;
+    text-style: bold;
+    padding: 0 1;
+}
+
+#team-list {
+    height: 1fr;
+    padding: 1 2;
+}
+
+#team-input {
+    dock: bottom;
+    height: 3;
+    border-top: solid $accent;
+}
+
+#team-hints {
+    dock: bottom;
+    height: 1;
+    background: $surface;
+}
+
+.section-header {
+    margin: 0 0 0 0;
+    text-style: bold;
+}
+
+.team-entry {
+    margin: 0;
+}
+
+.error-message {
+    margin: 1 0;
+}

--- a/tests/cli/test_cli_commands.py
+++ b/tests/cli/test_cli_commands.py
@@ -169,9 +169,14 @@ class TestReply:
 
 
 class TestChat:
-    def test_chat_no_args_shows_error(self) -> None:
-        result = _invoke(["chat"])
-        assert result.exit_code != 0
+    def test_chat_no_args_launches_team_select(self) -> None:
+        mock = _mock_client()
+        with patch("akgentic.infra.cli.main.ChatApp") as mock_app_cls:
+            mock_app_cls.return_value.run.return_value = None
+            result = _invoke(["chat"], mock)
+        assert result.exit_code == 0
+        mock_app_cls.assert_called_once_with(client=mock)
+        mock_app_cls.return_value.run.assert_called_once()
 
     def test_chat_launches_tui(self) -> None:
         mock = _mock_client()

--- a/tests/cli/test_tui_team_select.py
+++ b/tests/cli/test_tui_team_select.py
@@ -1,0 +1,338 @@
+"""Pilot tests for TeamSelectScreen and ChatApp integration."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+from textual.widgets import Input
+
+from akgentic.infra.cli.client import ApiClient, CatalogTeamInfo, TeamInfo
+from akgentic.infra.cli.tui.app import ChatApp
+from akgentic.infra.cli.tui.screens.team_select import TeamSelectScreen
+
+
+def _make_team(
+    team_id: str, name: str, status: str = "running"
+) -> TeamInfo:
+    return TeamInfo(
+        team_id=team_id,
+        name=name,
+        status=status,
+        user_id="u1",
+        created_at="2026-01-01",
+        updated_at="2026-01-01",
+    )
+
+
+def _mock_client(
+    running: int = 3, stopped: int = 2, catalog: int = 2
+) -> MagicMock:
+    """Create a mock ApiClient with configurable team counts."""
+    client = MagicMock(spec=ApiClient)
+    teams = [
+        _make_team(f"run-{i}", f"team-{i}", "running")
+        for i in range(1, running + 1)
+    ] + [
+        _make_team(f"stop-{i}", f"stopped-{i}", "stopped")
+        for i in range(1, stopped + 1)
+    ]
+    client.list_teams.return_value = teams
+    client.list_catalog_teams.return_value = [
+        CatalogTeamInfo(id=f"cat-{i}", name=f"catalog-{i}", description=f"Desc {i}")
+        for i in range(1, catalog + 1)
+    ]
+    return client
+
+
+def _get_team_list_text(app: ChatApp) -> str:
+    """Extract all rendered text from the team-list container."""
+    children = app.screen.query_one("#team-list").children
+    return " ".join(str(c.render()) for c in children)
+
+
+async def _submit_input(app: ChatApp, text: str, pilot: object) -> None:
+    """Set input value and post a Submitted message."""
+    inp = app.screen.query_one("#team-input", Input)
+    inp.value = text
+    app.screen.post_message(Input.Submitted(inp, text))
+    await pilot.pause()  # type: ignore[union-attr]
+
+
+# -- Task 6: Basic rendering and selection tests --
+
+
+@pytest.mark.asyncio
+async def test_screen_renders_teams_and_catalog() -> None:
+    """Screen renders running teams, stopped teams, and catalog entries."""
+    client = _mock_client(running=2, stopped=1, catalog=1)
+
+    class TestApp(ChatApp):
+        def on_mount(self) -> None:
+            self.push_screen(TeamSelectScreen(client=client))
+
+    app = TestApp(team_name="t", team_id="pre-set", team_status="running")
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        await pilot.pause()
+
+        all_text = _get_team_list_text(app)
+        assert "team-1" in all_text
+        assert "team-2" in all_text
+        assert "stopped-1" in all_text
+        assert "Desc 1" in all_text
+
+
+@pytest.mark.asyncio
+async def test_number_input_selects_running_team() -> None:
+    """Entering a number selects the corresponding running team."""
+    client = _mock_client(running=3, stopped=0, catalog=0)
+    dismissed_with: list[str | None] = []
+
+    class TrackingScreen(TeamSelectScreen):
+        def dismiss(self, result: str | None = None) -> None:
+            dismissed_with.append(result)
+            return super().dismiss(result)
+
+    class TestApp(ChatApp):
+        def on_mount(self) -> None:
+            self.push_screen(TrackingScreen(client=client))
+
+    app = TestApp(team_name="t", team_id="pre-set", team_status="running")
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        await pilot.pause()
+        await _submit_input(app, "2", pilot)
+        assert "run-2" in dismissed_with
+
+
+@pytest.mark.asyncio
+async def test_s_number_restores_stopped_team() -> None:
+    """Entering s<N> restores the corresponding stopped team."""
+    client = _mock_client(running=0, stopped=3, catalog=0)
+    client.restore_team.return_value = _make_team("stop-1", "stopped-1", "running")
+    dismissed_with: list[str | None] = []
+
+    class TrackingScreen(TeamSelectScreen):
+        def dismiss(self, result: str | None = None) -> None:
+            dismissed_with.append(result)
+            return super().dismiss(result)
+
+    class TestApp(ChatApp):
+        def on_mount(self) -> None:
+            self.push_screen(TrackingScreen(client=client))
+
+    app = TestApp(team_name="t", team_id="pre-set", team_status="running")
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        await pilot.pause()
+        await _submit_input(app, "s1", pilot)
+        await pilot.pause()  # wait for worker
+        await pilot.pause()
+        client.restore_team.assert_called_once_with("stop-1")
+        assert "stop-1" in dismissed_with
+
+
+@pytest.mark.asyncio
+async def test_c_name_creates_team() -> None:
+    """Entering 'c <name>' creates a team from catalog."""
+    client = _mock_client(running=0, stopped=0, catalog=1)
+    client.create_team.return_value = _make_team("new-1", "new-team", "running")
+    dismissed_with: list[str | None] = []
+
+    class TrackingScreen(TeamSelectScreen):
+        def dismiss(self, result: str | None = None) -> None:
+            dismissed_with.append(result)
+            return super().dismiss(result)
+
+    class TestApp(ChatApp):
+        def on_mount(self) -> None:
+            self.push_screen(TrackingScreen(client=client))
+
+    app = TestApp(team_name="t", team_id="pre-set", team_status="running")
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        await pilot.pause()
+        await _submit_input(app, "c cat-1", pilot)
+        await pilot.pause()  # wait for worker
+        await pilot.pause()
+        client.create_team.assert_called_once_with("cat-1")
+        assert "new-1" in dismissed_with
+
+
+@pytest.mark.asyncio
+async def test_q_dismisses_with_none() -> None:
+    """Entering 'q' dismisses the screen with None."""
+    client = _mock_client(running=1, stopped=0, catalog=0)
+    dismissed_with: list[str | None] = []
+
+    class TrackingScreen(TeamSelectScreen):
+        def dismiss(self, result: str | None = None) -> None:
+            dismissed_with.append(result)
+            return super().dismiss(result)
+
+    class TestApp(ChatApp):
+        def on_mount(self) -> None:
+            self.push_screen(TrackingScreen(client=client))
+
+    app = TestApp(team_name="t", team_id="pre-set", team_status="running")
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        await pilot.pause()
+        await _submit_input(app, "q", pilot)
+        assert None in dismissed_with
+
+
+@pytest.mark.asyncio
+async def test_invalid_number_shows_error() -> None:
+    """Entering an out-of-range number shows an error message."""
+    client = _mock_client(running=2, stopped=0, catalog=0)
+
+    class TestApp(ChatApp):
+        def on_mount(self) -> None:
+            self.push_screen(TeamSelectScreen(client=client))
+
+    app = TestApp(team_name="t", team_id="pre-set", team_status="running")
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        await pilot.pause()
+        await _submit_input(app, "99", pilot)
+        all_text = _get_team_list_text(app)
+        assert "Invalid selection" in all_text
+
+
+# -- Task 7: Pagination tests --
+
+
+@pytest.mark.asyncio
+async def test_pagination_indicator_with_many_teams() -> None:
+    """More than 5 running teams shows pagination indicator."""
+    client = _mock_client(running=12, stopped=0, catalog=0)
+
+    class TestApp(ChatApp):
+        def on_mount(self) -> None:
+            self.push_screen(TeamSelectScreen(client=client))
+
+    app = TestApp(team_name="t", team_id="pre-set", team_status="running")
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        await pilot.pause()
+        all_text = _get_team_list_text(app)
+        assert "1-5 of 12" in all_text
+
+
+@pytest.mark.asyncio
+async def test_n_advances_page() -> None:
+    """Typing 'n' advances to the next page with correct numbering."""
+    client = _mock_client(running=8, stopped=0, catalog=0)
+
+    class TestApp(ChatApp):
+        def on_mount(self) -> None:
+            self.push_screen(TeamSelectScreen(client=client))
+
+    app = TestApp(team_name="t", team_id="pre-set", team_status="running")
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        await pilot.pause()
+        await _submit_input(app, "n", pilot)
+        all_text = _get_team_list_text(app)
+        assert "6-8 of 8" in all_text
+
+
+@pytest.mark.asyncio
+async def test_p_goes_back() -> None:
+    """Typing 'p' goes back to previous page."""
+    client = _mock_client(running=8, stopped=0, catalog=0)
+
+    class TestApp(ChatApp):
+        def on_mount(self) -> None:
+            self.push_screen(TeamSelectScreen(client=client))
+
+    app = TestApp(team_name="t", team_id="pre-set", team_status="running")
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        await pilot.pause()
+        await _submit_input(app, "n", pilot)
+        await _submit_input(app, "p", pilot)
+        all_text = _get_team_list_text(app)
+        assert "1-5 of 8" in all_text
+
+
+@pytest.mark.asyncio
+async def test_right_arrow_advances_page() -> None:
+    """Right arrow key advances page."""
+    client = _mock_client(running=8, stopped=0, catalog=0)
+
+    class TestApp(ChatApp):
+        def on_mount(self) -> None:
+            self.push_screen(TeamSelectScreen(client=client))
+
+    app = TestApp(team_name="t", team_id="pre-set", team_status="running")
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        await pilot.pause()
+        await pilot.press("right")
+        await pilot.pause()
+        all_text = _get_team_list_text(app)
+        assert "6-8 of 8" in all_text
+
+
+@pytest.mark.asyncio
+async def test_first_page_no_prev() -> None:
+    """First page does not go back further."""
+    client = _mock_client(running=8, stopped=0, catalog=0)
+
+    class TestApp(ChatApp):
+        def on_mount(self) -> None:
+            self.push_screen(TeamSelectScreen(client=client))
+
+    app = TestApp(team_name="t", team_id="pre-set", team_status="running")
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        await pilot.pause()
+        await _submit_input(app, "p", pilot)
+        all_text = _get_team_list_text(app)
+        assert "1-5 of 8" in all_text
+
+
+@pytest.mark.asyncio
+async def test_last_page_no_next() -> None:
+    """Last page does not advance further."""
+    client = _mock_client(running=3, stopped=0, catalog=0)
+
+    class TestApp(ChatApp):
+        def on_mount(self) -> None:
+            self.push_screen(TeamSelectScreen(client=client))
+
+    app = TestApp(team_name="t", team_id="pre-set", team_status="running")
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        await pilot.pause()
+        await _submit_input(app, "n", pilot)
+        all_text = _get_team_list_text(app)
+        assert "1-3 of 3" in all_text
+
+
+# -- Task 8: ChatApp integration tests --
+
+
+@pytest.mark.asyncio
+async def test_chatapp_no_team_pushes_select_screen() -> None:
+    """ChatApp with no team_id pushes TeamSelectScreen on mount."""
+    client = _mock_client(running=1, stopped=0, catalog=0)
+
+    app = ChatApp(client=client)
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        await pilot.pause()
+        await pilot.pause()
+        assert isinstance(app.screen, TeamSelectScreen)
+
+
+@pytest.mark.asyncio
+async def test_chatapp_with_team_skips_select_screen() -> None:
+    """ChatApp with pre-set team_id skips TeamSelectScreen."""
+    app = ChatApp(team_name="test", team_id="abc123", team_status="running")
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        assert not isinstance(app.screen, TeamSelectScreen)

--- a/tests/cli/test_tui_team_select.py
+++ b/tests/cli/test_tui_team_select.py
@@ -7,7 +7,7 @@ from unittest.mock import MagicMock
 import pytest
 from textual.widgets import Input
 
-from akgentic.infra.cli.client import ApiClient, CatalogTeamInfo, TeamInfo
+from akgentic.infra.cli.client import ApiClient, ApiError, CatalogTeamInfo, TeamInfo
 from akgentic.infra.cli.tui.app import ChatApp
 from akgentic.infra.cli.tui.screens.team_select import TeamSelectScreen
 
@@ -199,6 +199,25 @@ async def test_invalid_number_shows_error() -> None:
         await _submit_input(app, "99", pilot)
         all_text = _get_team_list_text(app)
         assert "Invalid selection" in all_text
+
+
+@pytest.mark.asyncio
+async def test_api_error_during_fetch_shows_empty() -> None:
+    """ApiError during data fetch renders empty sections gracefully."""
+    client = MagicMock(spec=ApiClient)
+    client.list_teams.side_effect = ApiError(500, "connection refused")
+    client.list_catalog_teams.side_effect = ApiError(500, "connection refused")
+
+    class TestApp(ChatApp):
+        def on_mount(self) -> None:
+            self.push_screen(TeamSelectScreen(client=client))
+
+    app = TestApp(team_name="t", team_id="pre-set", team_status="running")
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        await pilot.pause()
+        all_text = _get_team_list_text(app)
+        assert "(none)" in all_text
 
 
 # -- Task 7: Pagination tests --


### PR DESCRIPTION
## Summary

- Full-screen team selection menu with pagination for running/stopped teams and catalog entries
- Global numbering across pages, `n`/`p`/arrow-key pagination, `q` quit
- Input parsing: number selects running team, `s<N>` restores stopped team, `c <name>` creates from catalog
- ChatApp integration via `push_screen_wait()` worker pattern
- CLI `chat` command updated: no-args launches TUI with TeamSelectScreen

## Code Review Fixes

- Escaped Rich markup brackets in hint bar to prevent style tag interpretation
- Narrowed exception catch in `_update_hints` from `Exception` to `LookupError`
- Clear previous error messages before showing new ones in `_show_error`
- Proper `Key` type annotation for `on_key` handler (was `object`)
- Deduplicated error handling in `chat()` command
- Added test for `ApiError` path during data fetch

Closes #147