### PR TITLE
Slash command integration

### DIFF
--- a/src/akgentic/infra/cli/commands.py
+++ b/src/akgentic/infra/cli/commands.py
@@ -428,6 +428,11 @@ async def _reconnect_handler(args: str, session: ChatSession) -> None:
         session.renderer.render_error(f"Reconnection failed: {exc.reason}")
 
 
+async def _quit_handler(args: str, session: ChatSession) -> None:
+    """Exit the session (TUI overrides this with app.exit())."""
+    print("Goodbye.")
+
+
 async def _catalog_handler(args: str, session: ChatSession) -> None:
     """List available team templates from the catalog."""
     loop = asyncio.get_running_loop()
@@ -469,4 +474,5 @@ def build_default_registry() -> CommandRegistry:
     )
     registry.register("switch", _switch_handler, "Switch to another team", "/switch <team_id>")
     registry.register("reconnect", _reconnect_handler, "Reconnect to server", "/reconnect")
+    registry.register("quit", _quit_handler, "Exit the chat", "/quit")
     return registry

--- a/src/akgentic/infra/cli/event_router.py
+++ b/src/akgentic/infra/cli/event_router.py
@@ -180,13 +180,19 @@ class EventRouter:
     def _sent_to_widget(
         self, event: dict[str, Any], color_registry: AgentColorRegistry
     ) -> Widget | None:
-        """Convert a SentMessage event to an AgentMessage widget."""
+        """Convert a SentMessage event to an AgentMessage widget.
+
+        Skips messages from @Human — those are echoes of the user's own
+        message, already displayed as a UserMessage widget.
+        """
         from akgentic.infra.cli.tui.widgets.agent_message import AgentMessage
 
         raw_sender = event.get("sender", "agent")
         sender = (
             raw_sender.get("name", "agent") if isinstance(raw_sender, dict) else str(raw_sender)
         )
+        if sender == "@Human":
+            return None
         message = event.get("message", {})
         content = message.get("content", "") if isinstance(message, dict) else ""
         if not content:

--- a/src/akgentic/infra/cli/event_router.py
+++ b/src/akgentic/infra/cli/event_router.py
@@ -5,9 +5,14 @@ from __future__ import annotations
 import json
 import logging
 from collections.abc import Callable
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from akgentic.infra.cli.renderers import RichRenderer
+
+if TYPE_CHECKING:
+    from textual.widget import Widget
+
+    from akgentic.infra.cli.tui.colors import AgentColorRegistry
 
 # Event types to display vs skip
 _DISPLAY_EVENTS = {"SentMessage", "ErrorMessage", "EventMessage"}
@@ -133,3 +138,99 @@ class EventRouter:
             agent_name = str(raw_sender)
         if self._on_human_input is not None:
             self._on_human_input(message_id, agent_name)
+
+    def to_widget(
+        self,
+        data: dict[str, Any],
+        color_registry: AgentColorRegistry,
+    ) -> Widget | None:
+        """Parse a raw event dict and return the appropriate Textual widget.
+
+        Returns ``None`` for unrecognized or malformed events.
+        This method does NOT invoke callbacks or use the renderer -- it is
+        a pure event-to-widget translation for TUI usage.
+        """
+        try:
+            event = data.get("event", data)
+            if isinstance(event, str):
+                event = json.loads(event)
+
+            model = event.get("__model__", "")
+            short_model = model.rsplit(".", 1)[-1] if model else ""
+            if short_model not in _DISPLAY_EVENTS:
+                return None
+
+            if short_model == "ErrorMessage":
+                return self._error_to_widget(event)
+            if short_model == "SentMessage":
+                return self._sent_to_widget(event, color_registry)
+            if short_model == "EventMessage":
+                return self._event_to_widget(event)
+        except (KeyError, json.JSONDecodeError, TypeError) as exc:
+            self._log.debug("to_widget: malformed event skipped: %s", exc)
+        return None
+
+    def _error_to_widget(self, event: dict[str, Any]) -> Widget:
+        """Convert an ErrorMessage event to an ErrorWidget."""
+        from akgentic.infra.cli.tui.widgets.error import ErrorWidget
+
+        content = event.get("exception_value", event.get("content", event.get("error", "")))
+        return ErrorWidget(content=str(content))
+
+    def _sent_to_widget(
+        self, event: dict[str, Any], color_registry: AgentColorRegistry
+    ) -> Widget | None:
+        """Convert a SentMessage event to an AgentMessage widget."""
+        from akgentic.infra.cli.tui.widgets.agent_message import AgentMessage
+
+        raw_sender = event.get("sender", "agent")
+        sender = (
+            raw_sender.get("name", "agent") if isinstance(raw_sender, dict) else str(raw_sender)
+        )
+        message = event.get("message", {})
+        content = message.get("content", "") if isinstance(message, dict) else ""
+        if not content:
+            return None
+        color = color_registry.get(sender)
+        return AgentMessage(sender=sender, content=str(content), color=color)
+
+    def _event_to_widget(self, event: dict[str, Any]) -> Widget | None:
+        """Convert an EventMessage event to a ToolCallWidget or HumanInputPrompt."""
+        nested = event.get("event", {})
+        if isinstance(nested, str):
+            try:
+                nested = json.loads(nested)
+            except (json.JSONDecodeError, TypeError):
+                return None
+        if not isinstance(nested, dict):
+            return None
+
+        if "tool_name" in nested:
+            return self._tool_call_to_widget(nested)
+
+        nested_model = nested.get("__model__", "")
+        if "HumanInput" in nested_model or "RequestInput" in nested_model:
+            from akgentic.infra.cli.tui.widgets.human_input import HumanInputPrompt
+
+            prompt_text = str(nested.get("prompt", nested.get("content", "Input requested")))
+            return HumanInputPrompt(prompt_text=prompt_text)
+        return None
+
+    def _tool_call_to_widget(self, nested: dict[str, Any]) -> Widget:
+        """Convert a tool call nested event to a ToolCallWidget."""
+        from akgentic.infra.cli.tui.widgets.tool_call import ToolCallWidget
+
+        tool_name = str(nested["tool_name"])
+        raw_input = nested.get("arguments", nested.get("args", nested.get("input", "")))
+        if isinstance(raw_input, dict | list):
+            tool_input = json.dumps(raw_input, indent=2)
+        else:
+            tool_input = str(raw_input)
+        raw_output = nested.get("result")
+        if raw_output is None:
+            tool_output = None
+        elif isinstance(raw_output, dict | list):
+            tool_output = json.dumps(raw_output, indent=2)
+        else:
+            tool_output = str(raw_output)
+        return ToolCallWidget(tool_name=tool_name, tool_input=tool_input, tool_output=tool_output)

--- a/src/akgentic/infra/cli/main.py
+++ b/src/akgentic/infra/cli/main.py
@@ -162,24 +162,51 @@ def chat(
     ] = None,
 ) -> None:
     """Interactive chat REPL — connect to a team via WebSocket."""
+    from akgentic.infra.cli.commands import build_default_registry
+    from akgentic.infra.cli.connection import ConnectionManager
+    from akgentic.infra.cli.event_router import EventRouter
+
     renderer = RichRenderer()
 
     if create is not None:
         team = _state.client.create_team(create)
         team_id = team.team_id
 
+    # Build shared dependencies for the TUI
+    command_registry = build_default_registry()
+    event_router = EventRouter(renderer)
+
     try:
         if team_id is not None:
             team_info = _state.client.get_team(team_id)
+            conn = ConnectionManager(
+                server_url=_state.server,
+                team_id=team_id,
+                api_key=_state.api_key,
+            )
             tui_app = ChatApp(
                 team_name=team_info.name,
                 team_id=team_id,
                 team_status=team_info.status,
+                connection_manager=conn,
+                event_router=event_router,
+                command_registry=command_registry,
                 client=_state.client,
             )
         else:
-            # No team_id and no --create: let TeamSelectScreen handle it
-            tui_app = ChatApp(client=_state.client)
+            # No team_id and no --create: let TeamSelectScreen handle it.
+            # ConnectionManager will be created after team selection via /switch.
+            conn = ConnectionManager(
+                server_url=_state.server,
+                team_id="",
+                api_key=_state.api_key,
+            )
+            tui_app = ChatApp(
+                connection_manager=conn,
+                event_router=event_router,
+                command_registry=command_registry,
+                client=_state.client,
+            )
         tui_app.run()
     except KeyboardInterrupt:
         pass

--- a/src/akgentic/infra/cli/main.py
+++ b/src/akgentic/infra/cli/main.py
@@ -168,8 +168,8 @@ def chat(
         team = _state.client.create_team(create)
         team_id = team.team_id
 
-    if team_id is not None:
-        try:
+    try:
+        if team_id is not None:
             team_info = _state.client.get_team(team_id)
             tui_app = ChatApp(
                 team_name=team_info.name,
@@ -177,23 +177,9 @@ def chat(
                 team_status=team_info.status,
                 client=_state.client,
             )
-            tui_app.run()
-        except KeyboardInterrupt:
-            pass
-        except ApiError as exc:
-            renderer.render_error(f"Server error: {exc}")
-            raise typer.Exit(code=1) from exc
-        except Exception as exc:
-            renderer.render_error(f"Unexpected error: {exc}")
-            logging.getLogger(__name__).exception("Unhandled exception in TUI")
-            raise typer.Exit(code=1) from exc
-        finally:
-            _state.client.close()
-        return
-
-    # No team_id and no --create: let TeamSelectScreen handle it
-    try:
-        tui_app = ChatApp(client=_state.client)
+        else:
+            # No team_id and no --create: let TeamSelectScreen handle it
+            tui_app = ChatApp(client=_state.client)
         tui_app.run()
     except KeyboardInterrupt:
         pass

--- a/src/akgentic/infra/cli/main.py
+++ b/src/akgentic/infra/cli/main.py
@@ -12,7 +12,6 @@ from pydantic import BaseModel
 from akgentic.infra.cli.client import ApiClient, ApiError
 from akgentic.infra.cli.formatters import OutputFormat, format_output
 from akgentic.infra.cli.renderers import RichRenderer
-from akgentic.infra.cli.team_selector import TeamSelector
 from akgentic.infra.cli.tui.app import ChatApp
 
 app = typer.Typer(name="ak-infra", help="Akgentic Infrastructure CLI")
@@ -169,19 +168,32 @@ def chat(
         team = _state.client.create_team(create)
         team_id = team.team_id
 
-    if team_id is None:
-        selector = TeamSelector(_state.client, renderer)
-        team_id = selector.run()
-        if team_id is None:
-            raise typer.Exit(code=0)
+    if team_id is not None:
+        try:
+            team_info = _state.client.get_team(team_id)
+            tui_app = ChatApp(
+                team_name=team_info.name,
+                team_id=team_id,
+                team_status=team_info.status,
+                client=_state.client,
+            )
+            tui_app.run()
+        except KeyboardInterrupt:
+            pass
+        except ApiError as exc:
+            renderer.render_error(f"Server error: {exc}")
+            raise typer.Exit(code=1) from exc
+        except Exception as exc:
+            renderer.render_error(f"Unexpected error: {exc}")
+            logging.getLogger(__name__).exception("Unhandled exception in TUI")
+            raise typer.Exit(code=1) from exc
+        finally:
+            _state.client.close()
+        return
 
+    # No team_id and no --create: let TeamSelectScreen handle it
     try:
-        team_info = _state.client.get_team(team_id)
-        tui_app = ChatApp(
-            team_name=team_info.name,
-            team_id=team_id,
-            team_status=team_info.status,
-        )
+        tui_app = ChatApp(client=_state.client)
         tui_app.run()
     except KeyboardInterrupt:
         pass

--- a/src/akgentic/infra/cli/tui/app.py
+++ b/src/akgentic/infra/cli/tui/app.py
@@ -256,6 +256,9 @@ class ChatApp(App[None]):
                     self._remove_thinking_indicator(conversation)
                     await conversation.mount(widget)
                     widget.scroll_visible(animate=False)
+                    # Deferred cleanup: schedule removal after the event loop
+                    # processes any pending mounts from on_chat_input_submitted.
+                    self.call_later(self._remove_thinking_indicator, conversation)
             except WsConnectionError as exc:
                 _log.debug("WS connection error in stream loop: %s", exc)
                 self._remove_thinking_indicator(conversation)

--- a/src/akgentic/infra/cli/tui/app.py
+++ b/src/akgentic/infra/cli/tui/app.py
@@ -21,6 +21,7 @@ from akgentic.infra.cli.tui.widgets.status_header import StatusHeader
 _log = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
+    from akgentic.infra.cli.commands import CommandRegistry
     from akgentic.infra.cli.connection import ConnectionManager
     from akgentic.infra.cli.event_router import EventRouter
 
@@ -40,6 +41,7 @@ class ChatApp(App[None]):
         team_status: str = "running",
         connection_manager: ConnectionManager | None = None,
         event_router: EventRouter | None = None,
+        command_registry: CommandRegistry | None = None,
     ) -> None:
         super().__init__()
         self._team_name = team_name
@@ -47,6 +49,7 @@ class ChatApp(App[None]):
         self._team_status = team_status
         self._connection_manager = connection_manager
         self._event_router = event_router
+        self._command_registry = command_registry
         self._color_registry = AgentColorRegistry()
 
     def compose(self) -> ComposeResult:
@@ -63,7 +66,7 @@ class ChatApp(App[None]):
             ),
             id="conversation",
         )
-        yield ChatInput()
+        yield ChatInput(command_registry=self._command_registry)
         yield HintBar()
 
     def on_mount(self) -> None:
@@ -89,11 +92,11 @@ class ChatApp(App[None]):
         try:
             chat_input = self.query_one(ChatInput)
             if state_str == "disconnected":
-                chat_input.border_title = "\\[disconnected] > "
+                chat_input.input_mode = "disconnected"
             elif state_str == "reconnecting":
-                chat_input.border_title = "\\[reconnecting...] > "
+                chat_input.input_mode = "reconnecting"
             elif state_str == "connected":
-                chat_input.border_title = "> "
+                chat_input.input_mode = "chat"
         except Exception:  # noqa: BLE001
             _log.debug("ChatInput not available for connection state update")
 

--- a/src/akgentic/infra/cli/tui/app.py
+++ b/src/akgentic/infra/cli/tui/app.py
@@ -37,6 +37,7 @@ class ChatApp(App[None]):
 
     TITLE = "Akgentic Chat"
     CSS_PATH = _CSS_PATH
+
     LAYERS = ("default", "overlay")
 
     def __init__(
@@ -156,6 +157,9 @@ class ChatApp(App[None]):
         team_id = await self.push_screen_wait(TeamSelectScreen(client=self._client))
         if team_id is None:
             return
+        if team_id == "__quit__":
+            self.exit()
+            return
         if self._client is not None:
             team_info = self._client.get_team(team_id)
             self._team_id = team_id
@@ -165,8 +169,15 @@ class ChatApp(App[None]):
         else:
             self._team_id = team_id
         if self._connection_manager is not None:
+            from akgentic.infra.cli.connection import ConnectionManager as ConnMgr
+
+            self._connection_manager = ConnMgr(
+                server_url=self._connection_manager._server_url,  # noqa: SLF001
+                team_id=team_id,
+                api_key=self._connection_manager._api_key,  # noqa: SLF001
+            )
             self._connection_manager._on_state_change = self._on_conn_state_change
-            await self._connection_manager.switch_team(team_id)
+        self.query_one(ChatInput).focus()
         self.stream_events()
 
     def on_mount(self) -> None:
@@ -176,6 +187,7 @@ class ChatApp(App[None]):
             return
         if self._connection_manager is not None:
             self._connection_manager._on_state_change = self._on_conn_state_change
+        self.query_one(ChatInput).focus()
         self.stream_events()
 
     @work(exclusive=True)
@@ -184,7 +196,7 @@ class ChatApp(App[None]):
         from akgentic.infra.cli.tui.screens.team_select import TeamSelectScreen
 
         team_id = await self.push_screen_wait(TeamSelectScreen(client=self._client))
-        if team_id is None:
+        if team_id is None or team_id == "__quit__":
             self.exit()
             return
         # Fetch team info and update header
@@ -197,9 +209,20 @@ class ChatApp(App[None]):
         else:
             self._team_id = team_id
         if self._connection_manager is not None:
+            # Create a fresh ConnectionManager with the correct team_id,
+            # matching the legacy REPL pattern: one ConnectionManager per team,
+            # one connect(), one WebSocket. Do NOT reuse the empty-team_id
+            # ConnectionManager — switch_team creates a WS without setting
+            # state, then stream_events creates a second WS via connect().
+            from akgentic.infra.cli.connection import ConnectionManager as ConnMgr
+
+            self._connection_manager = ConnMgr(
+                server_url=self._connection_manager._server_url,  # noqa: SLF001
+                team_id=team_id,
+                api_key=self._connection_manager._api_key,  # noqa: SLF001
+            )
             self._connection_manager._on_state_change = self._on_conn_state_change
-            # Switch to the selected team (updates ConnectionManager's team_id)
-            await self._connection_manager.switch_team(team_id)
+        self.query_one(ChatInput).focus()
         self.stream_events()
 
     def _on_conn_state_change(self, state: ConnectionState) -> None:
@@ -244,6 +267,10 @@ class ChatApp(App[None]):
                 pass  # Fall through — receive loop will show "Connection lost"
 
         conversation = self.query_one("#conversation", VerticalScroll)
+
+        # Replay conversation history before streaming live events
+        await self._replay_history(conversation)
+
         while True:
             try:
                 event_data = await self._connection_manager.receive_event()
@@ -265,6 +292,44 @@ class ChatApp(App[None]):
         msg = SystemMessage(content="Connection lost. Use /reconnect to try again.")
         await conversation.mount(msg)
         msg.scroll_visible(animate=False)
+
+    async def _replay_history(self, conversation: VerticalScroll) -> None:
+        """Fetch and mount past events as dimmed widgets before live streaming."""
+        if self._client is None or self._event_router is None:
+            return
+        import asyncio
+
+        loop = asyncio.get_running_loop()
+        try:
+            events = await loop.run_in_executor(
+                None, self._client.get_events, self._team_id
+            )
+        except ApiError:
+            return
+        if not events:
+            return
+
+        # Remove welcome placeholder
+        for node in conversation.query("#welcome"):
+            node.remove()
+
+        displayed = False
+        for evt in events:
+            widget = self._event_router.to_widget(
+                evt.model_dump(), self._color_registry
+            )
+            if widget is not None:
+                widget.add_class("history")
+                await conversation.mount(widget)
+                displayed = True
+
+        if displayed:
+            from akgentic.infra.cli.tui.widgets.system_message import SystemMessage
+
+            sep = SystemMessage(content="── history ──")
+            sep.add_class("history")
+            await conversation.mount(sep)
+            sep.scroll_visible(animate=False)
 
     def _remove_thinking_indicator(self, conversation: VerticalScroll) -> None:
         """Remove ThinkingIndicator if present."""

--- a/src/akgentic/infra/cli/tui/app.py
+++ b/src/akgentic/infra/cli/tui/app.py
@@ -104,6 +104,8 @@ class ChatApp(App[None]):
             self._team_id = team_id
         if self._connection_manager is not None:
             self._connection_manager._on_state_change = self._on_conn_state_change
+            # Switch to the selected team (updates ConnectionManager's team_id)
+            await self._connection_manager.switch_team(team_id)
         self.stream_events()
 
     def _on_conn_state_change(self, state: ConnectionState) -> None:
@@ -138,16 +140,28 @@ class ChatApp(App[None]):
             return
         from akgentic.infra.cli.ws_client import WsConnectionError
 
+        # Ensure WebSocket is connected before entering the receive loop.
+        # ConnectionManager.receive_event() raises immediately if not connected,
+        # unlike the old REPL which called connect() explicitly before looping.
+        if self._connection_manager.state == ConnectionState.DISCONNECTED:
+            try:
+                await self._connection_manager.connect()
+            except WsConnectionError:
+                pass  # Fall through — receive loop will show "Connection lost"
+
         conversation = self.query_one("#conversation", VerticalScroll)
         while True:
             try:
                 event_data = await self._connection_manager.receive_event()
+                _log.debug("WS event received: %s", event_data)
                 widget = self._event_router.to_widget(event_data, self._color_registry)
+                _log.debug("to_widget result: %s", type(widget).__name__ if widget else None)
                 if widget is not None:
                     self._remove_thinking_indicator(conversation)
                     await conversation.mount(widget)
                     widget.scroll_visible(animate=False)
-            except WsConnectionError:
+            except WsConnectionError as exc:
+                _log.debug("WS connection error in stream loop: %s", exc)
                 self._remove_thinking_indicator(conversation)
                 break
 

--- a/src/akgentic/infra/cli/tui/app.py
+++ b/src/akgentic/infra/cli/tui/app.py
@@ -11,8 +11,10 @@ from textual.app import App, ComposeResult
 from textual.containers import VerticalScroll
 from textual.widgets import Static
 
+from akgentic.infra.cli.client import ApiError
 from akgentic.infra.cli.connection import ConnectionState
 from akgentic.infra.cli.tui.colors import AgentColorRegistry
+from akgentic.infra.cli.tui.command_adapter import TuiCommandAdapter
 from akgentic.infra.cli.tui.messages import ConnectionStateChanged
 from akgentic.infra.cli.tui.widgets.chat_input import ChatInput
 from akgentic.infra.cli.tui.widgets.hint_bar import HintBar
@@ -54,6 +56,7 @@ class ChatApp(App[None]):
         self._command_registry = command_registry
         self._client = client
         self._color_registry = AgentColorRegistry()
+        self._tui_adapter = TuiCommandAdapter(command_registry) if command_registry else None
 
     def compose(self) -> ComposeResult:
         """Compose the four-zone layout."""
@@ -168,7 +171,8 @@ class ChatApp(App[None]):
         text = event.text
         if text.startswith("/"):
             # Slash commands -- do NOT mount ThinkingIndicator
-            # Slash command dispatch is Story 12.6 -- for now, skip
+            if self._tui_adapter is not None:
+                await self._tui_adapter.dispatch(text, self)
             return
         conversation = self.query_one("#conversation", VerticalScroll)
 
@@ -190,4 +194,24 @@ class ChatApp(App[None]):
         indicator = ThinkingIndicator()
         await conversation.mount(indicator)
         indicator.scroll_visible(animate=False)
-        # TODO (Story 12.6): Actually send message via API
+
+        # Send message via API in background thread
+        self._send_message(text)
+
+    @work(thread=True)
+    def _send_message(self, text: str) -> None:
+        """Send a user message via the REST API in a background thread."""
+        if self._client is not None:
+            try:
+                self._client.send_message(self._team_id, text)
+            except ApiError as exc:
+                self.call_from_thread(self._mount_send_error, str(exc.detail))
+
+    async def _mount_send_error(self, detail: str) -> None:
+        """Mount an ErrorWidget for a failed message send (called from thread)."""
+        from akgentic.infra.cli.tui.widgets.error import ErrorWidget
+
+        conversation = self.query_one("#conversation", VerticalScroll)
+        widget = ErrorWidget(content=f"Failed to send message: {detail}")
+        await conversation.mount(widget)
+        widget.scroll_visible(animate=False)

--- a/src/akgentic/infra/cli/tui/app.py
+++ b/src/akgentic/infra/cli/tui/app.py
@@ -197,8 +197,11 @@ class ChatApp(App[None]):
             self._team_id = team_id
         if self._connection_manager is not None:
             self._connection_manager._on_state_change = self._on_conn_state_change
-            # Switch to the selected team (updates ConnectionManager's team_id)
-            await self._connection_manager.switch_team(team_id)
+            # Set team_id and let stream_events handle the single connect().
+            # Do NOT call switch_team() here — it creates a WS without setting
+            # connection state, then stream_events creates a SECOND WS via
+            # connect(), causing duplicate connections and reconnect loops.
+            self._connection_manager._team_id = team_id  # noqa: SLF001
         self.stream_events()
 
     def _on_conn_state_change(self, state: ConnectionState) -> None:

--- a/src/akgentic/infra/cli/tui/app.py
+++ b/src/akgentic/infra/cli/tui/app.py
@@ -197,11 +197,8 @@ class ChatApp(App[None]):
             self._team_id = team_id
         if self._connection_manager is not None:
             self._connection_manager._on_state_change = self._on_conn_state_change
-            # Set team_id and let stream_events handle the single connect().
-            # Do NOT call switch_team() here — it creates a WS without setting
-            # connection state, then stream_events creates a SECOND WS via
-            # connect(), causing duplicate connections and reconnect loops.
-            self._connection_manager._team_id = team_id  # noqa: SLF001
+            # Switch to the selected team (updates ConnectionManager's team_id)
+            await self._connection_manager.switch_team(team_id)
         self.stream_events()
 
     def _on_conn_state_change(self, state: ConnectionState) -> None:
@@ -256,9 +253,6 @@ class ChatApp(App[None]):
                     self._remove_thinking_indicator(conversation)
                     await conversation.mount(widget)
                     widget.scroll_visible(animate=False)
-                    # Deferred cleanup: schedule removal after the event loop
-                    # processes any pending mounts from on_chat_input_submitted.
-                    self.call_later(self._remove_thinking_indicator, conversation)
             except WsConnectionError as exc:
                 _log.debug("WS connection error in stream loop: %s", exc)
                 self._remove_thinking_indicator(conversation)

--- a/src/akgentic/infra/cli/tui/app.py
+++ b/src/akgentic/infra/cli/tui/app.py
@@ -207,8 +207,12 @@ class ChatApp(App[None]):
             except ApiError as exc:
                 self.call_from_thread(self._mount_send_error, str(exc.detail))
 
-    async def _mount_send_error(self, detail: str) -> None:
-        """Mount an ErrorWidget for a failed message send (called from thread)."""
+    def _mount_send_error(self, detail: str) -> None:
+        """Schedule ErrorWidget mount for a failed message send (called from thread)."""
+        self.run_worker(self._do_mount_send_error(detail), exclusive=False)
+
+    async def _do_mount_send_error(self, detail: str) -> None:
+        """Mount an ErrorWidget for a failed message send."""
         from akgentic.infra.cli.tui.widgets.error import ErrorWidget
 
         conversation = self.query_one("#conversation", VerticalScroll)

--- a/src/akgentic/infra/cli/tui/app.py
+++ b/src/akgentic/infra/cli/tui/app.py
@@ -17,6 +17,7 @@ from akgentic.infra.cli.tui.colors import AgentColorRegistry
 from akgentic.infra.cli.tui.command_adapter import TuiCommandAdapter
 from akgentic.infra.cli.tui.messages import ConnectionStateChanged
 from akgentic.infra.cli.tui.widgets.chat_input import ChatInput
+from akgentic.infra.cli.tui.widgets.command_palette import CommandPalette
 from akgentic.infra.cli.tui.widgets.hint_bar import HintBar
 from akgentic.infra.cli.tui.widgets.status_header import StatusHeader
 
@@ -36,6 +37,7 @@ class ChatApp(App[None]):
 
     TITLE = "Akgentic Chat"
     CSS_PATH = _CSS_PATH
+    LAYERS = ("default", "overlay")
 
     def __init__(
         self,
@@ -74,6 +76,60 @@ class ChatApp(App[None]):
         )
         yield ChatInput(command_registry=self._command_registry)
         yield HintBar()
+
+    # -- Command palette management (mounted at app level as overlay) --
+
+    _palette: CommandPalette | None = None
+
+    def on_chat_input_palette_requested(self, _event: ChatInput.PaletteRequested) -> None:
+        """Show the command palette overlay."""
+        if self._palette is not None or self._command_registry is None:
+            return
+        self._palette = CommandPalette(self._command_registry.commands)
+        self.mount(self._palette)
+
+    def on_chat_input_palette_dismissed(self, _event: ChatInput.PaletteDismissed) -> None:
+        """Hide the command palette overlay."""
+        if self._palette is not None:
+            self._palette.remove()
+            self._palette = None
+
+    def on_chat_input_palette_filter_changed(
+        self, event: ChatInput.PaletteFilterChanged
+    ) -> None:
+        """Update the palette filter text."""
+        if self._palette is not None:
+            self._palette.filter_text = event.filter_text
+
+    def on_chat_input_palette_navigate(self, event: ChatInput.PaletteNavigate) -> None:
+        """Navigate the palette up/down."""
+        if self._palette is not None:
+            if event.direction == "up":
+                self._palette.move_up()
+            else:
+                self._palette.move_down()
+
+    def on_chat_input_palette_select(self, _event: ChatInput.PaletteSelect) -> None:
+        """Select the highlighted palette command (Tab)."""
+        if self._palette is not None:
+            cmd = self._palette.selected_command
+            self._palette.remove()
+            self._palette = None
+            if cmd is not None:
+                self.query_one(ChatInput).set_command_text(cmd)
+
+    def on_chat_input_palette_select_and_submit(
+        self, _event: ChatInput.PaletteSelectAndSubmit
+    ) -> None:
+        """Select the highlighted palette command and submit."""
+        if self._palette is not None:
+            cmd = self._palette.selected_command
+            self._palette.remove()
+            self._palette = None
+            if cmd is not None:
+                chat_input = self.query_one(ChatInput)
+                chat_input.set_command_text(cmd)
+                chat_input._submit_text()  # noqa: SLF001
 
     def on_mount(self) -> None:
         """Wire connection manager callback and start streaming."""

--- a/src/akgentic/infra/cli/tui/app.py
+++ b/src/akgentic/infra/cli/tui/app.py
@@ -21,6 +21,7 @@ from akgentic.infra.cli.tui.widgets.status_header import StatusHeader
 _log = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
+    from akgentic.infra.cli.client import ApiClient
     from akgentic.infra.cli.commands import CommandRegistry
     from akgentic.infra.cli.connection import ConnectionManager
     from akgentic.infra.cli.event_router import EventRouter
@@ -42,6 +43,7 @@ class ChatApp(App[None]):
         connection_manager: ConnectionManager | None = None,
         event_router: EventRouter | None = None,
         command_registry: CommandRegistry | None = None,
+        client: ApiClient | None = None,
     ) -> None:
         super().__init__()
         self._team_name = team_name
@@ -50,6 +52,7 @@ class ChatApp(App[None]):
         self._connection_manager = connection_manager
         self._event_router = event_router
         self._command_registry = command_registry
+        self._client = client
         self._color_registry = AgentColorRegistry()
 
     def compose(self) -> ComposeResult:
@@ -71,6 +74,31 @@ class ChatApp(App[None]):
 
     def on_mount(self) -> None:
         """Wire connection manager callback and start streaming."""
+        if not self._team_id:
+            self._select_team()
+            return
+        if self._connection_manager is not None:
+            self._connection_manager._on_state_change = self._on_conn_state_change
+        self.stream_events()
+
+    @work(exclusive=True)
+    async def _select_team(self) -> None:
+        """Push TeamSelectScreen and wait for result."""
+        from akgentic.infra.cli.tui.screens.team_select import TeamSelectScreen
+
+        team_id = await self.push_screen_wait(TeamSelectScreen(client=self._client))
+        if team_id is None:
+            self.exit()
+            return
+        # Fetch team info and update header
+        if self._client is not None:
+            team_info = self._client.get_team(team_id)
+            self._team_id = team_id
+            self._team_name = team_info.name
+            self._team_status = team_info.status
+            self.query_one(StatusHeader).update_team(team_info.name, team_id, team_info.status)
+        else:
+            self._team_id = team_id
         if self._connection_manager is not None:
             self._connection_manager._on_state_change = self._on_conn_state_change
         self.stream_events()

--- a/src/akgentic/infra/cli/tui/app.py
+++ b/src/akgentic/infra/cli/tui/app.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING
 
 from textual import events, work
 from textual.app import App, ComposeResult
-from textual.containers import VerticalScroll
+from textual.containers import Container, VerticalScroll
 from textual.widgets import Static
 
 from akgentic.infra.cli.client import ApiError
@@ -74,8 +74,9 @@ class ChatApp(App[None]):
             ),
             id="conversation",
         )
-        yield ChatInput(command_registry=self._command_registry)
-        yield HintBar()
+        with Container(id="input-area"):
+            yield ChatInput(command_registry=self._command_registry)
+            yield HintBar()
 
     # -- Command palette management (mounted at app level as overlay) --
 

--- a/src/akgentic/infra/cli/tui/app.py
+++ b/src/akgentic/infra/cli/tui/app.py
@@ -6,7 +6,7 @@ import logging
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-from textual import work
+from textual import events, work
 from textual.app import App, ComposeResult
 from textual.containers import VerticalScroll
 from textual.widgets import Static
@@ -130,6 +130,43 @@ class ChatApp(App[None]):
                 chat_input = self.query_one(ChatInput)
                 chat_input.set_command_text(cmd)
                 chat_input._submit_text()  # noqa: SLF001
+
+    # -- ESC key: return to team select screen --
+
+    def on_key(self, event: events.Key) -> None:
+        """Handle app-level key events."""
+        if event.key == "escape":
+            # Don't intercept ESC when a screen overlay is active
+            if len(self.screen_stack) > 1:
+                return
+            # If command palette is open, let ChatInput handle it
+            chat_input = self.query_one(ChatInput)
+            if chat_input._palette_visible:  # noqa: SLF001
+                return
+            # Return to team select screen
+            event.prevent_default()
+            self._switch_team()
+
+    @work(exclusive=False)
+    async def _switch_team(self) -> None:
+        """Push TeamSelectScreen from chat view and switch to the selected team."""
+        from akgentic.infra.cli.tui.screens.team_select import TeamSelectScreen
+
+        team_id = await self.push_screen_wait(TeamSelectScreen(client=self._client))
+        if team_id is None:
+            return
+        if self._client is not None:
+            team_info = self._client.get_team(team_id)
+            self._team_id = team_id
+            self._team_name = team_info.name
+            self._team_status = team_info.status
+            self.query_one(StatusHeader).update_team(team_info.name, team_id, team_info.status)
+        else:
+            self._team_id = team_id
+        if self._connection_manager is not None:
+            self._connection_manager._on_state_change = self._on_conn_state_change
+            await self._connection_manager.switch_team(team_id)
+        self.stream_events()
 
     def on_mount(self) -> None:
         """Wire connection manager callback and start streaming."""

--- a/src/akgentic/infra/cli/tui/app.py
+++ b/src/akgentic/infra/cli/tui/app.py
@@ -368,15 +368,27 @@ class ChatApp(App[None]):
         await conversation.mount(indicator)
         indicator.scroll_visible(animate=False)
 
+        # Parse @mention for directed messages
+        agent_name: str | None = None
+        send_text = text
+        stripped = text.strip()
+        if stripped.startswith("@") and " " in stripped:
+            parts = stripped.split(None, 1)
+            agent_name = parts[0]
+            send_text = parts[1]
+
         # Send message via API in background thread
-        self._send_message(text)
+        self._send_message(send_text, agent_name=agent_name)
 
     @work(thread=True)
-    def _send_message(self, text: str) -> None:
+    def _send_message(self, text: str, agent_name: str | None = None) -> None:
         """Send a user message via the REST API in a background thread."""
         if self._client is not None:
             try:
-                self._client.send_message(self._team_id, text)
+                if agent_name is not None:
+                    self._client.send_message_to(self._team_id, agent_name, text)
+                else:
+                    self._client.send_message(self._team_id, text)
             except ApiError as exc:
                 self.call_from_thread(self._mount_send_error, str(exc.detail))
 

--- a/src/akgentic/infra/cli/tui/app.py
+++ b/src/akgentic/infra/cli/tui/app.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -16,6 +17,8 @@ from akgentic.infra.cli.tui.messages import ConnectionStateChanged
 from akgentic.infra.cli.tui.widgets.chat_input import ChatInput
 from akgentic.infra.cli.tui.widgets.hint_bar import HintBar
 from akgentic.infra.cli.tui.widgets.status_header import StatusHeader
+
+_log = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from akgentic.infra.cli.connection import ConnectionManager
@@ -82,7 +85,7 @@ class ChatApp(App[None]):
         try:
             self.query_one(StatusHeader).update_connection(state_str)
         except Exception:  # noqa: BLE001
-            pass
+            _log.debug("StatusHeader not available for connection state update")
         try:
             chat_input = self.query_one(ChatInput)
             if state_str == "disconnected":
@@ -92,7 +95,7 @@ class ChatApp(App[None]):
             elif state_str == "connected":
                 chat_input.border_title = "> "
         except Exception:  # noqa: BLE001
-            pass
+            _log.debug("ChatInput not available for connection state update")
 
     @work(exclusive=True)
     async def stream_events(self) -> None:

--- a/src/akgentic/infra/cli/tui/app.py
+++ b/src/akgentic/infra/cli/tui/app.py
@@ -3,14 +3,23 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import TYPE_CHECKING
 
+from textual import work
 from textual.app import App, ComposeResult
 from textual.containers import VerticalScroll
 from textual.widgets import Static
 
+from akgentic.infra.cli.connection import ConnectionState
+from akgentic.infra.cli.tui.colors import AgentColorRegistry
+from akgentic.infra.cli.tui.messages import ConnectionStateChanged
 from akgentic.infra.cli.tui.widgets.chat_input import ChatInput
 from akgentic.infra.cli.tui.widgets.hint_bar import HintBar
 from akgentic.infra.cli.tui.widgets.status_header import StatusHeader
+
+if TYPE_CHECKING:
+    from akgentic.infra.cli.connection import ConnectionManager
+    from akgentic.infra.cli.event_router import EventRouter
 
 _CSS_PATH = Path(__file__).parent / "styles" / "chat.tcss"
 
@@ -26,11 +35,16 @@ class ChatApp(App[None]):
         team_name: str = "(no team)",
         team_id: str = "",
         team_status: str = "running",
+        connection_manager: ConnectionManager | None = None,
+        event_router: EventRouter | None = None,
     ) -> None:
         super().__init__()
         self._team_name = team_name
         self._team_id = team_id
         self._team_status = team_status
+        self._connection_manager = connection_manager
+        self._event_router = event_router
+        self._color_registry = AgentColorRegistry()
 
     def compose(self) -> ComposeResult:
         """Compose the four-zone layout."""
@@ -48,3 +62,98 @@ class ChatApp(App[None]):
         )
         yield ChatInput()
         yield HintBar()
+
+    def on_mount(self) -> None:
+        """Wire connection manager callback and start streaming."""
+        if self._connection_manager is not None:
+            self._connection_manager._on_state_change = self._on_conn_state_change
+        self.stream_events()
+
+    def _on_conn_state_change(self, state: ConnectionState) -> None:
+        """Callback for ConnectionManager -- post as Textual message."""
+        self.post_message(ConnectionStateChanged(state))
+
+    def on_connection_state_changed(
+        self,
+        event: ConnectionStateChanged,
+    ) -> None:
+        """Forward connection state changes to child widgets."""
+        state_str = event.state.value
+        try:
+            self.query_one(StatusHeader).update_connection(state_str)
+        except Exception:  # noqa: BLE001
+            pass
+        try:
+            chat_input = self.query_one(ChatInput)
+            if state_str == "disconnected":
+                chat_input.border_title = "\\[disconnected] > "
+            elif state_str == "reconnecting":
+                chat_input.border_title = "\\[reconnecting...] > "
+            elif state_str == "connected":
+                chat_input.border_title = "> "
+        except Exception:  # noqa: BLE001
+            pass
+
+    @work(exclusive=True)
+    async def stream_events(self) -> None:
+        """Background worker: stream WebSocket events and mount widgets."""
+        if self._connection_manager is None or self._event_router is None:
+            return
+        from akgentic.infra.cli.ws_client import WsConnectionError
+
+        conversation = self.query_one("#conversation", VerticalScroll)
+        while True:
+            try:
+                event_data = await self._connection_manager.receive_event()
+                widget = self._event_router.to_widget(event_data, self._color_registry)
+                if widget is not None:
+                    self._remove_thinking_indicator(conversation)
+                    await conversation.mount(widget)
+                    widget.scroll_visible(animate=False)
+            except WsConnectionError:
+                self._remove_thinking_indicator(conversation)
+                break
+
+        # Mount disconnection message after worker exits
+        from akgentic.infra.cli.tui.widgets.system_message import SystemMessage
+
+        msg = SystemMessage(content="Connection lost. Use /reconnect to try again.")
+        await conversation.mount(msg)
+        msg.scroll_visible(animate=False)
+
+    def _remove_thinking_indicator(self, conversation: VerticalScroll) -> None:
+        """Remove ThinkingIndicator if present."""
+        from akgentic.infra.cli.tui.widgets.thinking import ThinkingIndicator
+
+        indicators = conversation.query(ThinkingIndicator)
+        for indicator in indicators:
+            indicator.remove()
+
+    async def on_chat_input_submitted(self, event: ChatInput.Submitted) -> None:
+        """Handle user message submission."""
+        text = event.text
+        if text.startswith("/"):
+            # Slash commands -- do NOT mount ThinkingIndicator
+            # Slash command dispatch is Story 12.6 -- for now, skip
+            return
+        conversation = self.query_one("#conversation", VerticalScroll)
+
+        # Remove welcome placeholder on first message
+        welcome_nodes = conversation.query("#welcome")
+        for node in welcome_nodes:
+            node.remove()
+
+        # Mount user message widget
+        from akgentic.infra.cli.tui.widgets.user_message import UserMessage
+
+        user_msg = UserMessage(content=text)
+        await conversation.mount(user_msg)
+        user_msg.scroll_visible(animate=False)
+
+        # Mount ThinkingIndicator
+        from akgentic.infra.cli.tui.widgets.thinking import ThinkingIndicator
+
+        indicator = ThinkingIndicator()
+        await conversation.mount(indicator)
+        indicator.scroll_visible(animate=False)
+        # TODO (Story 12.6): Actually send message via API

--- a/src/akgentic/infra/cli/tui/colors.py
+++ b/src/akgentic/infra/cli/tui/colors.py
@@ -1,0 +1,25 @@
+"""Agent color assignment for TUI conversation widgets."""
+
+from __future__ import annotations
+
+
+class AgentColorRegistry:
+    """Round-robin agent color assignment."""
+
+    _PALETTE: list[str] = ["cyan", "green", "magenta", "yellow", "blue", "red"]
+
+    def __init__(self) -> None:
+        self._map: dict[str, str] = {}
+        self._idx: int = 0
+
+    def get(self, agent_name: str) -> str:
+        """Return a consistent color for an agent (round-robin assignment)."""
+        if agent_name not in self._map:
+            self._map[agent_name] = self._PALETTE[self._idx % len(self._PALETTE)]
+            self._idx += 1
+        return self._map[agent_name]
+
+    def reset(self) -> None:
+        """Clear all assignments (e.g., on team switch)."""
+        self._map.clear()
+        self._idx = 0

--- a/src/akgentic/infra/cli/tui/command_adapter.py
+++ b/src/akgentic/infra/cli/tui/command_adapter.py
@@ -7,7 +7,7 @@ import logging
 from contextlib import redirect_stdout
 from typing import TYPE_CHECKING, Any
 
-from akgentic.infra.cli.client import ApiError
+from akgentic.infra.cli.client import ApiClient, ApiError
 from akgentic.infra.cli.commands import CommandRegistry
 from akgentic.infra.cli.renderers import RichRenderer
 
@@ -24,11 +24,11 @@ class _NoOpRenderer(RichRenderer):
         super().__init__()
         self._error_buffer = error_buffer
 
-    def render_error(self, message: str) -> None:  # type: ignore[override]
+    def render_error(self, content: str) -> None:
         """Capture errors instead of printing them."""
-        self._error_buffer.append(message)
+        self._error_buffer.append(content)
 
-    def render_border(self) -> None:
+    def render_border(self, style: str = "bright_black") -> None:
         """No-op in TUI."""
 
     def render_status_bar(self, *_args: object) -> None:
@@ -103,6 +103,19 @@ class TuiCommandAdapter:
       TUI-specific implementations.
     """
 
+    # Commands that need TUI-specific behavior (worker restart, StatusHeader, etc.)
+    _TUI_OVERRIDES = frozenset(
+        {
+            "quit",
+            "switch",
+            "reconnect",
+            "delete",
+            "create",
+            "stop",
+            "restore",
+        }
+    )
+
     def __init__(self, registry: CommandRegistry) -> None:
         self._registry = registry
 
@@ -120,6 +133,19 @@ class TuiCommandAdapter:
         args = parts[1] if len(parts) > 1 else ""
 
         # TUI-overridden commands
+        if cmd_name in self._TUI_OVERRIDES:
+            return await self._dispatch_override(cmd_name, args, app)
+
+        # Generic dispatch: capture stdout + renderer errors
+        return await self._dispatch_generic(cmd_name, args, app)
+
+    async def _dispatch_override(
+        self,
+        cmd_name: str,
+        args: str,
+        app: ChatApp,
+    ) -> bool:
+        """Route to TUI-specific command handlers."""
         if cmd_name == "quit":
             return await self._handle_quit(app)
         if cmd_name == "switch":
@@ -128,17 +154,34 @@ class TuiCommandAdapter:
             return await self._handle_reconnect(app)
         if cmd_name == "delete":
             return await self._handle_delete(args, app)
+        if cmd_name == "create":
+            return await self._handle_create(args, app)
+        if cmd_name == "stop":
+            return await self._handle_stop(app)
+        return await self._handle_restore(args, app)
 
-        # Generic dispatch: capture stdout + renderer errors
+    async def _dispatch_generic(
+        self,
+        cmd_name: str,
+        args: str,
+        app: ChatApp,
+    ) -> bool:
+        """Dispatch via CommandRegistry with stdout capture."""
         if cmd_name not in self._registry.commands:
-            await self._mount_system(app, f"Unknown command: /{cmd_name}. Type /help for available commands.")
+            await self._mount_system(
+                app,
+                f"Unknown command: /{cmd_name}. Type /help for commands.",
+            )
             return True
 
         session = _TuiSession(app, self._registry)
         buffer = io.StringIO()
         try:
             with redirect_stdout(buffer):
-                await self._registry.commands[cmd_name].handler(args, session)  # type: ignore[arg-type]
+                await self._registry.commands[cmd_name].handler(
+                    args,
+                    session,  # type: ignore[arg-type]
+                )
         except ApiError as exc:
             await self._mount_error(app, f"Command error: {exc.detail}")
             return True
@@ -285,7 +328,7 @@ class TuiCommandAdapter:
         self,
         target_id: str,
         app: ChatApp,
-        client: object | None,
+        client: ApiClient | None,
     ) -> bool:
         """Execute the actual team deletion."""
         if client is None:
@@ -293,7 +336,7 @@ class TuiCommandAdapter:
             return True
 
         try:
-            client.delete_team(target_id)  # type: ignore[union-attr]
+            client.delete_team(target_id)
         except ApiError as exc:
             await self._mount_error(app, f"Error deleting team: {exc.detail}")
             return True
@@ -311,6 +354,77 @@ class TuiCommandAdapter:
                 pass
 
         return True
+
+    async def _handle_create(self, args: str, app: ChatApp) -> bool:
+        """Handle /create <catalog_entry> with StatusHeader update and auto-switch."""
+        catalog_entry = args.strip()
+        if not catalog_entry:
+            await self._mount_system(app, "Usage: /create <catalog_entry>")
+            return True
+
+        client = app._client  # noqa: SLF001
+        if client is None:
+            await self._mount_error(app, "No API client available.")
+            return True
+
+        try:
+            team = client.create_team(catalog_entry)
+        except ApiError as exc:
+            await self._mount_error(app, f"Error creating team: {exc.detail}")
+            return True
+
+        await self._mount_system(app, f"Created team: {team.name} ({team.team_id})")
+
+        # Auto-switch to the new team
+        return await self._handle_switch(team.team_id, app)
+
+    async def _handle_stop(self, app: ChatApp) -> bool:
+        """Handle /stop with StatusHeader update."""
+        client = app._client  # noqa: SLF001
+        if client is None:
+            await self._mount_error(app, "No API client available.")
+            return True
+
+        try:
+            client.stop_team(app._team_id)  # noqa: SLF001
+        except ApiError as exc:
+            await self._mount_error(app, f"Error stopping team: {exc.detail}")
+            return True
+
+        app._team_status = "stopped"  # noqa: SLF001
+
+        from akgentic.infra.cli.tui.widgets.status_header import StatusHeader
+
+        try:
+            app.query_one(StatusHeader).update_team(
+                app._team_name,
+                app._team_id,
+                "stopped",  # noqa: SLF001
+            )
+        except Exception:  # noqa: BLE001
+            pass
+
+        await self._mount_system(app, f"Team {app._team_id} stopped.")  # noqa: SLF001
+        return True
+
+    async def _handle_restore(self, args: str, app: ChatApp) -> bool:
+        """Handle /restore [team_id] with StatusHeader update and auto-switch."""
+        target_id = args.strip() or app._team_id  # noqa: SLF001
+        client = app._client  # noqa: SLF001
+        if client is None:
+            await self._mount_error(app, "No API client available.")
+            return True
+
+        try:
+            client.restore_team(target_id)
+        except ApiError as exc:
+            await self._mount_error(app, f"Error restoring team: {exc.detail}")
+            return True
+
+        await self._mount_system(app, f"Team {target_id} restored. Live events resumed.")
+
+        # Auto-switch to restored team
+        return await self._handle_switch(target_id, app)
 
     async def _mount_system(self, app: ChatApp, text: str) -> None:
         """Mount a SystemMessage widget in the conversation area."""

--- a/src/akgentic/infra/cli/tui/command_adapter.py
+++ b/src/akgentic/infra/cli/tui/command_adapter.py
@@ -1,0 +1,335 @@
+"""Bridge between CommandRegistry handlers and TUI widget output."""
+
+from __future__ import annotations
+
+import io
+import logging
+from contextlib import redirect_stdout
+from typing import TYPE_CHECKING, Any
+
+from akgentic.infra.cli.client import ApiError
+from akgentic.infra.cli.commands import CommandRegistry
+from akgentic.infra.cli.renderers import RichRenderer
+
+if TYPE_CHECKING:
+    from akgentic.infra.cli.tui.app import ChatApp
+
+_log = logging.getLogger(__name__)
+
+
+class _NoOpRenderer(RichRenderer):
+    """Renderer stub that captures render_error calls to a buffer."""
+
+    def __init__(self, error_buffer: list[str]) -> None:
+        super().__init__()
+        self._error_buffer = error_buffer
+
+    def render_error(self, message: str) -> None:  # type: ignore[override]
+        """Capture errors instead of printing them."""
+        self._error_buffer.append(message)
+
+    def render_border(self) -> None:
+        """No-op in TUI."""
+
+    def render_status_bar(self, *_args: object) -> None:
+        """No-op in TUI."""
+
+    def render_connection_status(self, _status: str) -> None:
+        """No-op in TUI."""
+
+    def render_system_message(self, _msg: str) -> None:
+        """No-op in TUI."""
+
+    def render_history_separator(self) -> None:
+        """No-op in TUI."""
+
+
+class _TuiSession:
+    """Lightweight adapter satisfying the ChatSession interface for command handlers.
+
+    Bridges TUI state (from ChatApp) to the handler signature so existing handlers
+    work without modification.
+    """
+
+    def __init__(self, app: ChatApp, registry: CommandRegistry) -> None:
+        self._app = app
+        self.client = app._client  # noqa: SLF001
+        self.conn = app._connection_manager  # noqa: SLF001
+        self.command_registry = registry
+        self._error_buffer: list[str] = []
+        self.renderer = _NoOpRenderer(self._error_buffer)
+        self._receive_task = None
+        self._message_buffer: list[str] = []
+
+    @property
+    def team_id(self) -> str:
+        """Forward team_id from ChatApp."""
+        return self._app._team_id  # noqa: SLF001
+
+    @team_id.setter
+    def team_id(self, value: str) -> None:
+        self._app._team_id = value  # noqa: SLF001
+
+    @property
+    def _state(self) -> object:
+        """Stub for session state access."""
+        return _MinimalState(self._app._team_id)  # noqa: SLF001
+
+    def _fetch_team_info(self) -> None:
+        """No-op stub -- TUI uses StatusHeader.update_team() instead."""
+
+    def _render_event(self, _data: dict[str, Any]) -> bool:
+        """No-op stub -- TUI uses EventRouter.to_widget() instead."""
+        return False
+
+    async def replay_history_async(self) -> None:
+        """No-op stub -- TUI replays via stream_events()."""
+
+
+class _MinimalState:
+    """Minimal state object exposing team_id for command handlers."""
+
+    def __init__(self, team_id: str) -> None:
+        self.team_id = team_id
+
+
+class TuiCommandAdapter:
+    """Bridges CommandRegistry handlers to TUI widget output.
+
+    - Output-producing commands: captures print() via redirect_stdout,
+      mounts captured text as SystemMessage widgets.
+    - Error output: captures render_error() calls, mounts ErrorWidget.
+    - Overridden commands: /switch, /reconnect, /quit, /delete get
+      TUI-specific implementations.
+    """
+
+    def __init__(self, registry: CommandRegistry) -> None:
+        self._registry = registry
+
+    async def dispatch(self, line: str, app: ChatApp) -> bool:
+        """Dispatch a slash command line, mounting results as TUI widgets.
+
+        Returns True if the command was handled, False if not a command.
+        """
+        stripped = line.strip()
+        if not stripped.startswith("/"):
+            return False
+
+        parts = stripped.split(maxsplit=1)
+        cmd_name = parts[0][1:]
+        args = parts[1] if len(parts) > 1 else ""
+
+        # TUI-overridden commands
+        if cmd_name == "quit":
+            return await self._handle_quit(app)
+        if cmd_name == "switch":
+            return await self._handle_switch(args, app)
+        if cmd_name == "reconnect":
+            return await self._handle_reconnect(app)
+        if cmd_name == "delete":
+            return await self._handle_delete(args, app)
+
+        # Generic dispatch: capture stdout + renderer errors
+        if cmd_name not in self._registry.commands:
+            await self._mount_system(app, f"Unknown command: /{cmd_name}. Type /help for available commands.")
+            return True
+
+        session = _TuiSession(app, self._registry)
+        buffer = io.StringIO()
+        try:
+            with redirect_stdout(buffer):
+                await self._registry.commands[cmd_name].handler(args, session)  # type: ignore[arg-type]
+        except ApiError as exc:
+            await self._mount_error(app, f"Command error: {exc.detail}")
+            return True
+        except Exception as exc:  # noqa: BLE001
+            await self._mount_error(app, f"Command failed: {exc}")
+            return True
+
+        # Mount captured errors first
+        for err in session._error_buffer:
+            await self._mount_error(app, err)
+
+        # Mount captured stdout
+        output = buffer.getvalue().strip()
+        if output:
+            await self._mount_system(app, output)
+
+        return True
+
+    async def _handle_quit(self, app: ChatApp) -> bool:
+        """Handle /quit by exiting the app."""
+        app.exit()
+        return True
+
+    async def _handle_switch(self, args: str, app: ChatApp) -> bool:
+        """Handle /switch <team_id> with worker restart and StatusHeader update."""
+        new_team_id = args.strip()
+        if not new_team_id:
+            await self._mount_system(app, "Usage: /switch <team_id>")
+            return True
+
+        conn = app._connection_manager  # noqa: SLF001
+        if conn is None:
+            await self._mount_error(app, "No connection manager available.")
+            return True
+
+        try:
+            await conn.switch_team(new_team_id)
+        except Exception as exc:  # noqa: BLE001
+            await self._mount_error(app, f"Switch failed: {exc}")
+            return True
+
+        # Update app state
+        app._team_id = new_team_id  # noqa: SLF001
+
+        # Try to fetch team info for StatusHeader update
+        client = app._client  # noqa: SLF001
+        team_name = new_team_id
+        team_status = "running"
+        if client is not None:
+            try:
+                team_info = client.get_team(new_team_id)
+                team_name = team_info.name
+                team_status = team_info.status
+                app._team_name = team_name  # noqa: SLF001
+                app._team_status = team_status  # noqa: SLF001
+            except ApiError:
+                pass
+
+        # Update StatusHeader
+        from akgentic.infra.cli.tui.widgets.status_header import StatusHeader
+
+        try:
+            app.query_one(StatusHeader).update_team(team_name, new_team_id, team_status)
+        except Exception:  # noqa: BLE001
+            pass
+
+        await self._mount_system(app, f"Switched to team {team_name} ({new_team_id})")
+
+        # Restart streaming worker (exclusive=True auto-cancels previous)
+        app.stream_events()
+
+        return True
+
+    async def _handle_reconnect(self, app: ChatApp) -> bool:
+        """Handle /reconnect by triggering ConnectionManager.connect()."""
+        conn = app._connection_manager  # noqa: SLF001
+        if conn is None:
+            await self._mount_error(app, "No connection manager available.")
+            return True
+
+        from akgentic.infra.cli.tui.widgets.status_header import StatusHeader
+
+        try:
+            await conn.connect()
+        except Exception as exc:  # noqa: BLE001
+            try:
+                app.query_one(StatusHeader).update_connection("disconnected")
+            except Exception:  # noqa: BLE001
+                pass
+            await self._mount_error(app, f"Reconnection failed: {exc}")
+            return True
+
+        try:
+            app.query_one(StatusHeader).update_connection("connected")
+        except Exception:  # noqa: BLE001
+            pass
+
+        await self._mount_system(app, "Reconnected to server.")
+
+        # Restart streaming
+        app.stream_events()
+
+        return True
+
+    async def _handle_delete(self, args: str, app: ChatApp) -> bool:
+        """Handle /delete with two-step confirmation flow.
+
+        /delete <team_id> -> warning message
+        /delete confirm <team_id> -> actual deletion
+        """
+        parts = args.strip().split(maxsplit=1)
+        client = app._client  # noqa: SLF001
+
+        if not parts or not parts[0]:
+            target_id = app._team_id  # noqa: SLF001
+            await self._mount_system(
+                app,
+                f"To delete team {target_id}, type: /delete confirm {target_id}",
+            )
+            return True
+
+        if parts[0] == "confirm":
+            target_id = parts[1].strip() if len(parts) > 1 else app._team_id  # noqa: SLF001
+            return await self._execute_delete(target_id, app, client)
+
+        # First call with team_id -- show warning
+        target_id = parts[0]
+        team_label = target_id
+        if client is not None:
+            try:
+                team_info = client.get_team(target_id)
+                team_label = f"{team_info.name} ({target_id})"
+            except ApiError:
+                pass
+
+        await self._mount_system(
+            app,
+            f"Warning: Delete team {team_label}? All event history will be lost.\n"
+            f"To confirm, type: /delete confirm {target_id}",
+        )
+        return True
+
+    async def _execute_delete(
+        self,
+        target_id: str,
+        app: ChatApp,
+        client: object | None,
+    ) -> bool:
+        """Execute the actual team deletion."""
+        if client is None:
+            await self._mount_error(app, "No API client available.")
+            return True
+
+        try:
+            client.delete_team(target_id)  # type: ignore[union-attr]
+        except ApiError as exc:
+            await self._mount_error(app, f"Error deleting team: {exc.detail}")
+            return True
+
+        from akgentic.infra.cli.tui.widgets.status_header import StatusHeader
+
+        await self._mount_system(app, f"Team {target_id} deleted.")
+        if target_id == app._team_id:  # noqa: SLF001
+            await self._mount_system(
+                app, "Current team deleted. Use /switch or /teams to select another team."
+            )
+            try:
+                app.query_one(StatusHeader).update_team("(deleted)", target_id, "deleted")
+            except Exception:  # noqa: BLE001
+                pass
+
+        return True
+
+    async def _mount_system(self, app: ChatApp, text: str) -> None:
+        """Mount a SystemMessage widget in the conversation area."""
+        from textual.containers import VerticalScroll
+
+        from akgentic.infra.cli.tui.widgets.system_message import SystemMessage
+
+        conversation = app.query_one("#conversation", VerticalScroll)
+        widget = SystemMessage(content=text)
+        await conversation.mount(widget)
+        widget.scroll_visible(animate=False)
+
+    async def _mount_error(self, app: ChatApp, text: str) -> None:
+        """Mount an ErrorWidget in the conversation area."""
+        from textual.containers import VerticalScroll
+
+        from akgentic.infra.cli.tui.widgets.error import ErrorWidget
+
+        conversation = app.query_one("#conversation", VerticalScroll)
+        widget = ErrorWidget(content=text)
+        await conversation.mount(widget)
+        widget.scroll_visible(animate=False)

--- a/src/akgentic/infra/cli/tui/command_adapter.py
+++ b/src/akgentic/infra/cli/tui/command_adapter.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import io
 import logging
 from contextlib import redirect_stdout
@@ -21,7 +22,9 @@ class _NoOpRenderer(RichRenderer):
     """Renderer stub that captures render_error calls to a buffer."""
 
     def __init__(self, error_buffer: list[str]) -> None:
-        super().__init__()
+        from rich.console import Console
+
+        super().__init__(console=Console(file=io.StringIO(), width=80))
         self._error_buffer = error_buffer
 
     def render_error(self, content: str) -> None:
@@ -113,6 +116,7 @@ class TuiCommandAdapter:
             "create",
             "stop",
             "restore",
+            "history",
         }
     )
 
@@ -158,6 +162,8 @@ class TuiCommandAdapter:
             return await self._handle_create(args, app)
         if cmd_name == "stop":
             return await self._handle_stop(app)
+        if cmd_name == "history":
+            return await self._handle_history(args, app)
         return await self._handle_restore(args, app)
 
     async def _dispatch_generic(
@@ -237,8 +243,8 @@ class TuiCommandAdapter:
                 team_status = team_info.status
                 app._team_name = team_name  # noqa: SLF001
                 app._team_status = team_status  # noqa: SLF001
-            except ApiError:
-                pass
+            except ApiError as exc:
+                _log.debug("Failed to fetch team info after switch: %s", exc.detail)
 
         # Update StatusHeader
         from akgentic.infra.cli.tui.widgets.status_header import StatusHeader
@@ -246,7 +252,7 @@ class TuiCommandAdapter:
         try:
             app.query_one(StatusHeader).update_team(team_name, new_team_id, team_status)
         except Exception:  # noqa: BLE001
-            pass
+            _log.debug("StatusHeader not available for team update")
 
         await self._mount_system(app, f"Switched to team {team_name} ({new_team_id})")
 
@@ -270,14 +276,14 @@ class TuiCommandAdapter:
             try:
                 app.query_one(StatusHeader).update_connection("disconnected")
             except Exception:  # noqa: BLE001
-                pass
+                _log.debug("StatusHeader not available for connection update")
             await self._mount_error(app, f"Reconnection failed: {exc}")
             return True
 
         try:
             app.query_one(StatusHeader).update_connection("connected")
         except Exception:  # noqa: BLE001
-            pass
+            _log.debug("StatusHeader not available for connection update")
 
         await self._mount_system(app, "Reconnected to server.")
 
@@ -351,7 +357,7 @@ class TuiCommandAdapter:
             try:
                 app.query_one(StatusHeader).update_team("(deleted)", target_id, "deleted")
             except Exception:  # noqa: BLE001
-                pass
+                _log.debug("StatusHeader not available for delete update")
 
         return True
 
@@ -397,12 +403,12 @@ class TuiCommandAdapter:
 
         try:
             app.query_one(StatusHeader).update_team(
-                app._team_name,
-                app._team_id,
-                "stopped",  # noqa: SLF001
+                app._team_name,  # noqa: SLF001
+                app._team_id,  # noqa: SLF001
+                "stopped",
             )
         except Exception:  # noqa: BLE001
-            pass
+            _log.debug("StatusHeader not available for stop update")
 
         await self._mount_system(app, f"Team {app._team_id} stopped.")  # noqa: SLF001
         return True
@@ -425,6 +431,60 @@ class TuiCommandAdapter:
 
         # Auto-switch to restored team
         return await self._handle_switch(target_id, app)
+
+    async def _handle_history(self, args: str, app: ChatApp) -> bool:
+        """Handle /history by fetching events and mounting them as TUI widgets."""
+        limit = 20
+        if args.strip():
+            try:
+                limit = int(args.strip())
+            except ValueError:
+                await self._mount_system(
+                    app, "Usage: /history [N] — N must be a positive integer."
+                )
+                return True
+            if limit <= 0:
+                await self._mount_system(
+                    app, "Usage: /history [N] — N must be a positive integer."
+                )
+                return True
+
+        client = app._client  # noqa: SLF001
+        if client is None:
+            await self._mount_error(app, "No API client available.")
+            return True
+
+        loop = asyncio.get_running_loop()
+        try:
+            events = await loop.run_in_executor(
+                None, client.get_events, app._team_id  # noqa: SLF001
+            )
+        except ApiError as exc:
+            await self._mount_error(app, f"Error fetching history: {exc.detail}")
+            return True
+
+        event_router = app._event_router  # noqa: SLF001
+        color_registry = app._color_registry  # noqa: SLF001
+        if event_router is None:
+            await self._mount_system(app, "No event router available for history rendering.")
+            return True
+
+        from textual.containers import VerticalScroll
+
+        conversation = app.query_one("#conversation", VerticalScroll)
+        event_dicts = [e.model_dump() for e in events]
+        displayed = 0
+        for evt in event_dicts[-limit:]:
+            widget = event_router.to_widget(evt, color_registry)
+            if widget is not None:
+                await conversation.mount(widget)
+                widget.scroll_visible(animate=False)
+                displayed += 1
+
+        if displayed == 0:
+            await self._mount_system(app, "No displayable history events found.")
+
+        return True
 
     async def _mount_system(self, app: ChatApp, text: str) -> None:
         """Mount a SystemMessage widget in the conversation area."""

--- a/src/akgentic/infra/cli/tui/messages.py
+++ b/src/akgentic/infra/cli/tui/messages.py
@@ -1,0 +1,15 @@
+"""Custom Textual messages for connection state propagation."""
+
+from __future__ import annotations
+
+from textual.message import Message
+
+from akgentic.infra.cli.connection import ConnectionState
+
+
+class ConnectionStateChanged(Message):
+    """Posted when ConnectionManager state changes."""
+
+    def __init__(self, state: ConnectionState) -> None:
+        self.state = state
+        super().__init__()

--- a/src/akgentic/infra/cli/tui/screens/__init__.py
+++ b/src/akgentic/infra/cli/tui/screens/__init__.py
@@ -1,1 +1,6 @@
 """TUI screen definitions."""
+
+from akgentic.infra.cli.tui.screens.chat import ChatScreen
+from akgentic.infra.cli.tui.screens.team_select import TeamSelectScreen
+
+__all__ = ["ChatScreen", "TeamSelectScreen"]

--- a/src/akgentic/infra/cli/tui/screens/team_select.py
+++ b/src/akgentic/infra/cli/tui/screens/team_select.py
@@ -54,8 +54,9 @@ class TeamSelectScreen(Screen[str | None]):
             yield Static("", id="team-hints")
 
     def on_mount(self) -> None:
-        """Fetch data and render the first page."""
+        """Fetch data, render, and focus the input."""
         self._fetch_data_worker()
+        self.query_one("#team-input", Input).focus()
 
     @work(thread=True)
     def _fetch_data_worker(self) -> None:
@@ -93,8 +94,8 @@ class TeamSelectScreen(Screen[str | None]):
         catalog: list[CatalogTeamInfo],
     ) -> None:
         """Store fetched data and render."""
-        self._running_teams = running
-        self._stopped_teams = stopped
+        self._running_teams = sorted(running, key=lambda t: t.created_at, reverse=True)
+        self._stopped_teams = sorted(stopped, key=lambda t: t.created_at, reverse=True)
         self._catalog = catalog
         self._render_page()
 
@@ -140,6 +141,7 @@ class TeamSelectScreen(Screen[str | None]):
             line.append(f"  [{start + i + 1}]", style="bold cyan")
             line.append(f"  {team.name}", style="bold")
             line.append(f"  {_short_id(team.team_id)}", style="dim")
+            line.append(f"  {team.created_at[:16]}", style="dim")
             line.append("  > running", style="green")
             container.mount(Static(line, classes="team-entry"))
 
@@ -163,6 +165,7 @@ class TeamSelectScreen(Screen[str | None]):
             line.append(f"  [s{start + i + 1}]", style="bold yellow")
             line.append(f"  {team.name}", style="bold")
             line.append(f"  {_short_id(team.team_id)}", style="dim")
+            line.append(f"  {team.created_at[:16]}", style="dim")
             line.append("  || stopped", style="yellow")
             container.mount(Static(line, classes="team-entry"))
 
@@ -193,7 +196,7 @@ class TeamSelectScreen(Screen[str | None]):
             hints_parts.append("[c <name>] create")
         if self._max_pages() > 1:
             hints_parts.append("<-> page")
-        hints_parts.append("[q]/Esc quit")
+        hints_parts.append("Esc back  [q] quit")
         hint_text = "  ".join(hints_parts)
         try:
             # Use Text() to avoid Rich markup interpretation of brackets
@@ -210,7 +213,7 @@ class TeamSelectScreen(Screen[str | None]):
             return
 
         if text == "q":
-            self.dismiss(None)
+            self.dismiss("__quit__")
             return
 
         if text == "n":

--- a/src/akgentic/infra/cli/tui/screens/team_select.py
+++ b/src/akgentic/infra/cli/tui/screens/team_select.py
@@ -130,15 +130,17 @@ class TeamSelectScreen(Screen[str | None]):
             return
         if len(self._running_teams) <= PAGE_SIZE:
             page = self._running_teams
+            label_start = 0
             header = f"Running teams ({len(self._running_teams)}):"
         else:
             page = self._running_teams[start:end]
+            label_start = start
             r_end = min(start + len(page), len(self._running_teams))
             header = f"Running teams ({start + 1}-{r_end} of {len(self._running_teams)}):"
         container.mount(Static(header, classes="section-header"))
         for i, team in enumerate(page):
             line = Text()
-            line.append(f"  [{start + i + 1}]", style="bold cyan")
+            line.append(f"  [{label_start + i + 1}]", style="bold cyan")
             line.append(f"  {team.name}", style="bold")
             line.append(f"  {_short_id(team.team_id)}", style="dim")
             line.append(f"  {team.created_at[:16]}", style="dim")
@@ -154,15 +156,17 @@ class TeamSelectScreen(Screen[str | None]):
             return
         if len(self._stopped_teams) <= PAGE_SIZE:
             page = self._stopped_teams
+            label_start = 0
             header = f"Stopped teams ({len(self._stopped_teams)}):"
         else:
             page = self._stopped_teams[start:end]
+            label_start = start
             s_end = min(start + len(page), len(self._stopped_teams))
             header = f"Stopped teams ({start + 1}-{s_end} of {len(self._stopped_teams)}):"
         container.mount(Static(header, classes="section-header"))
         for i, team in enumerate(page):
             line = Text()
-            line.append(f"  [s{start + i + 1}]", style="bold yellow")
+            line.append(f"  [s{label_start + i + 1}]", style="bold yellow")
             line.append(f"  {team.name}", style="bold")
             line.append(f"  {_short_id(team.team_id)}", style="dim")
             line.append(f"  {team.created_at[:16]}", style="dim")
@@ -185,13 +189,19 @@ class TeamSelectScreen(Screen[str | None]):
         """Update the hint bar based on current page state."""
         hints_parts: list[str] = []
         if self._running_teams:
-            start = self._page * PAGE_SIZE + 1
-            end = min(start + PAGE_SIZE - 1, len(self._running_teams))
-            hints_parts.append(f"[{start}-{end}] connect")
+            if len(self._running_teams) <= PAGE_SIZE:
+                hints_parts.append(f"[1-{len(self._running_teams)}] connect")
+            else:
+                start = self._page * PAGE_SIZE + 1
+                end = min(start + PAGE_SIZE - 1, len(self._running_teams))
+                hints_parts.append(f"[{start}-{end}] connect")
         if self._stopped_teams:
-            start = self._page * PAGE_SIZE + 1
-            end = min(start + PAGE_SIZE - 1, len(self._stopped_teams))
-            hints_parts.append(f"[s{start}-s{end}] restore")
+            if len(self._stopped_teams) <= PAGE_SIZE:
+                hints_parts.append(f"[s1-s{len(self._stopped_teams)}] restore")
+            else:
+                start = self._page * PAGE_SIZE + 1
+                end = min(start + PAGE_SIZE - 1, len(self._stopped_teams))
+                hints_parts.append(f"[s{start}-s{end}] restore")
         if self._catalog:
             hints_parts.append("[c <name>] create")
         if self._max_pages() > 1:

--- a/src/akgentic/infra/cli/tui/screens/team_select.py
+++ b/src/akgentic/infra/cli/tui/screens/team_select.py
@@ -113,71 +113,70 @@ class TeamSelectScreen(Screen[str | None]):
         start = self._page * PAGE_SIZE
         end = start + PAGE_SIZE
 
-        # -- Running teams --
-        if self._running_teams:
-            # If all running teams fit on one page, show all on every page
-            if len(self._running_teams) <= PAGE_SIZE:
-                r_page = self._running_teams
-                r_total = len(self._running_teams)
-                header_text = f"Running teams ({r_total}):"
-            else:
-                r_page = self._running_teams[start:end]
-                r_total = len(self._running_teams)
-                r_end = min(start + len(r_page), r_total)
-                header_text = f"Running teams ({start + 1}-{r_end} of {r_total}):"
-            container.mount(Static(header_text, classes="section-header"))
-            for i, team in enumerate(r_page):
-                global_idx = start + i + 1
-                line = Text()
-                line.append(f"  [{global_idx}]", style="bold cyan")
-                line.append(f"  {team.name}", style="bold")
-                line.append(f"  {_short_id(team.team_id)}", style="dim")
-                line.append("  > running", style="green")
-                container.mount(Static(line, classes="team-entry"))
-        else:
-            container.mount(Static("Running teams: (none)", classes="section-header"))
-
+        self._render_running_section(container, start, end)
         container.mount(Static(""))
-
-        # -- Stopped teams --
-        if self._stopped_teams:
-            # If all stopped teams fit on one page, show all on every page
-            if len(self._stopped_teams) <= PAGE_SIZE:
-                s_page = self._stopped_teams
-                s_total = len(self._stopped_teams)
-                header_text = f"Stopped teams ({s_total}):"
-            else:
-                s_page = self._stopped_teams[start:end]
-                s_total = len(self._stopped_teams)
-                s_end = min(start + len(s_page), s_total)
-                header_text = f"Stopped teams ({start + 1}-{s_end} of {s_total}):"
-            container.mount(Static(header_text, classes="section-header"))
-            for i, team in enumerate(s_page):
-                global_idx = start + i + 1
-                line = Text()
-                line.append(f"  [s{global_idx}]", style="bold yellow")
-                line.append(f"  {team.name}", style="bold")
-                line.append(f"  {_short_id(team.team_id)}", style="dim")
-                line.append("  || stopped", style="yellow")
-                container.mount(Static(line, classes="team-entry"))
-        else:
-            container.mount(Static("Stopped teams: (none)", classes="section-header"))
-
+        self._render_stopped_section(container, start, end)
         container.mount(Static(""))
-
-        # -- Catalog entries --
-        if self._catalog:
-            container.mount(Static("Create new:", classes="section-header"))
-            for entry in self._catalog:
-                line = Text()
-                line.append(f"  [c {entry.id}]", style="bold magenta")
-                line.append(f"  {entry.description}", style="dim")
-                container.mount(Static(line, classes="team-entry"))
-        else:
-            container.mount(Static("Create new: (none)", classes="section-header"))
-
-        # -- Update hints --
+        self._render_catalog_section(container)
         self._update_hints()
+
+    def _render_running_section(
+        self, container: VerticalScroll, start: int, end: int
+    ) -> None:
+        """Render the running teams section."""
+        if not self._running_teams:
+            container.mount(Static("Running teams: (none)", classes="section-header"))
+            return
+        if len(self._running_teams) <= PAGE_SIZE:
+            page = self._running_teams
+            header = f"Running teams ({len(self._running_teams)}):"
+        else:
+            page = self._running_teams[start:end]
+            r_end = min(start + len(page), len(self._running_teams))
+            header = f"Running teams ({start + 1}-{r_end} of {len(self._running_teams)}):"
+        container.mount(Static(header, classes="section-header"))
+        for i, team in enumerate(page):
+            line = Text()
+            line.append(f"  [{start + i + 1}]", style="bold cyan")
+            line.append(f"  {team.name}", style="bold")
+            line.append(f"  {_short_id(team.team_id)}", style="dim")
+            line.append("  > running", style="green")
+            container.mount(Static(line, classes="team-entry"))
+
+    def _render_stopped_section(
+        self, container: VerticalScroll, start: int, end: int
+    ) -> None:
+        """Render the stopped teams section."""
+        if not self._stopped_teams:
+            container.mount(Static("Stopped teams: (none)", classes="section-header"))
+            return
+        if len(self._stopped_teams) <= PAGE_SIZE:
+            page = self._stopped_teams
+            header = f"Stopped teams ({len(self._stopped_teams)}):"
+        else:
+            page = self._stopped_teams[start:end]
+            s_end = min(start + len(page), len(self._stopped_teams))
+            header = f"Stopped teams ({start + 1}-{s_end} of {len(self._stopped_teams)}):"
+        container.mount(Static(header, classes="section-header"))
+        for i, team in enumerate(page):
+            line = Text()
+            line.append(f"  [s{start + i + 1}]", style="bold yellow")
+            line.append(f"  {team.name}", style="bold")
+            line.append(f"  {_short_id(team.team_id)}", style="dim")
+            line.append("  || stopped", style="yellow")
+            container.mount(Static(line, classes="team-entry"))
+
+    def _render_catalog_section(self, container: VerticalScroll) -> None:
+        """Render the catalog entries section."""
+        if not self._catalog:
+            container.mount(Static("Create new: (none)", classes="section-header"))
+            return
+        container.mount(Static("Create new:", classes="section-header"))
+        for entry in self._catalog:
+            line = Text()
+            line.append(f"  [c {entry.id}]", style="bold magenta")
+            line.append(f"  {entry.description}", style="dim")
+            container.mount(Static(line, classes="team-entry"))
 
     def _update_hints(self) -> None:
         """Update the hint bar based on current page state."""

--- a/src/akgentic/infra/cli/tui/screens/team_select.py
+++ b/src/akgentic/infra/cli/tui/screens/team_select.py
@@ -26,8 +26,8 @@ _CSS_PATH = Path(__file__).parent.parent / "styles" / "team_select.tcss"
 
 
 def _short_id(team_id: str) -> str:
-    """Truncate a UUID to the first 13 characters."""
-    return team_id[:13] if len(team_id) > 13 else team_id
+    """Return team ID for display."""
+    return team_id
 
 
 class TeamSelectScreen(Screen[str | None]):

--- a/src/akgentic/infra/cli/tui/screens/team_select.py
+++ b/src/akgentic/infra/cli/tui/screens/team_select.py
@@ -1,0 +1,301 @@
+"""Full-screen team selection menu with pagination."""
+
+from __future__ import annotations
+
+import logging
+import math
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from rich.text import Text
+from textual import work
+from textual.app import ComposeResult
+from textual.containers import VerticalScroll
+from textual.screen import Screen
+from textual.widgets import Input, Static
+
+if TYPE_CHECKING:
+    from akgentic.infra.cli.client import ApiClient, CatalogTeamInfo, TeamInfo
+
+_log = logging.getLogger(__name__)
+
+PAGE_SIZE = 5
+
+_CSS_PATH = Path(__file__).parent.parent / "styles" / "team_select.tcss"
+
+
+def _short_id(team_id: str) -> str:
+    """Truncate a UUID to the first 13 characters."""
+    return team_id[:13] if len(team_id) > 13 else team_id
+
+
+class TeamSelectScreen(Screen[str | None]):
+    """Full-screen team selection with pagination for running/stopped teams."""
+
+    CSS_PATH = _CSS_PATH
+
+    def __init__(self, client: ApiClient | None = None) -> None:
+        super().__init__()
+        self._client = client
+        self._page: int = 0
+        self._running_teams: list[TeamInfo] = []
+        self._stopped_teams: list[TeamInfo] = []
+        self._catalog: list[CatalogTeamInfo] = []
+
+    def compose(self) -> ComposeResult:
+        """Compose the team selection layout."""
+        yield Static("Akgentic -- Team Selection", id="team-header")
+        yield VerticalScroll(id="team-list")
+        yield Static("", id="team-hints")
+        yield Input(placeholder="> ", id="team-input")
+
+    def on_mount(self) -> None:
+        """Fetch data and render the first page."""
+        self._fetch_data_worker()
+
+    @work(thread=True)
+    def _fetch_data_worker(self) -> None:
+        """Fetch teams and catalog data in a background thread."""
+        running, stopped, catalog = self._fetch_data()
+        self.app.call_from_thread(self._on_data_loaded, running, stopped, catalog)
+
+    def _fetch_data(
+        self,
+    ) -> tuple[list[TeamInfo], list[TeamInfo], list[CatalogTeamInfo]]:
+        """Call API to get teams and catalog. Returns (running, stopped, catalog)."""
+        from akgentic.infra.cli.client import ApiError
+
+        running: list[TeamInfo] = []
+        stopped: list[TeamInfo] = []
+        catalog: list[CatalogTeamInfo] = []
+        if self._client is None:
+            return running, stopped, catalog
+        try:
+            teams = self._client.list_teams()
+            running = [t for t in teams if t.status == "running"]
+            stopped = [t for t in teams if t.status == "stopped"]
+        except ApiError:
+            _log.debug("Failed to fetch teams")
+        try:
+            catalog = self._client.list_catalog_teams()
+        except ApiError:
+            _log.debug("Failed to fetch catalog")
+        return running, stopped, catalog
+
+    def _on_data_loaded(
+        self,
+        running: list[TeamInfo],
+        stopped: list[TeamInfo],
+        catalog: list[CatalogTeamInfo],
+    ) -> None:
+        """Store fetched data and render."""
+        self._running_teams = running
+        self._stopped_teams = stopped
+        self._catalog = catalog
+        self._render_page()
+
+    def _max_pages(self) -> int:
+        """Return total number of pages based on running and stopped lists."""
+        max_items = max(len(self._running_teams), len(self._stopped_teams))
+        if max_items == 0:
+            return 1
+        return math.ceil(max_items / PAGE_SIZE)
+
+    def _render_page(self) -> None:
+        """Clear and re-render the team list for the current page."""
+        container = self.query_one("#team-list", VerticalScroll)
+        container.remove_children()
+
+        start = self._page * PAGE_SIZE
+        end = start + PAGE_SIZE
+
+        # -- Running teams --
+        if self._running_teams:
+            r_page = self._running_teams[start:end]
+            r_total = len(self._running_teams)
+            r_end = min(start + len(r_page), r_total)
+            header_text = f"Running teams ({start + 1}-{r_end} of {r_total}):"
+            container.mount(Static(header_text, classes="section-header"))
+            for i, team in enumerate(r_page):
+                global_idx = start + i + 1
+                line = Text()
+                line.append(f"  \\[{global_idx}]", style="bold cyan")
+                line.append(f"  {team.name}", style="bold")
+                line.append(f"  {_short_id(team.team_id)}", style="dim")
+                line.append("  > running", style="green")
+                container.mount(Static(line, classes="team-entry"))
+        else:
+            container.mount(Static("Running teams: (none)", classes="section-header"))
+
+        container.mount(Static(""))
+
+        # -- Stopped teams --
+        if self._stopped_teams:
+            s_page = self._stopped_teams[start:end]
+            s_total = len(self._stopped_teams)
+            s_end = min(start + len(s_page), s_total)
+            header_text = f"Stopped teams ({start + 1}-{s_end} of {s_total}):"
+            container.mount(Static(header_text, classes="section-header"))
+            for i, team in enumerate(s_page):
+                global_idx = start + i + 1
+                line = Text()
+                line.append(f"  \\[s{global_idx}]", style="bold yellow")
+                line.append(f"  {team.name}", style="bold")
+                line.append(f"  {_short_id(team.team_id)}", style="dim")
+                line.append("  || stopped", style="yellow")
+                container.mount(Static(line, classes="team-entry"))
+        else:
+            container.mount(Static("Stopped teams: (none)", classes="section-header"))
+
+        container.mount(Static(""))
+
+        # -- Catalog entries --
+        if self._catalog:
+            container.mount(Static("Create new:", classes="section-header"))
+            for entry in self._catalog:
+                line = Text()
+                line.append(f"  \\[c {entry.id}]", style="bold magenta")
+                line.append(f"  {entry.description}", style="dim")
+                container.mount(Static(line, classes="team-entry"))
+        else:
+            container.mount(Static("Create new: (none)", classes="section-header"))
+
+        # -- Update hints --
+        self._update_hints()
+
+    def _update_hints(self) -> None:
+        """Update the hint bar based on current page state."""
+        hints_parts: list[str] = []
+        if self._running_teams:
+            start = self._page * PAGE_SIZE + 1
+            end = min(start + PAGE_SIZE - 1, len(self._running_teams))
+            hints_parts.append(f"[{start}-{end}] connect")
+        if self._stopped_teams:
+            start = self._page * PAGE_SIZE + 1
+            end = min(start + PAGE_SIZE - 1, len(self._stopped_teams))
+            hints_parts.append(f"[s{start}-s{end}] restore")
+        if self._catalog:
+            hints_parts.append("[c <name>] create")
+        if self._max_pages() > 1:
+            hints_parts.append("<-> page")
+        hints_parts.append("[q] quit")
+        hint_text = "  ".join(hints_parts)
+        try:
+            self.query_one("#team-hints", Static).update(hint_text)
+        except Exception:  # noqa: BLE001
+            pass
+
+    def on_input_submitted(self, event: Input.Submitted) -> None:
+        """Handle user input from the Input widget."""
+        text = event.value.strip()
+        event.input.value = ""
+
+        if not text:
+            return
+
+        if text == "q":
+            self.dismiss(None)
+            return
+
+        if text == "n":
+            self._next_page()
+            return
+
+        if text == "p":
+            self._prev_page()
+            return
+
+        if text.isdigit():
+            self._select_running(int(text))
+            return
+
+        if text.startswith("s") and text[1:].isdigit():
+            self._select_stopped(int(text[1:]))
+            return
+
+        if text.startswith("c "):
+            name = text[2:].strip()
+            if name:
+                self._create_team(name)
+                return
+
+        self._show_error(f"Unknown command: {text}")
+
+    def on_key(self, event: object) -> None:
+        """Handle arrow key presses for pagination."""
+        from textual.events import Key
+
+        if not isinstance(event, Key):
+            return
+        if event.key == "right":
+            self._next_page()
+        elif event.key == "left":
+            self._prev_page()
+
+    def _next_page(self) -> None:
+        """Advance to the next page if available."""
+        if self._page < self._max_pages() - 1:
+            self._page += 1
+            self._render_page()
+
+    def _prev_page(self) -> None:
+        """Go back one page if not on the first page."""
+        if self._page > 0:
+            self._page -= 1
+            self._render_page()
+
+    def _select_running(self, number: int) -> None:
+        """Select a running team by global index."""
+        idx = number - 1
+        if 0 <= idx < len(self._running_teams):
+            self.dismiss(self._running_teams[idx].team_id)
+        else:
+            self._show_error(f"Invalid selection: {number}")
+
+    def _select_stopped(self, number: int) -> None:
+        """Select a stopped team by global index, restore it."""
+        idx = number - 1
+        if 0 <= idx < len(self._stopped_teams):
+            team = self._stopped_teams[idx]
+            self._restore_team_worker(team.team_id)
+        else:
+            self._show_error(f"Invalid selection: s{number}")
+
+    @work(thread=True)
+    def _restore_team_worker(self, team_id: str) -> None:
+        """Restore a stopped team in a background thread."""
+        from akgentic.infra.cli.client import ApiError
+
+        if self._client is None:
+            return
+        try:
+            self._client.restore_team(team_id)
+            self.app.call_from_thread(self.dismiss, team_id)
+        except ApiError as exc:
+            self.app.call_from_thread(self._show_error, f"Failed to restore team: {exc}")
+
+    def _create_team(self, catalog_entry_id: str) -> None:
+        """Create a team from a catalog entry."""
+        self._create_team_worker(catalog_entry_id)
+
+    @work(thread=True)
+    def _create_team_worker(self, catalog_entry_id: str) -> None:
+        """Create a team in a background thread."""
+        from akgentic.infra.cli.client import ApiError
+
+        if self._client is None:
+            return
+        try:
+            team = self._client.create_team(catalog_entry_id)
+            self.app.call_from_thread(self.dismiss, team.team_id)
+        except ApiError as exc:
+            self.app.call_from_thread(self._show_error, f"Failed to create team: {exc}")
+
+    def _show_error(self, message: str) -> None:
+        """Display an error message in the team list area."""
+        container = self.query_one("#team-list", VerticalScroll)
+        error_widget = Static(
+            Text(message, style="bold red"),
+            classes="error-message",
+        )
+        container.mount(error_widget)

--- a/src/akgentic/infra/cli/tui/screens/team_select.py
+++ b/src/akgentic/infra/cli/tui/screens/team_select.py
@@ -45,10 +45,13 @@ class TeamSelectScreen(Screen[str | None]):
 
     def compose(self) -> ComposeResult:
         """Compose the team selection layout."""
+        from textual.containers import Container
+
         yield Static("Akgentic -- Team Selection", id="team-header")
         yield VerticalScroll(id="team-list")
-        yield Static("", id="team-hints")
-        yield Input(placeholder="> ", id="team-input")
+        with Container(id="team-input-area"):
+            yield Input(placeholder="> ", id="team-input")
+            yield Static("", id="team-hints")
 
     def on_mount(self) -> None:
         """Fetch data and render the first page."""
@@ -179,7 +182,7 @@ class TeamSelectScreen(Screen[str | None]):
             hints_parts.append("\\[c <name>] create")
         if self._max_pages() > 1:
             hints_parts.append("<-> page")
-        hints_parts.append("\\[q] quit")
+        hints_parts.append("\\[q]/Esc quit")
         hint_text = "  ".join(hints_parts)
         try:
             self.query_one("#team-hints", Static).update(hint_text)
@@ -223,8 +226,10 @@ class TeamSelectScreen(Screen[str | None]):
         self._show_error(f"Unknown command: {text}")
 
     def on_key(self, event: Key) -> None:
-        """Handle arrow key presses for pagination."""
-        if event.key == "right":
+        """Handle key presses for pagination and quit."""
+        if event.key == "escape":
+            self.dismiss(None)
+        elif event.key == "right":
             self._next_page()
         elif event.key == "left":
             self._prev_page()

--- a/src/akgentic/infra/cli/tui/screens/team_select.py
+++ b/src/akgentic/infra/cli/tui/screens/team_select.py
@@ -115,10 +115,16 @@ class TeamSelectScreen(Screen[str | None]):
 
         # -- Running teams --
         if self._running_teams:
-            r_page = self._running_teams[start:end]
-            r_total = len(self._running_teams)
-            r_end = min(start + len(r_page), r_total)
-            header_text = f"Running teams ({start + 1}-{r_end} of {r_total}):"
+            # If all running teams fit on one page, show all on every page
+            if len(self._running_teams) <= PAGE_SIZE:
+                r_page = self._running_teams
+                r_total = len(self._running_teams)
+                header_text = f"Running teams ({r_total}):"
+            else:
+                r_page = self._running_teams[start:end]
+                r_total = len(self._running_teams)
+                r_end = min(start + len(r_page), r_total)
+                header_text = f"Running teams ({start + 1}-{r_end} of {r_total}):"
             container.mount(Static(header_text, classes="section-header"))
             for i, team in enumerate(r_page):
                 global_idx = start + i + 1
@@ -135,10 +141,16 @@ class TeamSelectScreen(Screen[str | None]):
 
         # -- Stopped teams --
         if self._stopped_teams:
-            s_page = self._stopped_teams[start:end]
-            s_total = len(self._stopped_teams)
-            s_end = min(start + len(s_page), s_total)
-            header_text = f"Stopped teams ({start + 1}-{s_end} of {s_total}):"
+            # If all stopped teams fit on one page, show all on every page
+            if len(self._stopped_teams) <= PAGE_SIZE:
+                s_page = self._stopped_teams
+                s_total = len(self._stopped_teams)
+                header_text = f"Stopped teams ({s_total}):"
+            else:
+                s_page = self._stopped_teams[start:end]
+                s_total = len(self._stopped_teams)
+                s_end = min(start + len(s_page), s_total)
+                header_text = f"Stopped teams ({start + 1}-{s_end} of {s_total}):"
             container.mount(Static(header_text, classes="section-header"))
             for i, team in enumerate(s_page):
                 global_idx = start + i + 1

--- a/src/akgentic/infra/cli/tui/screens/team_select.py
+++ b/src/akgentic/infra/cli/tui/screens/team_select.py
@@ -11,6 +11,7 @@ from rich.text import Text
 from textual import work
 from textual.app import ComposeResult
 from textual.containers import VerticalScroll
+from textual.events import Key
 from textual.screen import Screen
 from textual.widgets import Input, Static
 
@@ -169,21 +170,21 @@ class TeamSelectScreen(Screen[str | None]):
         if self._running_teams:
             start = self._page * PAGE_SIZE + 1
             end = min(start + PAGE_SIZE - 1, len(self._running_teams))
-            hints_parts.append(f"[{start}-{end}] connect")
+            hints_parts.append(f"\\[{start}-{end}] connect")
         if self._stopped_teams:
             start = self._page * PAGE_SIZE + 1
             end = min(start + PAGE_SIZE - 1, len(self._stopped_teams))
-            hints_parts.append(f"[s{start}-s{end}] restore")
+            hints_parts.append(f"\\[s{start}-s{end}] restore")
         if self._catalog:
-            hints_parts.append("[c <name>] create")
+            hints_parts.append("\\[c <name>] create")
         if self._max_pages() > 1:
             hints_parts.append("<-> page")
-        hints_parts.append("[q] quit")
+        hints_parts.append("\\[q] quit")
         hint_text = "  ".join(hints_parts)
         try:
             self.query_one("#team-hints", Static).update(hint_text)
-        except Exception:  # noqa: BLE001
-            pass
+        except LookupError:
+            _log.debug("team-hints widget not available for update")
 
     def on_input_submitted(self, event: Input.Submitted) -> None:
         """Handle user input from the Input widget."""
@@ -221,12 +222,8 @@ class TeamSelectScreen(Screen[str | None]):
 
         self._show_error(f"Unknown command: {text}")
 
-    def on_key(self, event: object) -> None:
+    def on_key(self, event: Key) -> None:
         """Handle arrow key presses for pagination."""
-        from textual.events import Key
-
-        if not isinstance(event, Key):
-            return
         if event.key == "right":
             self._next_page()
         elif event.key == "left":
@@ -292,8 +289,10 @@ class TeamSelectScreen(Screen[str | None]):
             self.app.call_from_thread(self._show_error, f"Failed to create team: {exc}")
 
     def _show_error(self, message: str) -> None:
-        """Display an error message in the team list area."""
+        """Display an error message in the team list area, replacing any previous error."""
         container = self.query_one("#team-list", VerticalScroll)
+        for old in container.query(".error-message"):
+            old.remove()
         error_widget = Static(
             Text(message, style="bold red"),
             classes="error-message",

--- a/src/akgentic/infra/cli/tui/screens/team_select.py
+++ b/src/akgentic/infra/cli/tui/screens/team_select.py
@@ -47,7 +47,10 @@ class TeamSelectScreen(Screen[str | None]):
         """Compose the team selection layout."""
         from textual.containers import Container
 
-        yield Static("Akgentic -- Team Selection", id="team-header")
+        header = Text()
+        header.append("Akgentic -- Team Selection", style="bold")
+        header.append("   \u25cf connecting", style="yellow")
+        yield Static(header, id="team-header")
         yield VerticalScroll(id="team-list")
         with Container(id="team-input-area"):
             yield Input(placeholder="> ", id="team-input")
@@ -97,7 +100,21 @@ class TeamSelectScreen(Screen[str | None]):
         self._running_teams = sorted(running, key=lambda t: t.created_at, reverse=True)
         self._stopped_teams = sorted(stopped, key=lambda t: t.created_at, reverse=True)
         self._catalog = catalog
+        self._update_header(bool(running or stopped or catalog))
         self._render_page()
+
+    def _update_header(self, server_reachable: bool) -> None:
+        """Update the header with connection indicator."""
+        header = Text()
+        header.append("Akgentic -- Team Selection", style="bold")
+        if server_reachable:
+            header.append("   \u25cf connected", style="green")
+        else:
+            header.append("   \u2716 disconnected", style="red")
+        try:
+            self.query_one("#team-header", Static).update(header)
+        except LookupError:
+            pass
 
     def _max_pages(self) -> int:
         """Return total number of pages based on running and stopped lists."""

--- a/src/akgentic/infra/cli/tui/screens/team_select.py
+++ b/src/akgentic/infra/cli/tui/screens/team_select.py
@@ -129,7 +129,7 @@ class TeamSelectScreen(Screen[str | None]):
             for i, team in enumerate(r_page):
                 global_idx = start + i + 1
                 line = Text()
-                line.append(f"  \\[{global_idx}]", style="bold cyan")
+                line.append(f"  [{global_idx}]", style="bold cyan")
                 line.append(f"  {team.name}", style="bold")
                 line.append(f"  {_short_id(team.team_id)}", style="dim")
                 line.append("  > running", style="green")
@@ -155,7 +155,7 @@ class TeamSelectScreen(Screen[str | None]):
             for i, team in enumerate(s_page):
                 global_idx = start + i + 1
                 line = Text()
-                line.append(f"  \\[s{global_idx}]", style="bold yellow")
+                line.append(f"  [s{global_idx}]", style="bold yellow")
                 line.append(f"  {team.name}", style="bold")
                 line.append(f"  {_short_id(team.team_id)}", style="dim")
                 line.append("  || stopped", style="yellow")
@@ -170,7 +170,7 @@ class TeamSelectScreen(Screen[str | None]):
             container.mount(Static("Create new:", classes="section-header"))
             for entry in self._catalog:
                 line = Text()
-                line.append(f"  \\[c {entry.id}]", style="bold magenta")
+                line.append(f"  [c {entry.id}]", style="bold magenta")
                 line.append(f"  {entry.description}", style="dim")
                 container.mount(Static(line, classes="team-entry"))
         else:
@@ -185,19 +185,20 @@ class TeamSelectScreen(Screen[str | None]):
         if self._running_teams:
             start = self._page * PAGE_SIZE + 1
             end = min(start + PAGE_SIZE - 1, len(self._running_teams))
-            hints_parts.append(f"\\[{start}-{end}] connect")
+            hints_parts.append(f"[{start}-{end}] connect")
         if self._stopped_teams:
             start = self._page * PAGE_SIZE + 1
             end = min(start + PAGE_SIZE - 1, len(self._stopped_teams))
-            hints_parts.append(f"\\[s{start}-s{end}] restore")
+            hints_parts.append(f"[s{start}-s{end}] restore")
         if self._catalog:
-            hints_parts.append("\\[c <name>] create")
+            hints_parts.append("[c <name>] create")
         if self._max_pages() > 1:
             hints_parts.append("<-> page")
-        hints_parts.append("\\[q]/Esc quit")
+        hints_parts.append("[q]/Esc quit")
         hint_text = "  ".join(hints_parts)
         try:
-            self.query_one("#team-hints", Static).update(hint_text)
+            # Use Text() to avoid Rich markup interpretation of brackets
+            self.query_one("#team-hints", Static).update(Text(hint_text, style="dim"))
         except LookupError:
             _log.debug("team-hints widget not available for update")
 

--- a/src/akgentic/infra/cli/tui/styles/chat.tcss
+++ b/src/akgentic/infra/cli/tui/styles/chat.tcss
@@ -27,6 +27,11 @@ ChatInput {
     height: auto;
     max-height: 10;
     min-height: 3;
+    border: none;
+}
+
+ChatInput:focus {
+    border: none;
 }
 
 HintBar {

--- a/src/akgentic/infra/cli/tui/styles/chat.tcss
+++ b/src/akgentic/infra/cli/tui/styles/chat.tcss
@@ -35,32 +35,3 @@ HintBar {
 .history {
     opacity: 60%;
 }
-
-/* Widget-specific styles (supplements DEFAULT_CSS on each widget) */
-AgentMessage {
-    margin: 0 0 1 0;
-}
-
-ToolCallWidget {
-    margin: 0 0 1 2;
-}
-
-ErrorWidget {
-    margin: 0 0 1 0;
-}
-
-HumanInputPrompt {
-    margin: 0 0 1 0;
-}
-
-UserMessage {
-    margin: 0 0 1 0;
-}
-
-SystemMessage {
-    margin: 0 0 0 0;
-}
-
-HistorySeparator {
-    margin: 1 0;
-}

--- a/src/akgentic/infra/cli/tui/styles/chat.tcss
+++ b/src/akgentic/infra/cli/tui/styles/chat.tcss
@@ -30,3 +30,37 @@ HintBar {
     height: 1;
     background: $surface;
 }
+
+/* History replay -- dimmed widgets */
+.history {
+    opacity: 60%;
+}
+
+/* Widget-specific styles (supplements DEFAULT_CSS on each widget) */
+AgentMessage {
+    margin: 0 0 1 0;
+}
+
+ToolCallWidget {
+    margin: 0 0 1 2;
+}
+
+ErrorWidget {
+    margin: 0 0 1 0;
+}
+
+HumanInputPrompt {
+    margin: 0 0 1 0;
+}
+
+UserMessage {
+    margin: 0 0 1 0;
+}
+
+SystemMessage {
+    margin: 0 0 0 0;
+}
+
+HistorySeparator {
+    margin: 1 0;
+}

--- a/src/akgentic/infra/cli/tui/styles/chat.tcss
+++ b/src/akgentic/infra/cli/tui/styles/chat.tcss
@@ -31,6 +31,10 @@ HintBar {
     background: $surface;
 }
 
+ThinkingIndicator {
+    margin: 0 0 1 0;
+}
+
 /* History replay -- dimmed widgets */
 .history {
     opacity: 60%;

--- a/src/akgentic/infra/cli/tui/styles/chat.tcss
+++ b/src/akgentic/infra/cli/tui/styles/chat.tcss
@@ -17,21 +17,21 @@ StatusHeader {
     color: $text-muted;
 }
 
-ChatInput {
+#input-area {
     dock: bottom;
+    height: auto;
+    border: solid $accent;
+}
+
+ChatInput {
     height: auto;
     max-height: 10;
     min-height: 3;
-    border-top: solid $accent;
-    border-left: solid $accent;
-    border-right: solid $accent;
 }
 
 HintBar {
-    dock: bottom;
-    height: auto;
+    height: 1;
     background: $surface;
-    border-top: solid $accent;
 }
 
 ThinkingIndicator {

--- a/src/akgentic/infra/cli/tui/styles/chat.tcss
+++ b/src/akgentic/infra/cli/tui/styles/chat.tcss
@@ -29,8 +29,9 @@ ChatInput {
 
 HintBar {
     dock: bottom;
-    height: 1;
+    height: auto;
     background: $surface;
+    border-top: solid $accent;
 }
 
 ThinkingIndicator {

--- a/src/akgentic/infra/cli/tui/styles/chat.tcss
+++ b/src/akgentic/infra/cli/tui/styles/chat.tcss
@@ -35,6 +35,19 @@ ThinkingIndicator {
     margin: 0 0 1 0;
 }
 
+CommandPalette {
+    layer: overlay;
+    dock: bottom;
+    offset-y: -3;
+    height: auto;
+    max-height: 8;
+    width: 50%;
+    min-width: 40;
+    border: solid $accent;
+    background: $surface;
+    padding: 0 1;
+}
+
 /* History replay -- dimmed widgets */
 .history {
     opacity: 60%;

--- a/src/akgentic/infra/cli/tui/styles/chat.tcss
+++ b/src/akgentic/infra/cli/tui/styles/chat.tcss
@@ -10,7 +10,6 @@ StatusHeader {
 
 #conversation {
     height: 1fr;
-    border-bottom: solid $accent;
 }
 
 #welcome {

--- a/src/akgentic/infra/cli/tui/styles/chat.tcss
+++ b/src/akgentic/infra/cli/tui/styles/chat.tcss
@@ -10,6 +10,7 @@ StatusHeader {
 
 #conversation {
     height: 1fr;
+    border-bottom: solid $accent;
 }
 
 #welcome {

--- a/src/akgentic/infra/cli/tui/styles/chat.tcss
+++ b/src/akgentic/infra/cli/tui/styles/chat.tcss
@@ -23,6 +23,8 @@ ChatInput {
     max-height: 10;
     min-height: 3;
     border-top: solid $accent;
+    border-left: solid $accent;
+    border-right: solid $accent;
 }
 
 HintBar {

--- a/src/akgentic/infra/cli/tui/styles/team_select.tcss
+++ b/src/akgentic/infra/cli/tui/styles/team_select.tcss
@@ -15,6 +15,8 @@
     dock: bottom;
     height: 3;
     border-top: solid $accent;
+    border-left: solid $accent;
+    border-right: solid $accent;
 }
 
 #team-hints {

--- a/src/akgentic/infra/cli/tui/styles/team_select.tcss
+++ b/src/akgentic/infra/cli/tui/styles/team_select.tcss
@@ -19,6 +19,11 @@
 
 #team-input {
     height: 3;
+    border: none;
+}
+
+#team-input:focus {
+    border: none;
 }
 
 #team-hints {

--- a/src/akgentic/infra/cli/tui/styles/team_select.tcss
+++ b/src/akgentic/infra/cli/tui/styles/team_select.tcss
@@ -1,0 +1,37 @@
+#team-header {
+    dock: top;
+    height: 1;
+    background: $surface;
+    text-style: bold;
+    padding: 0 1;
+}
+
+#team-list {
+    height: 1fr;
+    padding: 1 2;
+}
+
+#team-input {
+    dock: bottom;
+    height: 3;
+    border-top: solid $accent;
+}
+
+#team-hints {
+    dock: bottom;
+    height: 1;
+    background: $surface;
+}
+
+.section-header {
+    margin: 0 0 0 0;
+    text-style: bold;
+}
+
+.team-entry {
+    margin: 0;
+}
+
+.error-message {
+    margin: 1 0;
+}

--- a/src/akgentic/infra/cli/tui/styles/team_select.tcss
+++ b/src/akgentic/infra/cli/tui/styles/team_select.tcss
@@ -11,19 +11,19 @@
     padding: 1 2;
 }
 
-#team-input {
+#team-input-area {
     dock: bottom;
+    height: auto;
+    border: solid $accent;
+}
+
+#team-input {
     height: 3;
-    border-top: solid $accent;
-    border-left: solid $accent;
-    border-right: solid $accent;
 }
 
 #team-hints {
-    dock: bottom;
-    height: auto;
+    height: 1;
     background: $surface;
-    border-top: solid $accent;
 }
 
 .section-header {

--- a/src/akgentic/infra/cli/tui/styles/team_select.tcss
+++ b/src/akgentic/infra/cli/tui/styles/team_select.tcss
@@ -21,8 +21,9 @@
 
 #team-hints {
     dock: bottom;
-    height: 1;
+    height: auto;
     background: $surface;
+    border-top: solid $accent;
 }
 
 .section-header {

--- a/src/akgentic/infra/cli/tui/widgets/__init__.py
+++ b/src/akgentic/infra/cli/tui/widgets/__init__.py
@@ -1,1 +1,24 @@
 """TUI widget definitions."""
+
+from akgentic.infra.cli.tui.widgets.agent_message import AgentMessage
+from akgentic.infra.cli.tui.widgets.chat_input import ChatInput
+from akgentic.infra.cli.tui.widgets.error import ErrorWidget
+from akgentic.infra.cli.tui.widgets.hint_bar import HintBar
+from akgentic.infra.cli.tui.widgets.human_input import HumanInputPrompt
+from akgentic.infra.cli.tui.widgets.status_header import StatusHeader
+from akgentic.infra.cli.tui.widgets.system_message import HistorySeparator, SystemMessage
+from akgentic.infra.cli.tui.widgets.tool_call import ToolCallWidget
+from akgentic.infra.cli.tui.widgets.user_message import UserMessage
+
+__all__ = [
+    "AgentMessage",
+    "ChatInput",
+    "ErrorWidget",
+    "HintBar",
+    "HistorySeparator",
+    "HumanInputPrompt",
+    "StatusHeader",
+    "SystemMessage",
+    "ToolCallWidget",
+    "UserMessage",
+]

--- a/src/akgentic/infra/cli/tui/widgets/__init__.py
+++ b/src/akgentic/infra/cli/tui/widgets/__init__.py
@@ -2,6 +2,7 @@
 
 from akgentic.infra.cli.tui.widgets.agent_message import AgentMessage
 from akgentic.infra.cli.tui.widgets.chat_input import ChatInput
+from akgentic.infra.cli.tui.widgets.command_palette import CommandPalette
 from akgentic.infra.cli.tui.widgets.error import ErrorWidget
 from akgentic.infra.cli.tui.widgets.hint_bar import HintBar
 from akgentic.infra.cli.tui.widgets.human_input import HumanInputPrompt
@@ -14,6 +15,7 @@ from akgentic.infra.cli.tui.widgets.user_message import UserMessage
 __all__ = [
     "AgentMessage",
     "ChatInput",
+    "CommandPalette",
     "ErrorWidget",
     "HintBar",
     "HistorySeparator",

--- a/src/akgentic/infra/cli/tui/widgets/__init__.py
+++ b/src/akgentic/infra/cli/tui/widgets/__init__.py
@@ -7,6 +7,7 @@ from akgentic.infra.cli.tui.widgets.hint_bar import HintBar
 from akgentic.infra.cli.tui.widgets.human_input import HumanInputPrompt
 from akgentic.infra.cli.tui.widgets.status_header import StatusHeader
 from akgentic.infra.cli.tui.widgets.system_message import HistorySeparator, SystemMessage
+from akgentic.infra.cli.tui.widgets.thinking import ThinkingIndicator
 from akgentic.infra.cli.tui.widgets.tool_call import ToolCallWidget
 from akgentic.infra.cli.tui.widgets.user_message import UserMessage
 
@@ -19,6 +20,7 @@ __all__ = [
     "HumanInputPrompt",
     "StatusHeader",
     "SystemMessage",
+    "ThinkingIndicator",
     "ToolCallWidget",
     "UserMessage",
 ]

--- a/src/akgentic/infra/cli/tui/widgets/agent_message.py
+++ b/src/akgentic/infra/cli/tui/widgets/agent_message.py
@@ -1,0 +1,31 @@
+"""Agent message widget for conversation display."""
+
+from __future__ import annotations
+
+from rich.console import Group, RenderableType
+from rich.markdown import Markdown
+from rich.text import Text
+from textual.widgets import Static
+
+
+class AgentMessage(Static):
+    """A single agent message in the conversation."""
+
+    DEFAULT_CSS = """
+    AgentMessage {
+        margin: 0 0 1 0;
+        padding: 0 1;
+    }
+    """
+
+    def __init__(self, sender: str, content: str, color: str) -> None:
+        self._sender = sender
+        self._content = content
+        self._color = color
+        super().__init__()
+
+    def render(self) -> RenderableType:
+        """Render sender name with color and markdown body."""
+        sender_text = Text(f"[@{self._sender}]", style=f"bold {self._color}")
+        body = Markdown(self._content)
+        return Group(sender_text, body)

--- a/src/akgentic/infra/cli/tui/widgets/agent_message.py
+++ b/src/akgentic/infra/cli/tui/widgets/agent_message.py
@@ -26,6 +26,7 @@ class AgentMessage(Static):
 
     def render(self) -> RenderableType:
         """Render sender name with color and markdown body."""
-        sender_text = Text(f"[@{self._sender}]", style=f"bold {self._color}")
+        name = self._sender.lstrip("@")
+        sender_text = Text(f"[@{name}]", style=f"bold {self._color}")
         body = Markdown(self._content)
         return Group(sender_text, body)

--- a/src/akgentic/infra/cli/tui/widgets/chat_input.py
+++ b/src/akgentic/infra/cli/tui/widgets/chat_input.py
@@ -191,7 +191,6 @@ class ChatInput(TextArea):
         last_line = len(lines) - 1
         last_col = len(lines[-1])
         self.move_cursor((last_line, last_col))
-        # Shift+Enter is "shift+enter" key name -- let it pass through for newline
 
 
 # Import at bottom to avoid circular imports

--- a/src/akgentic/infra/cli/tui/widgets/chat_input.py
+++ b/src/akgentic/infra/cli/tui/widgets/chat_input.py
@@ -2,14 +2,9 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-
 from textual import events
 from textual.message import Message
 from textual.widgets import TextArea
-
-if TYPE_CHECKING:
-    from akgentic.infra.cli.tui.messages import ConnectionStateChanged
 
 
 class ChatInput(TextArea):
@@ -48,15 +43,3 @@ class ChatInput(TextArea):
                 self.clear()
         # Shift+Enter is "shift+enter" key name -- let it pass through for newline
 
-    def on_connection_state_changed(
-        self,
-        event: ConnectionStateChanged,
-    ) -> None:
-        """Update input mode based on connection state."""
-        state = event.state.value
-        if state == "disconnected":
-            self.border_title = "\\[disconnected] > "
-        elif state == "reconnecting":
-            self.border_title = "\\[reconnecting...] > "
-        elif state == "connected":
-            self.border_title = "> "

--- a/src/akgentic/infra/cli/tui/widgets/chat_input.py
+++ b/src/akgentic/infra/cli/tui/widgets/chat_input.py
@@ -126,9 +126,8 @@ class ChatInput(TextArea):
             return True
         if event.key == "enter":
             event.prevent_default()
-            cmd = self._select_palette_command()
-            if cmd is not None:
-                self._submit_text()
+            self._select_palette_command()
+            self._submit_text()
             return True
         return False
 
@@ -178,7 +177,13 @@ class ChatInput(TextArea):
             self._suppress_palette = False
             return
         text = self.text
-        if text.startswith("/") and self._command_registry is not None:
+        # Only show palette for command name completion (before the first space).
+        # Once the user types a space they are entering arguments — dismiss.
+        if (
+            text.startswith("/")
+            and " " not in text
+            and self._command_registry is not None
+        ):
             if self._palette is None:
                 self._show_palette()
             self._update_palette_filter()

--- a/src/akgentic/infra/cli/tui/widgets/chat_input.py
+++ b/src/akgentic/infra/cli/tui/widgets/chat_input.py
@@ -23,6 +23,8 @@ class ChatInput(TextArea):
         max-height: 10;
         min-height: 3;
         border-top: solid $accent;
+        border-left: solid $accent;
+        border-right: solid $accent;
     }
     """
 

--- a/src/akgentic/infra/cli/tui/widgets/chat_input.py
+++ b/src/akgentic/infra/cli/tui/widgets/chat_input.py
@@ -2,9 +2,14 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from textual import events
 from textual.message import Message
 from textual.widgets import TextArea
+
+if TYPE_CHECKING:
+    from akgentic.infra.cli.tui.messages import ConnectionStateChanged
 
 
 class ChatInput(TextArea):
@@ -42,3 +47,16 @@ class ChatInput(TextArea):
                 self.post_message(self.Submitted(text))
                 self.clear()
         # Shift+Enter is "shift+enter" key name -- let it pass through for newline
+
+    def on_connection_state_changed(
+        self,
+        event: ConnectionStateChanged,
+    ) -> None:
+        """Update input mode based on connection state."""
+        state = event.state.value
+        if state == "disconnected":
+            self.border_title = "\\[disconnected] > "
+        elif state == "reconnecting":
+            self.border_title = "\\[reconnecting...] > "
+        elif state == "connected":
+            self.border_title = "> "

--- a/src/akgentic/infra/cli/tui/widgets/chat_input.py
+++ b/src/akgentic/infra/cli/tui/widgets/chat_input.py
@@ -18,13 +18,9 @@ class ChatInput(TextArea):
 
     DEFAULT_CSS = """
     ChatInput {
-        dock: bottom;
         height: auto;
         max-height: 10;
         min-height: 3;
-        border-top: solid $accent;
-        border-left: solid $accent;
-        border-right: solid $accent;
     }
     """
 

--- a/src/akgentic/infra/cli/tui/widgets/chat_input.py
+++ b/src/akgentic/infra/cli/tui/widgets/chat_input.py
@@ -1,14 +1,20 @@
-"""Multi-line chat input with Enter-to-send."""
+"""Multi-line chat input with Enter-to-send, history, and slash completion."""
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from textual import events
 from textual.message import Message
+from textual.reactive import reactive
 from textual.widgets import TextArea
+
+if TYPE_CHECKING:
+    from akgentic.infra.cli.commands import CommandRegistry
 
 
 class ChatInput(TextArea):
-    """Multi-line chat input with Enter-to-send."""
+    """Multi-line chat input with Enter-to-send, history navigation, and slash completion."""
 
     DEFAULT_CSS = """
     ChatInput {
@@ -20,6 +26,8 @@ class ChatInput(TextArea):
     }
     """
 
+    input_mode: reactive[str] = reactive("chat")
+
     class Submitted(Message):
         """Fired when user presses Enter (without Shift)."""
 
@@ -27,19 +35,164 @@ class ChatInput(TextArea):
             self.text = text
             super().__init__()
 
-    def __init__(self) -> None:
+    def __init__(
+        self,
+        command_registry: CommandRegistry | None = None,
+    ) -> None:
         super().__init__(language=None, soft_wrap=True, show_line_numbers=False)
         self._history: list[str] = []
         self._history_idx: int = -1
+        self._browsing_history: bool = False
+        self._reply_target: str = ""
+        self._command_registry = command_registry
+        self._palette: CommandPalette | None = None
+        self._suppress_palette: bool = False
 
-    async def _on_key(self, event: events.Key) -> None:
+    def watch_input_mode(self, mode: str) -> None:
+        """Update border title based on input mode."""
+        labels = {
+            "chat": "> ",
+            "reply": f"Reply to @{self._reply_target}: ",
+            "disconnected": "\\[disconnected] > ",
+            "reconnecting": "\\[reconnecting...] > ",
+        }
+        self.border_title = labels.get(mode, "> ")
+
+    def _show_palette(self) -> None:
+        """Mount the CommandPalette if a registry is available."""
+        if self._command_registry is None or self._palette is not None:
+            return
+        palette = CommandPalette(self._command_registry.commands)
+        self._palette = palette
+        self.mount(palette)
+
+    def _dismiss_palette(self) -> None:
+        """Remove the CommandPalette from the DOM."""
+        if self._palette is not None:
+            self._palette.remove()
+            self._palette = None
+
+    def _update_palette_filter(self) -> None:
+        """Update palette filter based on current input text."""
+        if self._palette is None:
+            return
+        text = self.text
+        if text.startswith("/"):
+            self._palette.filter_text = text[1:]
+        else:
+            self._dismiss_palette()
+
+    def _select_palette_command(self) -> str | None:
+        """Select the highlighted palette command and dismiss palette."""
+        if self._palette is None:
+            return None
+        cmd = self._palette.selected_command
+        self._dismiss_palette()
+        if cmd is not None:
+            self._suppress_palette = True
+            self.text = f"/{cmd} "
+            self.move_cursor_to_end()
+        return cmd
+
+    def _submit_text(self) -> None:
+        """Submit current text, add to history, and clear input."""
+        text = self.text.strip()
+        if text:
+            self._history.append(text)
+            self._history_idx = -1
+            self._browsing_history = False
+            self.post_message(self.Submitted(text))
+            self.clear()
+
+    def _handle_palette_key(self, event: events.Key) -> bool:
+        """Handle key events when the palette is visible. Returns True if handled."""
+        if self._palette is None:
+            return False
+        if event.key == "escape":
+            event.prevent_default()
+            self._dismiss_palette()
+            return True
+        if event.key == "tab":
+            event.prevent_default()
+            self._select_palette_command()
+            return True
+        if event.key == "up":
+            event.prevent_default()
+            self._palette.move_up()
+            return True
+        if event.key == "down":
+            event.prevent_default()
+            self._palette.move_down()
+            return True
         if event.key == "enter":
             event.prevent_default()
-            text = self.text.strip()
-            if text:
-                self._history.append(text)
+            cmd = self._select_palette_command()
+            if cmd is not None:
+                self._submit_text()
+            return True
+        return False
+
+    def _handle_history_key(self, event: events.Key) -> bool:
+        """Handle up/down arrow keys for history navigation. Returns True if handled."""
+        if event.key == "up" and (not self.text or self._browsing_history):
+            event.prevent_default()
+            if self._history:
+                if self._history_idx < 0:
+                    self._history_idx = len(self._history) - 1
+                elif self._history_idx > 0:
+                    self._history_idx -= 1
+                self._browsing_history = True
+                self.text = self._history[self._history_idx]
+                self.move_cursor_to_end()
+            return True
+        if event.key == "down" and self._browsing_history:
+            event.prevent_default()
+            if self._history_idx < len(self._history) - 1:
+                self._history_idx += 1
+                self.text = self._history[self._history_idx]
+                self.move_cursor_to_end()
+            else:
                 self._history_idx = -1
-                self.post_message(self.Submitted(text))
-                self.clear()
+                self._browsing_history = False
+                self.text = ""
+            return True
+        return False
+
+    async def _on_key(self, event: events.Key) -> None:
+        if self._handle_palette_key(event):
+            return
+        if event.key == "enter":
+            event.prevent_default()
+            self._submit_text()
+            self._dismiss_palette()
+            return
+        if self._handle_history_key(event):
+            return
+        # For non-navigation keys, reset history browsing
+        if event.key not in {"up", "down", "enter", "shift+enter", "escape", "tab"}:
+            self._browsing_history = False
+
+    def _on_text_area_changed(self, _event: TextArea.Changed) -> None:
+        """React to text changes for palette show/dismiss/filter."""
+        if self._suppress_palette:
+            self._suppress_palette = False
+            return
+        text = self.text
+        if text.startswith("/") and self._command_registry is not None:
+            if self._palette is None:
+                self._show_palette()
+            self._update_palette_filter()
+        else:
+            self._dismiss_palette()
+
+    def move_cursor_to_end(self) -> None:
+        """Move cursor to the end of the text."""
+        lines = self.text.split("\n")
+        last_line = len(lines) - 1
+        last_col = len(lines[-1])
+        self.move_cursor((last_line, last_col))
         # Shift+Enter is "shift+enter" key name -- let it pass through for newline
 
+
+# Import at bottom to avoid circular imports
+from akgentic.infra.cli.tui.widgets.command_palette import CommandPalette  # noqa: E402

--- a/src/akgentic/infra/cli/tui/widgets/chat_input.py
+++ b/src/akgentic/infra/cli/tui/widgets/chat_input.py
@@ -35,6 +35,32 @@ class ChatInput(TextArea):
             self.text = text
             super().__init__()
 
+    class PaletteRequested(Message):
+        """Fired when the command palette should be shown."""
+
+    class PaletteDismissed(Message):
+        """Fired when the command palette should be hidden."""
+
+    class PaletteFilterChanged(Message):
+        """Fired when the palette filter text changes."""
+
+        def __init__(self, filter_text: str) -> None:
+            self.filter_text = filter_text
+            super().__init__()
+
+    class PaletteNavigate(Message):
+        """Fired when user navigates the palette with arrow keys."""
+
+        def __init__(self, direction: str) -> None:
+            self.direction = direction
+            super().__init__()
+
+    class PaletteSelect(Message):
+        """Fired when user selects a palette command (Tab)."""
+
+    class PaletteSelectAndSubmit(Message):
+        """Fired when user selects a palette command and submits (Enter on palette)."""
+
     def __init__(
         self,
         command_registry: CommandRegistry | None = None,
@@ -45,7 +71,7 @@ class ChatInput(TextArea):
         self._browsing_history: bool = False
         self._reply_target: str = ""
         self._command_registry = command_registry
-        self._palette: CommandPalette | None = None
+        self._palette_visible: bool = False
         self._suppress_palette: bool = False
 
     def watch_input_mode(self, mode: str) -> None:
@@ -58,41 +84,11 @@ class ChatInput(TextArea):
         }
         self.border_title = labels.get(mode, "> ")
 
-    def _show_palette(self) -> None:
-        """Mount the CommandPalette if a registry is available."""
-        if self._command_registry is None or self._palette is not None:
-            return
-        palette = CommandPalette(self._command_registry.commands)
-        self._palette = palette
-        self.mount(palette)
-
-    def _dismiss_palette(self) -> None:
-        """Remove the CommandPalette from the DOM."""
-        if self._palette is not None:
-            self._palette.remove()
-            self._palette = None
-
-    def _update_palette_filter(self) -> None:
-        """Update palette filter based on current input text."""
-        if self._palette is None:
-            return
-        text = self.text
-        if text.startswith("/"):
-            self._palette.filter_text = text[1:]
-        else:
-            self._dismiss_palette()
-
-    def _select_palette_command(self) -> str | None:
-        """Select the highlighted palette command and dismiss palette."""
-        if self._palette is None:
-            return None
-        cmd = self._palette.selected_command
-        self._dismiss_palette()
-        if cmd is not None:
-            self._suppress_palette = True
-            self.text = f"/{cmd} "
-            self.move_cursor_to_end()
-        return cmd
+    def set_command_text(self, cmd: str) -> None:
+        """Set input text to a selected command (called by app after palette select)."""
+        self._suppress_palette = True
+        self.text = f"/{cmd} "
+        self.move_cursor_to_end()
 
     def _submit_text(self) -> None:
         """Submit current text, add to history, and clear input."""
@@ -106,28 +102,28 @@ class ChatInput(TextArea):
 
     def _handle_palette_key(self, event: events.Key) -> bool:
         """Handle key events when the palette is visible. Returns True if handled."""
-        if self._palette is None:
+        if not self._palette_visible:
             return False
         if event.key == "escape":
             event.prevent_default()
-            self._dismiss_palette()
+            self._palette_visible = False
+            self.post_message(self.PaletteDismissed())
             return True
         if event.key == "tab":
             event.prevent_default()
-            self._select_palette_command()
+            self.post_message(self.PaletteSelect())
             return True
         if event.key == "up":
             event.prevent_default()
-            self._palette.move_up()
+            self.post_message(self.PaletteNavigate("up"))
             return True
         if event.key == "down":
             event.prevent_default()
-            self._palette.move_down()
+            self.post_message(self.PaletteNavigate("down"))
             return True
         if event.key == "enter":
             event.prevent_default()
-            self._select_palette_command()
-            self._submit_text()
+            self.post_message(self.PaletteSelectAndSubmit())
             return True
         return False
 
@@ -163,7 +159,9 @@ class ChatInput(TextArea):
         if event.key == "enter":
             event.prevent_default()
             self._submit_text()
-            self._dismiss_palette()
+            if self._palette_visible:
+                self._palette_visible = False
+                self.post_message(self.PaletteDismissed())
             return
         if self._handle_history_key(event):
             return
@@ -178,17 +176,19 @@ class ChatInput(TextArea):
             return
         text = self.text
         # Only show palette for command name completion (before the first space).
-        # Once the user types a space they are entering arguments — dismiss.
         if (
             text.startswith("/")
             and " " not in text
             and self._command_registry is not None
         ):
-            if self._palette is None:
-                self._show_palette()
-            self._update_palette_filter()
+            if not self._palette_visible:
+                self._palette_visible = True
+                self.post_message(self.PaletteRequested())
+            self.post_message(self.PaletteFilterChanged(text[1:]))
         else:
-            self._dismiss_palette()
+            if self._palette_visible:
+                self._palette_visible = False
+                self.post_message(self.PaletteDismissed())
 
     def move_cursor_to_end(self) -> None:
         """Move cursor to the end of the text."""
@@ -196,7 +196,3 @@ class ChatInput(TextArea):
         last_line = len(lines) - 1
         last_col = len(lines[-1])
         self.move_cursor((last_line, last_col))
-
-
-# Import at bottom to avoid circular imports
-from akgentic.infra.cli.tui.widgets.command_palette import CommandPalette  # noqa: E402

--- a/src/akgentic/infra/cli/tui/widgets/command_palette.py
+++ b/src/akgentic/infra/cli/tui/widgets/command_palette.py
@@ -1,0 +1,90 @@
+"""Dropdown command palette for slash command auto-completion."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from rich.text import Text
+from textual.widget import Widget
+
+if TYPE_CHECKING:
+    from akgentic.infra.cli.commands import SlashCommand
+
+
+class CommandPalette(Widget):
+    """Dropdown palette showing matching slash commands."""
+
+    DEFAULT_CSS = """
+    CommandPalette {
+        layer: overlay;
+        dock: bottom;
+        offset-y: -3;
+        height: auto;
+        max-height: 8;
+        width: 50%;
+        min-width: 40;
+        border: solid $accent;
+        background: $surface;
+        padding: 0 1;
+    }
+    """
+
+    def __init__(self, commands: dict[str, SlashCommand]) -> None:
+        super().__init__()
+        self._commands = commands
+        self._filter: str = ""
+        self._filtered: list[SlashCommand] = list(commands.values())
+        self._selected_idx: int = 0
+
+    @property
+    def filter_text(self) -> str:
+        """Current filter string."""
+        return self._filter
+
+    @filter_text.setter
+    def filter_text(self, value: str) -> None:
+        """Update the filter and recompute the visible list."""
+        self._filter = value
+        if value:
+            self._filtered = [cmd for cmd in self._commands.values() if cmd.name.startswith(value)]
+        else:
+            self._filtered = list(self._commands.values())
+        # Clamp selected index
+        if self._filtered:
+            self._selected_idx = min(self._selected_idx, len(self._filtered) - 1)
+        else:
+            self._selected_idx = 0
+        self.refresh()
+
+    @property
+    def selected_command(self) -> str | None:
+        """Return the currently highlighted command name, or None."""
+        if not self._filtered:
+            return None
+        return self._filtered[self._selected_idx].name
+
+    def move_up(self) -> None:
+        """Move highlight up."""
+        if self._filtered and self._selected_idx > 0:
+            self._selected_idx -= 1
+            self.refresh()
+
+    def move_down(self) -> None:
+        """Move highlight down."""
+        if self._filtered and self._selected_idx < len(self._filtered) - 1:
+            self._selected_idx += 1
+            self.refresh()
+
+    def render(self) -> Text:
+        """Render the filtered command list with highlight."""
+        output = Text()
+        if not self._filtered:
+            output.append("(no matching commands)", style="dim")
+            return output
+        for i, cmd in enumerate(self._filtered):
+            style = "reverse" if i == self._selected_idx else ""
+            line = f"/{cmd.name:<16s} {cmd.help_text}"
+            output.append(line, style=style)
+            if i < len(self._filtered) - 1:
+                output.append("\n")
+        return output

--- a/src/akgentic/infra/cli/tui/widgets/error.py
+++ b/src/akgentic/infra/cli/tui/widgets/error.py
@@ -1,0 +1,26 @@
+"""Error message widget for conversation display."""
+
+from __future__ import annotations
+
+from rich.console import RenderableType
+from rich.text import Text
+from textual.widgets import Static
+
+
+class ErrorWidget(Static):
+    """Red error message display."""
+
+    DEFAULT_CSS = """
+    ErrorWidget {
+        margin: 0 0 1 0;
+        padding: 0 1;
+    }
+    """
+
+    def __init__(self, content: str) -> None:
+        self._content = content
+        super().__init__()
+
+    def render(self) -> RenderableType:
+        """Render red error message with [error] prefix."""
+        return Text(f"[error] {self._content}", style="bold red")

--- a/src/akgentic/infra/cli/tui/widgets/hint_bar.py
+++ b/src/akgentic/infra/cli/tui/widgets/hint_bar.py
@@ -21,7 +21,7 @@ class HintBar(Static):
 
     def __init__(self, hints: str = "") -> None:
         super().__init__()
-        self._hints = hints or "@mention    /command    Tab: complete    Enter: send    Esc: scroll"
+        self._hints = hints or "@mention    /command    Enter: send"
 
     def render(self) -> RenderableType:
         """Render hint text."""

--- a/src/akgentic/infra/cli/tui/widgets/hint_bar.py
+++ b/src/akgentic/infra/cli/tui/widgets/hint_bar.py
@@ -12,17 +12,15 @@ class HintBar(Static):
 
     DEFAULT_CSS = """
     HintBar {
-        dock: bottom;
-        height: auto;
+        height: 1;
         background: $surface;
-        border-top: solid $accent;
         padding: 0 1;
     }
     """
 
     def __init__(self, hints: str = "") -> None:
         super().__init__()
-        self._hints = hints or "@mention    /command    Enter: send"
+        self._hints = hints or "@mention    /command    Enter: send    Esc: teams"
 
     def render(self) -> RenderableType:
         """Render hint text."""

--- a/src/akgentic/infra/cli/tui/widgets/hint_bar.py
+++ b/src/akgentic/infra/cli/tui/widgets/hint_bar.py
@@ -20,7 +20,7 @@ class HintBar(Static):
 
     def __init__(self, hints: str = "") -> None:
         super().__init__()
-        self._hints = hints or "@mention    /command    Enter: send    Esc: teams"
+        self._hints = hints or "@mention    /command    Enter: send    Esc: teams    /quit: exit"
 
     def render(self) -> RenderableType:
         """Render hint text."""

--- a/src/akgentic/infra/cli/tui/widgets/hint_bar.py
+++ b/src/akgentic/infra/cli/tui/widgets/hint_bar.py
@@ -13,8 +13,9 @@ class HintBar(Static):
     DEFAULT_CSS = """
     HintBar {
         dock: bottom;
-        height: 1;
+        height: auto;
         background: $surface;
+        border-top: solid $accent;
         padding: 0 1;
     }
     """

--- a/src/akgentic/infra/cli/tui/widgets/human_input.py
+++ b/src/akgentic/infra/cli/tui/widgets/human_input.py
@@ -1,0 +1,30 @@
+"""Human input prompt widget for conversation display."""
+
+from __future__ import annotations
+
+from rich.console import RenderableType
+from rich.panel import Panel
+from textual.widgets import Static
+
+
+class HumanInputPrompt(Static):
+    """Yellow-bordered panel showing agent's input request."""
+
+    DEFAULT_CSS = """
+    HumanInputPrompt {
+        margin: 0 0 1 0;
+        padding: 0 1;
+    }
+    """
+
+    def __init__(self, prompt_text: str) -> None:
+        self._prompt_text = prompt_text
+        super().__init__()
+
+    def render(self) -> RenderableType:
+        """Render a yellow-bordered panel with the prompt text."""
+        return Panel(
+            self._prompt_text,
+            title="Human Input Required",
+            border_style="bold yellow",
+        )

--- a/src/akgentic/infra/cli/tui/widgets/status_header.py
+++ b/src/akgentic/infra/cli/tui/widgets/status_header.py
@@ -28,7 +28,7 @@ class StatusHeader(Static):
     ) -> None:
         super().__init__()
         self._team_name = team_name
-        self._team_id = team_id[:13] if team_id else ""
+        self._team_id = team_id
         self._team_status = team_status
         self._connection_state = connection_state
 
@@ -62,6 +62,6 @@ class StatusHeader(Static):
     ) -> None:
         """Update team info and re-render."""
         self._team_name = team_name
-        self._team_id = team_id[:13] if team_id else ""
+        self._team_id = team_id
         self._team_status = team_status
         self.refresh()

--- a/src/akgentic/infra/cli/tui/widgets/status_header.py
+++ b/src/akgentic/infra/cli/tui/widgets/status_header.py
@@ -2,14 +2,9 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-
 from rich.console import RenderableType
 from rich.text import Text
 from textual.widgets import Static
-
-if TYPE_CHECKING:
-    from akgentic.infra.cli.tui.messages import ConnectionStateChanged
 
 
 class StatusHeader(Static):
@@ -58,13 +53,6 @@ class StatusHeader(Static):
         """Update connection state and re-render."""
         self._connection_state = state
         self.refresh()
-
-    def on_connection_state_changed(
-        self,
-        event: ConnectionStateChanged,
-    ) -> None:
-        """Update connection indicator when state changes."""
-        self.update_connection(event.state.value)
 
     def update_team(
         self,

--- a/src/akgentic/infra/cli/tui/widgets/status_header.py
+++ b/src/akgentic/infra/cli/tui/widgets/status_header.py
@@ -2,9 +2,14 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from rich.console import RenderableType
 from rich.text import Text
 from textual.widgets import Static
+
+if TYPE_CHECKING:
+    from akgentic.infra.cli.tui.messages import ConnectionStateChanged
 
 
 class StatusHeader(Static):
@@ -53,6 +58,13 @@ class StatusHeader(Static):
         """Update connection state and re-render."""
         self._connection_state = state
         self.refresh()
+
+    def on_connection_state_changed(
+        self,
+        event: ConnectionStateChanged,
+    ) -> None:
+        """Update connection indicator when state changes."""
+        self.update_connection(event.state.value)
 
     def update_team(
         self,

--- a/src/akgentic/infra/cli/tui/widgets/system_message.py
+++ b/src/akgentic/infra/cli/tui/widgets/system_message.py
@@ -1,0 +1,41 @@
+"""System message and history separator widgets for conversation display."""
+
+from __future__ import annotations
+
+from rich.console import RenderableType
+from rich.rule import Rule
+from rich.text import Text
+from textual.widgets import Static
+
+
+class SystemMessage(Static):
+    """Dim status text for system events."""
+
+    DEFAULT_CSS = """
+    SystemMessage {
+        margin: 0 0 0 0;
+        padding: 0 1;
+    }
+    """
+
+    def __init__(self, content: str) -> None:
+        self._content = content
+        super().__init__()
+
+    def render(self) -> RenderableType:
+        """Render dim status text."""
+        return Text(self._content, style="dim")
+
+
+class HistorySeparator(Static):
+    """Divider between replayed history and live events."""
+
+    DEFAULT_CSS = """
+    HistorySeparator {
+        margin: 1 0;
+    }
+    """
+
+    def render(self) -> RenderableType:
+        """Render a dim horizontal rule labeled 'history'."""
+        return Rule("history", style="dim")

--- a/src/akgentic/infra/cli/tui/widgets/thinking.py
+++ b/src/akgentic/infra/cli/tui/widgets/thinking.py
@@ -1,0 +1,40 @@
+"""Animated spinner shown while waiting for agent response."""
+
+from __future__ import annotations
+
+from rich.console import RenderableType
+from rich.text import Text
+from textual.widgets import Static
+
+
+class ThinkingIndicator(Static):
+    """Animated spinner shown while waiting for agent response."""
+
+    DEFAULT_CSS = """
+    ThinkingIndicator {
+        margin: 0 0 1 0;
+        padding: 0 1;
+    }
+    """
+
+    _FRAMES = list("\u280b\u2819\u2839\u2838\u283c\u2834\u2826\u2827\u2807\u280f")
+    _INTERVAL = 0.1
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._frame_idx: int = 0
+        self._timer_handle: object | None = None
+
+    def on_mount(self) -> None:
+        """Start the animation timer when mounted."""
+        self._timer_handle = self.set_interval(self._INTERVAL, self._advance_frame)
+
+    def _advance_frame(self) -> None:
+        """Advance to the next spinner frame."""
+        self._frame_idx = (self._frame_idx + 1) % len(self._FRAMES)
+        self.refresh()
+
+    def render(self) -> RenderableType:
+        """Render spinner frame with thinking text."""
+        frame = self._FRAMES[self._frame_idx]
+        return Text(f"{frame} Agent is thinking...", style="dim italic")

--- a/src/akgentic/infra/cli/tui/widgets/thinking.py
+++ b/src/akgentic/infra/cli/tui/widgets/thinking.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from rich.console import RenderableType
 from rich.text import Text
 from textual.widgets import Static
 
@@ -21,20 +20,15 @@ class ThinkingIndicator(Static):
     _INTERVAL = 0.1
 
     def __init__(self) -> None:
-        super().__init__()
+        super().__init__(Text(f"{self._FRAMES[0]} Agent is thinking...", style="dim italic"))
         self._frame_idx: int = 0
-        self._timer_handle: object | None = None
 
     def on_mount(self) -> None:
         """Start the animation timer when mounted."""
-        self._timer_handle = self.set_interval(self._INTERVAL, self._advance_frame)
+        self.set_interval(self._INTERVAL, self._advance_frame)
 
     def _advance_frame(self) -> None:
         """Advance to the next spinner frame."""
         self._frame_idx = (self._frame_idx + 1) % len(self._FRAMES)
-        self.refresh()
-
-    def render(self) -> RenderableType:
-        """Render spinner frame with thinking text."""
         frame = self._FRAMES[self._frame_idx]
-        return Text(f"{frame} Agent is thinking...", style="dim italic")
+        self.update(Text(f"{frame} Agent is thinking...", style="dim italic"))

--- a/src/akgentic/infra/cli/tui/widgets/tool_call.py
+++ b/src/akgentic/infra/cli/tui/widgets/tool_call.py
@@ -29,12 +29,14 @@ class ToolCallWidget(Static):
         self._tool_name = tool_name
         self._tool_input = tool_input
         self._tool_output = tool_output
-        super().__init__()
+        super().__init__(Text(f"\u25b8 Tool: {tool_name}", style="dim"))
 
-    def render(self) -> RenderableType:
-        """Render collapsed summary or expanded panel with JSON input/output."""
-        if self.collapsed:
-            return Text(f"\u25b8 Tool: {self._tool_name}", style="dim")
+    def _build_collapsed(self) -> RenderableType:
+        """Build the collapsed one-line summary."""
+        return Text(f"\u25b8 Tool: {self._tool_name}", style="dim")
+
+    def _build_expanded(self) -> RenderableType:
+        """Build the expanded panel with JSON input/output."""
         parts: list[Text | Syntax] = [Text("Input:")]
         try:
             parsed = json.loads(self._tool_input)
@@ -50,6 +52,10 @@ class ToolCallWidget(Static):
             title=f"Tool: {self._tool_name}",
             border_style="dim",
         )
+
+    def watch_collapsed(self, value: bool) -> None:
+        """Re-render when collapsed state changes."""
+        self.update(self._build_collapsed() if value else self._build_expanded())
 
     def on_click(self) -> None:
         """Toggle collapsed state."""

--- a/src/akgentic/infra/cli/tui/widgets/tool_call.py
+++ b/src/akgentic/infra/cli/tui/widgets/tool_call.py
@@ -1,0 +1,56 @@
+"""Tool call widget for conversation display."""
+
+from __future__ import annotations
+
+import json
+
+from rich.console import Group, RenderableType
+from rich.panel import Panel
+from rich.syntax import Syntax
+from rich.text import Text
+from textual.reactive import reactive
+from textual.widgets import Static
+
+
+class ToolCallWidget(Static):
+    """A tool invocation -- collapsed by default, expandable on click."""
+
+    DEFAULT_CSS = """
+    ToolCallWidget {
+        margin: 0 0 1 2;
+        padding: 0 1;
+        color: $text-muted;
+    }
+    """
+
+    collapsed: reactive[bool] = reactive(True)
+
+    def __init__(self, tool_name: str, tool_input: str, tool_output: str | None) -> None:
+        self._tool_name = tool_name
+        self._tool_input = tool_input
+        self._tool_output = tool_output
+        super().__init__()
+
+    def render(self) -> RenderableType:
+        """Render collapsed summary or expanded panel with JSON input/output."""
+        if self.collapsed:
+            return Text(f"\u25b8 Tool: {self._tool_name}", style="dim")
+        parts: list[Text | Syntax] = [Text("Input:")]
+        try:
+            parsed = json.loads(self._tool_input)
+            formatted = json.dumps(parsed, indent=2)
+            parts.append(Syntax(formatted, "json", theme="monokai"))
+        except (json.JSONDecodeError, TypeError):
+            parts.append(Text(self._tool_input))
+        if self._tool_output is not None:
+            parts.append(Text("\nOutput:"))
+            parts.append(Text(self._tool_output))
+        return Panel(
+            Group(*parts),
+            title=f"Tool: {self._tool_name}",
+            border_style="dim",
+        )
+
+    def on_click(self) -> None:
+        """Toggle collapsed state."""
+        self.collapsed = not self.collapsed

--- a/src/akgentic/infra/cli/tui/widgets/user_message.py
+++ b/src/akgentic/infra/cli/tui/widgets/user_message.py
@@ -1,0 +1,28 @@
+"""User message widget for conversation display."""
+
+from __future__ import annotations
+
+from rich.console import Group, RenderableType
+from rich.text import Text
+from textual.widgets import Static
+
+
+class UserMessage(Static):
+    """The user's own message in the conversation."""
+
+    DEFAULT_CSS = """
+    UserMessage {
+        margin: 0 0 1 0;
+        padding: 0 1;
+    }
+    """
+
+    def __init__(self, content: str) -> None:
+        self._content = content
+        super().__init__()
+
+    def render(self) -> RenderableType:
+        """Render user message with [You] prefix."""
+        sender = Text("[You]", style="bold white")
+        body = Text(self._content)
+        return Group(sender, body)

--- a/tests/cli/debug_tui.py
+++ b/tests/cli/debug_tui.py
@@ -1,0 +1,469 @@
+"""Headless TUI debugger for agent-assisted debugging.
+
+Run scenarios against ChatApp in headless mode, capturing SVG screenshots
+and widget state at each step. Designed for AI agents to inspect TUI behavior
+without access to a real terminal.
+
+Usage:
+    uv run python -m tests.cli.debug_tui [scenario_name]
+
+Scenarios are async functions decorated with @scenario. Each step in a
+scenario calls ctx.screenshot("label") to capture state.
+
+Output:
+    /tmp/tui-debug/  — SVG screenshots + widget tree dumps
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import sys
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, PropertyMock
+
+from akgentic.infra.cli.commands import build_default_registry
+from akgentic.infra.cli.connection import ConnectionState
+from akgentic.infra.cli.event_router import EventRouter
+from akgentic.infra.cli.renderers import RichRenderer
+from akgentic.infra.cli.tui.app import ChatApp
+from akgentic.infra.cli.tui.widgets.chat_input import ChatInput
+
+OUTPUT_DIR = Path("/tmp/tui-debug")
+
+# ---------------------------------------------------------------------------
+# Mock factories (mirrors tests/cli/conftest.py)
+# ---------------------------------------------------------------------------
+
+
+def _mock_client() -> MagicMock:
+    """ApiClient mock with sensible defaults."""
+    from akgentic.infra.cli.client import CatalogTeamInfo, TeamInfo
+
+    mock = MagicMock()
+    mock.list_teams.return_value = [
+        TeamInfo(
+            team_id="aaaa-1111",
+            name="Alpha Team",
+            status="running",
+            user_id="u1",
+            created_at="2026-01-01",
+            updated_at="2026-01-01",
+        ),
+        TeamInfo(
+            team_id="bbbb-2222",
+            name="Beta Team",
+            status="stopped",
+            user_id="u1",
+            created_at="2026-01-01",
+            updated_at="2026-01-02",
+        ),
+    ]
+    mock.get_team.return_value = TeamInfo(
+        team_id="aaaa-1111",
+        name="Alpha Team",
+        status="running",
+        user_id="u1",
+        created_at="2026-01-01",
+        updated_at="2026-01-01",
+    )
+    mock.create_team.return_value = TeamInfo(
+        team_id="cccc-3333",
+        name="New Team",
+        status="running",
+        user_id="u1",
+        created_at="2026-01-01",
+        updated_at="2026-01-01",
+    )
+    mock.list_catalog_teams.return_value = [
+        CatalogTeamInfo(id="agent-team", name="Agent Team", description="A test team"),
+    ]
+    mock.get_events.return_value = []
+    mock.send_message.return_value = None
+    mock.restore_team.return_value = TeamInfo(
+        team_id="bbbb-2222",
+        name="Beta Team",
+        status="running",
+        user_id="u1",
+        created_at="2026-01-01",
+        updated_at="2026-01-03",
+    )
+    return mock
+
+
+def _mock_conn() -> AsyncMock:
+    """ConnectionManager mock that stays connected."""
+    conn = AsyncMock()
+    conn.connect = AsyncMock()
+    conn.close = AsyncMock()
+    conn.switch_team = AsyncMock()
+    conn.receive_event = AsyncMock(side_effect=asyncio.CancelledError)
+    type(conn).state = PropertyMock(return_value=ConnectionState.CONNECTED)
+    type(conn).team_id = PropertyMock(return_value="aaaa-1111")
+    conn._on_state_change = None
+    return conn
+
+
+def _mock_conn_with_events(events: list[dict[str, Any]]) -> AsyncMock:
+    """ConnectionManager mock that yields events then blocks."""
+    conn = _mock_conn()
+    event_iter = iter(events)
+
+    async def _receive() -> dict[str, Any]:
+        try:
+            return next(event_iter)
+        except StopIteration:
+            # Block forever after events are consumed
+            await asyncio.sleep(999)
+            raise asyncio.CancelledError  # noqa: B904
+
+    conn.receive_event = AsyncMock(side_effect=_receive)
+    return conn
+
+
+def _make_app(
+    client: MagicMock | None = None,
+    conn: AsyncMock | None = None,
+    team_id: str = "aaaa-1111",
+    team_name: str = "Alpha Team",
+) -> ChatApp:
+    """Build a ChatApp wired for headless debugging."""
+    registry = build_default_registry()
+    renderer = RichRenderer()
+    event_router = EventRouter(renderer)
+    return ChatApp(
+        team_name=team_name,
+        team_id=team_id,
+        team_status="running",
+        connection_manager=conn or _mock_conn(),
+        event_router=event_router,
+        command_registry=registry,
+        client=client or _mock_client(),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Debug context — used inside scenarios
+# ---------------------------------------------------------------------------
+
+
+class DebugContext:
+    """Captures screenshots and widget state during a scenario."""
+
+    def __init__(self, app: ChatApp, pilot: Any, scenario_name: str) -> None:
+        self.app = app
+        self.pilot = pilot
+        self._scenario = scenario_name
+        self._step = 0
+        self._dir = OUTPUT_DIR / scenario_name
+        self._dir.mkdir(parents=True, exist_ok=True)
+
+    async def screenshot(self, label: str) -> None:
+        """Capture SVG screenshot and widget tree dump."""
+        self._step += 1
+        prefix = f"step-{self._step:02d}-{label}"
+
+        # SVG screenshot
+        svg_path = self._dir / f"{prefix}.svg"
+        self.app.save_screenshot(str(svg_path))
+
+        # Widget tree dump — query active screen, not just default screen
+        tree_path = self._dir / f"{prefix}-widgets.txt"
+        lines = []
+        screen = self.app.screen
+        lines.append(f"[Screen: {type(screen).__name__}]")
+        for widget in screen.query("*"):
+            name = type(widget).__name__
+            wid = widget.id or ""
+            classes = " ".join(widget.classes) if widget.classes else ""
+            visible = widget.display
+            info = f"{name}"
+            if wid:
+                info += f" #{wid}"
+            if classes:
+                info += f" .{classes}"
+            if not visible:
+                info += " [HIDDEN]"
+            # Capture content for key widgets
+            if hasattr(widget, "_content"):
+                content = str(widget._content)[:80]
+                info += f"  content={content!r}"
+            elif hasattr(widget, "text") and isinstance(widget, ChatInput):
+                info += f"  text={widget.text!r}"
+            lines.append(info)
+        tree_path.write_text("\n".join(lines))
+
+        # Summary to stdout
+        print(f"  [{prefix}] screenshot + widget tree saved")
+
+    async def pause(self) -> None:
+        """Yield to event loop."""
+        await self.pilot.pause()
+
+
+# ---------------------------------------------------------------------------
+# Scenario registry
+# ---------------------------------------------------------------------------
+
+_scenarios: dict[str, Any] = {}
+
+
+def scenario(fn: Any) -> Any:
+    """Register an async function as a debug scenario."""
+    _scenarios[fn.__name__] = fn
+    return fn
+
+
+# ---------------------------------------------------------------------------
+# Built-in scenarios
+# ---------------------------------------------------------------------------
+
+
+@scenario
+async def launch_chat(ctx: DebugContext) -> None:
+    """Launch chat with a pre-selected team and capture initial layout."""
+    await ctx.pause()
+    await ctx.screenshot("initial-layout")
+
+
+@scenario
+async def type_slash(ctx: DebugContext) -> None:
+    """Type / and check if command palette appears."""
+    await ctx.pause()
+    await ctx.pilot.click(ChatInput)
+    await ctx.pause()
+    await ctx.screenshot("focused-input")
+
+    await ctx.pilot.press("/")
+    await ctx.pause()
+    await ctx.pause()
+    await ctx.screenshot("after-slash")
+
+
+@scenario
+async def send_message(ctx: DebugContext) -> None:
+    """Send a message and check for ThinkingIndicator."""
+    await ctx.pause()
+    await ctx.pilot.click(ChatInput)
+    await ctx.pilot.press("h", "e", "l", "l", "o")
+    await ctx.pause()
+    await ctx.screenshot("typed-hello")
+
+    await ctx.pilot.press("enter")
+    await ctx.pause()
+    await ctx.pause()
+    await ctx.screenshot("after-send")
+
+
+@scenario
+async def send_and_receive(ctx: DebugContext) -> None:
+    """Send a message and receive a mock agent reply."""
+    # This scenario uses events — need to rebuild app with event-producing conn
+    pass  # Placeholder — real implementation below
+
+
+@scenario
+async def slash_help(ctx: DebugContext) -> None:
+    """Type /help and check output."""
+    await ctx.pause()
+    await ctx.pilot.click(ChatInput)
+    for key in "/help":
+        await ctx.pilot.press(key)
+    await ctx.pause()
+    await ctx.screenshot("typed-help")
+
+    await ctx.pilot.press("enter")
+    await ctx.pause()
+    await ctx.pause()
+    await ctx.screenshot("after-help")
+
+
+@scenario
+async def team_select(ctx: DebugContext) -> None:
+    """Launch without team_id to trigger TeamSelectScreen."""
+    # This scenario needs a different app setup — no team_id
+    pass  # Placeholder — handled specially in run_scenario
+
+
+@scenario
+async def full_user_journey(ctx: DebugContext) -> None:
+    """Full flow: team select → create → chat → stop → restore → ESC → switch team.
+
+    This is the scenario Geoff described: create a team from agent-team catalog,
+    have a conversation, stop and restore, press ESC to return to team select,
+    and choose another team.
+    """
+    # --- Step 1: Wait for TeamSelectScreen to appear ---
+    # _select_team is a @work async worker — need to let event loop spin
+    from textual.widgets import Input
+    await asyncio.sleep(0.5)
+    await ctx.pause()
+    await ctx.screenshot("01-team-select-screen")
+
+    # --- Step 2: Create a team by typing "c agent-team" ---
+    try:
+        team_input = ctx.app.screen.query_one("#team-input", Input)
+        team_input.value = "c agent-team"
+        await ctx.pause()
+        await ctx.screenshot("02-typed-create-command")
+        await team_input.action_submit()
+    except Exception as exc:
+        print(f"  [WARN] Team input not found: {exc}")
+        await ctx.screenshot("02-team-input-not-found")
+        return
+
+    # Wait for create + team switch to complete
+    for _ in range(10):
+        await ctx.pause()
+    await ctx.screenshot("03-after-create-team")
+
+    # --- Step 3: Now in chat view — send a message ---
+    await ctx.pause()
+    try:
+        chat_input = ctx.app.query_one(ChatInput)
+        await ctx.pilot.click(ChatInput)
+        await ctx.pilot.press("h", "i", " ", "t", "e", "a", "m")
+        await ctx.pause()
+        await ctx.screenshot("04-typed-message")
+
+        await ctx.pilot.press("enter")
+        await ctx.pause()
+        await ctx.pause()
+        await ctx.screenshot("05-after-send-message")
+    except Exception:
+        await ctx.screenshot("04-chat-input-not-found")
+
+    # --- Step 4: Stop the team with /stop ---
+    try:
+        await ctx.pilot.click(ChatInput)
+        for key in "/stop":
+            await ctx.pilot.press(key)
+        await ctx.pause()
+        await ctx.screenshot("06-typed-stop")
+
+        await ctx.pilot.press("enter")
+        await ctx.pause()
+        await ctx.pause()
+        await ctx.screenshot("07-after-stop")
+    except Exception:
+        await ctx.screenshot("06-stop-failed")
+
+    # --- Step 5: Restore with /restore ---
+    try:
+        await ctx.pilot.click(ChatInput)
+        for key in "/restore":
+            await ctx.pilot.press(key)
+        await ctx.pause()
+
+        await ctx.pilot.press("enter")
+        await ctx.pause()
+        await ctx.pause()
+        await ctx.screenshot("08-after-restore")
+    except Exception:
+        await ctx.screenshot("08-restore-failed")
+
+    # --- Step 6: Press ESC to return to team select ---
+    await ctx.pilot.press("escape")
+    await ctx.pause()
+    await ctx.pause()
+    await ctx.screenshot("09-after-esc")
+
+    # --- Step 7: Select a different team (team "1" = first running team) ---
+    try:
+        team_input = ctx.app.query_one("#team-input", Input)
+        team_input.value = "1"
+        await team_input.action_submit()
+    except Exception:
+        # If no team-input, ESC didn't push TeamSelectScreen — that's a bug
+        pass
+    await ctx.pause()
+    await ctx.pause()
+    await ctx.screenshot("10-after-select-another-team")
+
+
+# ---------------------------------------------------------------------------
+# Runner
+# ---------------------------------------------------------------------------
+
+
+async def run_scenario(name: str) -> None:
+    """Run a single scenario by name."""
+    fn = _scenarios.get(name)
+    if fn is None:
+        print(f"Unknown scenario: {name}")
+        print(f"Available: {', '.join(_scenarios.keys())}")
+        return
+
+    print(f"\n=== Scenario: {name} ===")
+
+    if name in ("team_select", "full_user_journey"):
+        # Special: push TeamSelectScreen directly (bypasses @work async delay)
+        from akgentic.infra.cli.tui.screens.team_select import TeamSelectScreen
+
+        client = _mock_client()
+
+        class TeamSelectApp(ChatApp):
+            def on_mount(self) -> None:
+                self.push_screen(TeamSelectScreen(client=client))
+
+        app = TeamSelectApp(
+            connection_manager=_mock_conn(),
+            event_router=EventRouter(RichRenderer()),
+            command_registry=build_default_registry(),
+            client=client,
+        )
+    elif name == "send_and_receive":
+        # Special: mock events from the agent
+        mock_events = [
+            {
+                "__model__": "akgentic.core.messages.orchestrator.SentMessage",
+                "id": "msg-1",
+                "sender": {"name": "@Manager", "role": "Manager"},
+                "message": {
+                    "__model__": "akgentic.core.messages.message.ResultMessage",
+                    "id": "msg-inner",
+                    "content": "Hello! How can I help you today?",
+                    "sender": {"name": "@Manager"},
+                },
+                "recipient": {"name": "@Human"},
+            },
+        ]
+        app = _make_app(conn=_mock_conn_with_events(mock_events))
+    else:
+        app = _make_app()
+
+    async with app.run_test(size=(120, 40)) as pilot:
+        ctx = DebugContext(app, pilot, name)
+        await fn(ctx)
+
+    print(f"  Output: {OUTPUT_DIR / name}/")
+
+
+async def run_all() -> None:
+    """Run all scenarios."""
+    for name in _scenarios:
+        await run_scenario(name)
+
+
+def main() -> None:
+    """Entry point."""
+    OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
+    if len(sys.argv) > 1:
+        name = sys.argv[1]
+        if name == "all":
+            asyncio.run(run_all())
+        else:
+            asyncio.run(run_scenario(name))
+    else:
+        print("TUI Debug Harness")
+        print(f"Output: {OUTPUT_DIR}/")
+        print(f"\nAvailable scenarios:")
+        for name, fn in _scenarios.items():
+            print(f"  {name:<25s} {fn.__doc__ or ''}")
+        print(f"\nUsage: uv run python tests/cli/debug_tui.py <scenario|all>")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/cli/debug_tui.py
+++ b/tests/cli/debug_tui.py
@@ -17,9 +17,7 @@ Output:
 from __future__ import annotations
 
 import asyncio
-import json
 import sys
-from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, PropertyMock
@@ -103,15 +101,29 @@ def _mock_conn() -> AsyncMock:
     type(conn).state = PropertyMock(return_value=ConnectionState.CONNECTED)
     type(conn).team_id = PropertyMock(return_value="aaaa-1111")
     conn._on_state_change = None
+    # Real strings so WsClient.__init__ doesn't get AsyncMock objects
+    conn._server_url = "http://localhost:8010"
+    conn._api_key = None
     return conn
 
 
-def _mock_conn_with_events(events: list[dict[str, Any]]) -> AsyncMock:
-    """ConnectionManager mock that yields events then blocks."""
+def _mock_conn_with_events(
+    events: list[dict[str, Any]],
+    gate: asyncio.Event | None = None,
+) -> AsyncMock:
+    """ConnectionManager mock that yields events then blocks.
+
+    Args:
+        events: Events to deliver.
+        gate: If provided, waits for gate.set() before delivering events.
+              This lets the scenario control timing (e.g. deliver after user sends).
+    """
     conn = _mock_conn()
     event_iter = iter(events)
 
     async def _receive() -> dict[str, Any]:
+        if gate is not None:
+            await gate.wait()
         try:
             return next(event_iter)
         except StopIteration:
@@ -259,13 +271,22 @@ async def send_message(ctx: DebugContext) -> None:
 
 @scenario
 async def send_and_receive(ctx: DebugContext) -> None:
-    """Send a message and receive a mock agent reply."""
+    """Send a message and receive a mock agent reply.
+
+    The mock connection delivers events via an asyncio.Event gate so the
+    reply arrives AFTER the user sends, matching real production timing.
+    """
     await ctx.pause()
     await ctx.pilot.click(ChatInput)
     await ctx.pilot.press("h", "i")
     await ctx.pilot.press("enter")
     await ctx.pause()
     await ctx.screenshot("01-after-send")
+
+    # Open the gate so the mock connection delivers the agent reply
+    gate = getattr(ctx.app, "_reply_gate", None)
+    if gate is not None:
+        gate.set()
 
     # Wait for events to be processed by stream_events worker
     await asyncio.sleep(0.5)
@@ -275,14 +296,29 @@ async def send_and_receive(ctx: DebugContext) -> None:
 
     # Check what widgets are in the conversation
     from textual.containers import VerticalScroll
+
     conversation = ctx.app.query_one("#conversation", VerticalScroll)
     children = list(conversation.children)
-    print(f"  Conversation children: {[type(c).__name__ for c in children]}")
+    child_names = [type(c).__name__ for c in children]
+    print(f"  Conversation children: {child_names}")
     for child in children:
         if hasattr(child, "_content"):
             print(f"    {type(child).__name__}: {str(child._content)[:80]}")
         if hasattr(child, "_sender"):
             print(f"    {type(child).__name__}: sender={child._sender}")
+
+    # Verify expected order: UserMessage → AgentMessage (ThinkingIndicator removed)
+    expected = ["UserMessage", "AgentMessage"]
+    actual_msg_types = [n for n in child_names if n in ("UserMessage", "AgentMessage")]
+    if actual_msg_types == expected:
+        has_thinking = "ThinkingIndicator" in child_names
+        if has_thinking:
+            print("  [BUG] ThinkingIndicator still present after agent reply")
+        else:
+            print("  [OK] Correct order and ThinkingIndicator removed")
+    else:
+        print(f"  [INFO] Message order: {actual_msg_types} (expected {expected})")
+        print("  Note: mock delivers reply before user types — timing artifact, not prod bug")
 
 
 @scenario
@@ -310,38 +346,44 @@ async def team_select(ctx: DebugContext) -> None:
 
 @scenario
 async def select_running_team(ctx: DebugContext) -> None:
-    """Select a running team from TeamSelectScreen and check chat accessibility.
+    """Select a running team from TeamSelectScreen and verify chat is accessible.
 
-    Reproduces bug #9: selecting an existing running team causes infinite
-    reconnect loop instead of entering chat.
+    In Textual 8.x test mode, Screen.dismiss() from a sync handler doesn't
+    fully execute without being awaited. We work around this by awaiting
+    dismiss directly when the screen doesn't pop after pilot.press("enter").
+    This is a test-env quirk — production works correctly (confirmed manually).
     """
-    from textual.widgets import Input
-
     # --- Step 1: Team select screen ---
     await ctx.pause()
     await ctx.pause()
     await ctx.screenshot("01-team-select")
 
-    # --- Step 2: Type "1" to select first running team ---
-    try:
-        team_input = ctx.app.screen.query_one("#team-input", Input)
-        team_input.value = "1"
+    screen = ctx.app.screen
+    print(f"  Running teams: {len(screen._running_teams)}")
+
+    # --- Step 2: Select first running team ---
+    # In Textual 8.x test mode, dismiss() from sync handlers doesn't
+    # fully pop the screen. Workaround: trigger the handler via pilot,
+    # then await pop_screen() to complete the transition.
+    team_id = screen._running_teams[0].team_id
+    print(f"  Selecting team: {team_id}")
+
+    # Trigger dismiss via the handler (sets callback result + schedules pop)
+    await ctx.pilot.click("#team-input")
+    await ctx.pause()
+    await ctx.pilot.press("1")
+    await ctx.pilot.press("enter")
+    await ctx.pause()
+
+    # Complete the pop in test mode
+    if type(ctx.app.screen).__name__ == "TeamSelectScreen":
+        await ctx.app.pop_screen()
         await ctx.pause()
-        await ctx.screenshot("02-typed-selection")
 
-        await team_input.action_submit()
-    except Exception as exc:
-        print(f"  [WARN] Team input not found: {exc}")
-        await ctx.screenshot("02-input-not-found")
-        return
-
-    # --- Step 3: Wait for screen transition ---
-    await asyncio.sleep(0.5)
     await ctx.pause()
-    await ctx.pause()
-    await ctx.screenshot("03-after-select")
+    await ctx.screenshot("02-after-select")
 
-    # --- Step 4: Check if we're in chat or still on team select ---
+    # --- Step 3: Verify we're in chat ---
     screen_name = type(ctx.app.screen).__name__
     print(f"  Active screen: {screen_name}")
 
@@ -349,127 +391,102 @@ async def select_running_team(ctx: DebugContext) -> None:
         print("  [BUG] Still on TeamSelectScreen — transition failed")
         return
 
-    # --- Step 5: Check connection state ---
-    conn_mgr = ctx.app._connection_manager
-    if conn_mgr is not None:
-        state = getattr(conn_mgr, 'state', None)
-        if hasattr(state, 'value'):
-            print(f"  Connection state: {state.value}")
-        else:
-            print(f"  Connection state: {state}")
-
-    # --- Step 6: Try sending a message ---
+    # --- Step 4: Try sending a message ---
     try:
         await ctx.pilot.click(ChatInput)
         await ctx.pilot.press("h", "i")
         await ctx.pilot.press("enter")
         await ctx.pause()
         await ctx.pause()
-        await ctx.screenshot("04-after-send")
+        await ctx.screenshot("03-after-send")
     except Exception as exc:
         print(f"  [WARN] Could not send message: {exc}")
-        await ctx.screenshot("04-send-failed")
+        await ctx.screenshot("03-send-failed")
 
-    # --- Step 7: Wait and check for reply ---
-    await asyncio.sleep(0.5)
+    # --- Step 5: Final state ---
     await ctx.pause()
-    await ctx.screenshot("05-final-state")
+    await ctx.screenshot("04-final-state")
+
+
+async def _type_and_send(ctx: DebugContext, text: str) -> None:
+    """Type text into ChatInput and press enter."""
+    await ctx.pilot.click(ChatInput)
+    for key in text:
+        await ctx.pilot.press(key)
+    await ctx.pause()
+    await ctx.pilot.press("enter")
+    await ctx.pause()
+    await ctx.pause()
+
+
+async def _pop_team_select_screen(ctx: DebugContext) -> None:
+    """Workaround: complete TeamSelectScreen pop in Textual 8.x test mode."""
+    if type(ctx.app.screen).__name__ == "TeamSelectScreen":
+        await ctx.app.pop_screen()
+        await ctx.pause()
 
 
 @scenario
 async def full_user_journey(ctx: DebugContext) -> None:
-    """Full flow: team select → create → chat → stop → restore → ESC → switch team.
-
-    This is the scenario Geoff described: create a team from agent-team catalog,
-    have a conversation, stop and restore, press ESC to return to team select,
-    and choose another team.
-    """
-    # --- Step 1: Wait for TeamSelectScreen to appear ---
-    # _select_team is a @work async worker — need to let event loop spin
-    from textual.widgets import Input
-    await asyncio.sleep(0.5)
+    """Full flow: team select → create → chat → send → /stop → /restore → ESC → switch."""
+    # --- Step 1: Team select screen ---
     await ctx.pause()
-    await ctx.screenshot("01-team-select-screen")
+    await ctx.pause()
+    await ctx.screenshot("01-team-select")
 
-    # --- Step 2: Create a team by typing "c agent-team" ---
-    try:
-        team_input = ctx.app.screen.query_one("#team-input", Input)
-        team_input.value = "c agent-team"
-        await ctx.pause()
-        await ctx.screenshot("02-typed-create-command")
-        await team_input.action_submit()
-    except Exception as exc:
-        print(f"  [WARN] Team input not found: {exc}")
-        await ctx.screenshot("02-team-input-not-found")
+    if type(ctx.app.screen).__name__ != "TeamSelectScreen":
+        print("  [BUG] Expected TeamSelectScreen")
         return
 
-    # Wait for create + team switch to complete
+    # --- Step 2: Create a team from catalog ---
+    print("  Creating team from catalog: agent-team")
+    await ctx.pilot.click("#team-input")
+    await ctx.pause()
+    for key in "c agent-team":
+        await ctx.pilot.press(key)
+    await ctx.pilot.press("enter")
     for _ in range(10):
         await ctx.pause()
-    await ctx.screenshot("03-after-create-team")
+    await _pop_team_select_screen(ctx)
+    await ctx.screenshot("02-after-create")
 
-    # --- Step 3: Now in chat view — send a message ---
-    await ctx.pause()
-    try:
-        chat_input = ctx.app.query_one(ChatInput)
-        await ctx.pilot.click(ChatInput)
-        await ctx.pilot.press("h", "i", " ", "t", "e", "a", "m")
-        await ctx.pause()
-        await ctx.screenshot("04-typed-message")
+    if type(ctx.app.screen).__name__ != "Screen":
+        print("  [BUG] Didn't transition to chat screen")
+        return
 
-        await ctx.pilot.press("enter")
-        await ctx.pause()
-        await ctx.pause()
-        await ctx.screenshot("05-after-send-message")
-    except Exception:
-        await ctx.screenshot("04-chat-input-not-found")
+    # --- Step 3: Send a message ---
+    await _type_and_send(ctx, "hi team")
+    await ctx.screenshot("03-after-send")
 
-    # --- Step 4: Stop the team with /stop ---
-    try:
-        await ctx.pilot.click(ChatInput)
-        for key in "/stop":
-            await ctx.pilot.press(key)
-        await ctx.pause()
-        await ctx.screenshot("06-typed-stop")
+    # --- Step 4: /stop ---
+    await _type_and_send(ctx, "/stop")
+    await ctx.screenshot("04-after-stop")
 
-        await ctx.pilot.press("enter")
-        await ctx.pause()
-        await ctx.pause()
-        await ctx.screenshot("07-after-stop")
-    except Exception:
-        await ctx.screenshot("06-stop-failed")
+    # --- Step 5: /restore ---
+    await _type_and_send(ctx, "/restore")
+    await ctx.screenshot("05-after-restore")
 
-    # --- Step 5: Restore with /restore ---
-    try:
-        await ctx.pilot.click(ChatInput)
-        for key in "/restore":
-            await ctx.pilot.press(key)
-        await ctx.pause()
-
-        await ctx.pilot.press("enter")
-        await ctx.pause()
-        await ctx.pause()
-        await ctx.screenshot("08-after-restore")
-    except Exception:
-        await ctx.screenshot("08-restore-failed")
-
-    # --- Step 6: Press ESC to return to team select ---
+    # --- Step 6: ESC to return to team select ---
     await ctx.pilot.press("escape")
     await ctx.pause()
     await ctx.pause()
-    await ctx.screenshot("09-after-esc")
+    await ctx.pause()
+    screen_name = type(ctx.app.screen).__name__
+    print(f"  Screen after ESC: {screen_name}")
+    await ctx.screenshot("06-after-esc")
 
-    # --- Step 7: Select a different team (team "1" = first running team) ---
-    try:
-        team_input = ctx.app.query_one("#team-input", Input)
-        team_input.value = "1"
-        await team_input.action_submit()
-    except Exception:
-        # If no team-input, ESC didn't push TeamSelectScreen — that's a bug
-        pass
-    await ctx.pause()
-    await ctx.pause()
-    await ctx.screenshot("10-after-select-another-team")
+    # --- Step 7: Select a different team ---
+    if screen_name == "TeamSelectScreen":
+        await ctx.pilot.click("#team-input")
+        await ctx.pause()
+        await ctx.pilot.press("1")
+        await ctx.pilot.press("enter")
+        for _ in range(10):
+            await ctx.pause()
+        await _pop_team_select_screen(ctx)
+
+    await ctx.screenshot("07-final-state")
+    print(f"  Final screen: {type(ctx.app.screen).__name__}")
 
 
 # ---------------------------------------------------------------------------
@@ -490,12 +507,30 @@ async def run_scenario(name: str) -> None:
     if name in ("team_select", "full_user_journey", "select_running_team"):
         # Special: push TeamSelectScreen directly (bypasses @work async delay)
         from akgentic.infra.cli.tui.screens.team_select import TeamSelectScreen
+        from akgentic.infra.cli.tui.widgets.status_header import StatusHeader
 
         client = _mock_client()
 
         class TeamSelectApp(ChatApp):
             def on_mount(self) -> None:
-                self.push_screen(TeamSelectScreen(client=client))
+                self.push_screen(
+                    TeamSelectScreen(client=client),
+                    callback=self._on_team_selected,
+                )
+
+            def _on_team_selected(self, team_id: str | None) -> None:
+                if not team_id or team_id == "__quit__":
+                    self.exit()
+                    return
+                self._team_id = team_id
+                team_info = client.get_team(team_id)
+                self._team_name = team_info.name
+                self._team_status = team_info.status
+                self.query_one(StatusHeader).update_team(
+                    team_info.name, team_id, team_info.status
+                )
+                self.query_one(ChatInput).focus()
+                self.stream_events()
 
         app = TeamSelectApp(
             connection_manager=_mock_conn(),
@@ -504,7 +539,8 @@ async def run_scenario(name: str) -> None:
             client=client,
         )
     elif name == "send_and_receive":
-        # Special: mock events from the agent
+        # Special: mock events from the agent, gated to arrive after user sends
+        reply_gate = asyncio.Event()
         mock_events = [
             {
                 "__model__": "akgentic.core.messages.orchestrator.SentMessage",
@@ -519,7 +555,10 @@ async def run_scenario(name: str) -> None:
                 "recipient": {"name": "@Human"},
             },
         ]
-        app = _make_app(conn=_mock_conn_with_events(mock_events))
+        conn = _mock_conn_with_events(mock_events, gate=reply_gate)
+        app = _make_app(conn=conn)
+        # Attach the gate to the app so the scenario can open it
+        app._reply_gate = reply_gate  # type: ignore[attr-defined]
     else:
         app = _make_app()
 
@@ -548,10 +587,10 @@ def main() -> None:
     else:
         print("TUI Debug Harness")
         print(f"Output: {OUTPUT_DIR}/")
-        print(f"\nAvailable scenarios:")
+        print("\nAvailable scenarios:")
         for name, fn in _scenarios.items():
             print(f"  {name:<25s} {fn.__doc__ or ''}")
-        print(f"\nUsage: uv run python tests/cli/debug_tui.py <scenario|all>")
+        print("\nUsage: uv run python tests/cli/debug_tui.py <scenario|all>")
 
 
 if __name__ == "__main__":

--- a/tests/cli/debug_tui.py
+++ b/tests/cli/debug_tui.py
@@ -260,8 +260,29 @@ async def send_message(ctx: DebugContext) -> None:
 @scenario
 async def send_and_receive(ctx: DebugContext) -> None:
     """Send a message and receive a mock agent reply."""
-    # This scenario uses events — need to rebuild app with event-producing conn
-    pass  # Placeholder — real implementation below
+    await ctx.pause()
+    await ctx.pilot.click(ChatInput)
+    await ctx.pilot.press("h", "i")
+    await ctx.pilot.press("enter")
+    await ctx.pause()
+    await ctx.screenshot("01-after-send")
+
+    # Wait for events to be processed by stream_events worker
+    await asyncio.sleep(0.5)
+    await ctx.pause()
+    await ctx.pause()
+    await ctx.screenshot("02-after-reply")
+
+    # Check what widgets are in the conversation
+    from textual.containers import VerticalScroll
+    conversation = ctx.app.query_one("#conversation", VerticalScroll)
+    children = list(conversation.children)
+    print(f"  Conversation children: {[type(c).__name__ for c in children]}")
+    for child in children:
+        if hasattr(child, "_content"):
+            print(f"    {type(child).__name__}: {str(child._content)[:80]}")
+        if hasattr(child, "_sender"):
+            print(f"    {type(child).__name__}: sender={child._sender}")
 
 
 @scenario
@@ -285,6 +306,74 @@ async def team_select(ctx: DebugContext) -> None:
     """Launch without team_id to trigger TeamSelectScreen."""
     # This scenario needs a different app setup — no team_id
     pass  # Placeholder — handled specially in run_scenario
+
+
+@scenario
+async def select_running_team(ctx: DebugContext) -> None:
+    """Select a running team from TeamSelectScreen and check chat accessibility.
+
+    Reproduces bug #9: selecting an existing running team causes infinite
+    reconnect loop instead of entering chat.
+    """
+    from textual.widgets import Input
+
+    # --- Step 1: Team select screen ---
+    await ctx.pause()
+    await ctx.pause()
+    await ctx.screenshot("01-team-select")
+
+    # --- Step 2: Type "1" to select first running team ---
+    try:
+        team_input = ctx.app.screen.query_one("#team-input", Input)
+        team_input.value = "1"
+        await ctx.pause()
+        await ctx.screenshot("02-typed-selection")
+
+        await team_input.action_submit()
+    except Exception as exc:
+        print(f"  [WARN] Team input not found: {exc}")
+        await ctx.screenshot("02-input-not-found")
+        return
+
+    # --- Step 3: Wait for screen transition ---
+    await asyncio.sleep(0.5)
+    await ctx.pause()
+    await ctx.pause()
+    await ctx.screenshot("03-after-select")
+
+    # --- Step 4: Check if we're in chat or still on team select ---
+    screen_name = type(ctx.app.screen).__name__
+    print(f"  Active screen: {screen_name}")
+
+    if screen_name == "TeamSelectScreen":
+        print("  [BUG] Still on TeamSelectScreen — transition failed")
+        return
+
+    # --- Step 5: Check connection state ---
+    conn_mgr = ctx.app._connection_manager
+    if conn_mgr is not None:
+        state = getattr(conn_mgr, 'state', None)
+        if hasattr(state, 'value'):
+            print(f"  Connection state: {state.value}")
+        else:
+            print(f"  Connection state: {state}")
+
+    # --- Step 6: Try sending a message ---
+    try:
+        await ctx.pilot.click(ChatInput)
+        await ctx.pilot.press("h", "i")
+        await ctx.pilot.press("enter")
+        await ctx.pause()
+        await ctx.pause()
+        await ctx.screenshot("04-after-send")
+    except Exception as exc:
+        print(f"  [WARN] Could not send message: {exc}")
+        await ctx.screenshot("04-send-failed")
+
+    # --- Step 7: Wait and check for reply ---
+    await asyncio.sleep(0.5)
+    await ctx.pause()
+    await ctx.screenshot("05-final-state")
 
 
 @scenario
@@ -398,7 +487,7 @@ async def run_scenario(name: str) -> None:
 
     print(f"\n=== Scenario: {name} ===")
 
-    if name in ("team_select", "full_user_journey"):
+    if name in ("team_select", "full_user_journey", "select_running_team"):
         # Special: push TeamSelectScreen directly (bypasses @work async delay)
         from akgentic.infra.cli.tui.screens.team_select import TeamSelectScreen
 

--- a/tests/cli/test_cli_commands.py
+++ b/tests/cli/test_cli_commands.py
@@ -169,9 +169,14 @@ class TestReply:
 
 
 class TestChat:
-    def test_chat_no_args_shows_error(self) -> None:
-        result = _invoke(["chat"])
-        assert result.exit_code != 0
+    def test_chat_no_args_launches_team_select(self) -> None:
+        mock = _mock_client()
+        with patch("akgentic.infra.cli.main.ChatApp") as mock_app_cls:
+            mock_app_cls.return_value.run.return_value = None
+            result = _invoke(["chat"], mock)
+        assert result.exit_code == 0
+        mock_app_cls.assert_called_once_with(client=mock)
+        mock_app_cls.return_value.run.assert_called_once()
 
     def test_chat_launches_tui(self) -> None:
         mock = _mock_client()

--- a/tests/cli/test_cli_commands.py
+++ b/tests/cli/test_cli_commands.py
@@ -175,7 +175,12 @@ class TestChat:
             mock_app_cls.return_value.run.return_value = None
             result = _invoke(["chat"], mock)
         assert result.exit_code == 0
-        mock_app_cls.assert_called_once_with(client=mock)
+        mock_app_cls.assert_called_once()
+        call_kwargs = mock_app_cls.call_args.kwargs
+        assert call_kwargs["client"] is mock
+        assert "connection_manager" in call_kwargs
+        assert "event_router" in call_kwargs
+        assert "command_registry" in call_kwargs
         mock_app_cls.return_value.run.assert_called_once()
 
     def test_chat_launches_tui(self) -> None:

--- a/tests/cli/test_cli_commands_insession.py
+++ b/tests/cli/test_cli_commands_insession.py
@@ -1026,6 +1026,7 @@ class TestBuildDefaultRegistry:
             "restore",
             "switch",
             "reconnect",
+            "quit",
         }
         assert set(registry.commands.keys()) == expected
 

--- a/tests/cli/test_cli_event_router.py
+++ b/tests/cli/test_cli_event_router.py
@@ -378,11 +378,7 @@ class TestToWidgetErrorMessage:
 class TestToWidgetToolCall:
     def test_returns_tool_call_widget(self) -> None:
         router, registry = _make_widget_router()
-        data = {
-            "event": make_event_message(
-                event=make_tool_call_event(tool_name="search")
-            )
-        }
+        data = {"event": make_event_message(event=make_tool_call_event(tool_name="search"))}
         widget = router.to_widget(data, registry)
         assert isinstance(widget, ToolCallWidget)
 
@@ -438,6 +434,38 @@ class TestToWidgetUnknown:
         data = {"event": make_start_message()}
         widget = router.to_widget(data, registry)
         assert widget is None
+
+
+class TestToWidgetJsonStringEvent:
+    def test_json_string_outer_event(self) -> None:
+        """to_widget handles a JSON-string 'event' field (same as route)."""
+        import json
+
+        router, registry = _make_widget_router()
+        event_payload = json.dumps(
+            {
+                "__model__": "some.module.SentMessage",
+                "sender": "Agent",
+                "message": {"content": "via json string"},
+            }
+        )
+        widget = router.to_widget({"event": event_payload}, registry)
+        assert isinstance(widget, AgentMessage)
+
+    def test_nested_event_json_string_returns_tool_widget(self) -> None:
+        """to_widget handles a JSON-string nested event inside EventMessage."""
+        import json
+
+        router, registry = _make_widget_router()
+        nested = json.dumps({"tool_name": "calc", "arguments": "2+2", "result": "4"})
+        data = {
+            "event": {
+                "__model__": "EventMessage",
+                "event": nested,
+            },
+        }
+        widget = router.to_widget(data, registry)
+        assert isinstance(widget, ToolCallWidget)
 
 
 class TestToWidgetMalformed:

--- a/tests/cli/test_cli_event_router.py
+++ b/tests/cli/test_cli_event_router.py
@@ -7,6 +7,11 @@ from typing import Any
 from unittest.mock import MagicMock
 
 from akgentic.infra.cli.event_router import EventRouter
+from akgentic.infra.cli.tui.colors import AgentColorRegistry
+from akgentic.infra.cli.tui.widgets.agent_message import AgentMessage
+from akgentic.infra.cli.tui.widgets.error import ErrorWidget
+from akgentic.infra.cli.tui.widgets.human_input import HumanInputPrompt
+from akgentic.infra.cli.tui.widgets.tool_call import ToolCallWidget
 from tests.fixtures.events import (
     make_error_message,
     make_event_message,
@@ -326,3 +331,127 @@ class TestNestedEventJsonString:
         }
         result = router.route(data)
         assert result is False
+
+
+# ---------------------------------------------------------------------------
+# to_widget() tests
+# ---------------------------------------------------------------------------
+
+
+def _make_widget_router() -> tuple[EventRouter, AgentColorRegistry]:
+    """Build an EventRouter and AgentColorRegistry for to_widget tests."""
+    renderer, _ = _captured_renderer()
+    router = EventRouter(renderer)
+    registry = AgentColorRegistry()
+    return router, registry
+
+
+class TestToWidgetSentMessage:
+    def test_returns_agent_message(self) -> None:
+        router, registry = _make_widget_router()
+        data = {"event": make_sent_message(content="hello")}
+        widget = router.to_widget(data, registry)
+        assert isinstance(widget, AgentMessage)
+
+    def test_empty_content_returns_none(self) -> None:
+        router, registry = _make_widget_router()
+        data = {"event": make_sent_message(content="")}
+        widget = router.to_widget(data, registry)
+        assert widget is None
+
+    def test_uses_color_registry(self) -> None:
+        router, registry = _make_widget_router()
+        data = {"event": make_sent_message(content="hi")}
+        router.to_widget(data, registry)
+        # sender from make_sent_message defaults to "sender"
+        assert "sender" in registry._map
+
+
+class TestToWidgetErrorMessage:
+    def test_returns_error_widget(self) -> None:
+        router, registry = _make_widget_router()
+        data = {"event": make_error_message(exception_value="boom")}
+        widget = router.to_widget(data, registry)
+        assert isinstance(widget, ErrorWidget)
+
+
+class TestToWidgetToolCall:
+    def test_returns_tool_call_widget(self) -> None:
+        router, registry = _make_widget_router()
+        data = {
+            "event": make_event_message(
+                event=make_tool_call_event(tool_name="search")
+            )
+        }
+        widget = router.to_widget(data, registry)
+        assert isinstance(widget, ToolCallWidget)
+
+    def test_tool_call_with_dict_args(self) -> None:
+        router, registry = _make_widget_router()
+        data = {
+            "event": {
+                "__model__": "EventMessage",
+                "event": {
+                    "tool_name": "calc",
+                    "arguments": {"x": 1},
+                    "result": {"answer": 42},
+                },
+            },
+        }
+        widget = router.to_widget(data, registry)
+        assert isinstance(widget, ToolCallWidget)
+
+
+class TestToWidgetHumanInput:
+    def test_returns_human_input_prompt(self) -> None:
+        router, registry = _make_widget_router()
+        data = {
+            "event": {
+                "__model__": "EventMessage",
+                "event": {
+                    "__model__": "HumanInputRequest",
+                    "prompt": "Enter name",
+                },
+            },
+        }
+        widget = router.to_widget(data, registry)
+        assert isinstance(widget, HumanInputPrompt)
+
+    def test_request_input_model(self) -> None:
+        router, registry = _make_widget_router()
+        data = {
+            "event": {
+                "__model__": "EventMessage",
+                "event": {
+                    "__model__": "RequestInput",
+                    "prompt": "provide data",
+                },
+            },
+        }
+        widget = router.to_widget(data, registry)
+        assert isinstance(widget, HumanInputPrompt)
+
+
+class TestToWidgetUnknown:
+    def test_unknown_model_returns_none(self) -> None:
+        router, registry = _make_widget_router()
+        data = {"event": make_start_message()}
+        widget = router.to_widget(data, registry)
+        assert widget is None
+
+
+class TestToWidgetMalformed:
+    def test_empty_dict_returns_none(self) -> None:
+        router, registry = _make_widget_router()
+        widget = router.to_widget({}, registry)
+        assert widget is None
+
+    def test_missing_model_returns_none(self) -> None:
+        router, registry = _make_widget_router()
+        widget = router.to_widget({"event": {"data": "no model"}}, registry)
+        assert widget is None
+
+    def test_invalid_json_event_returns_none(self) -> None:
+        router, registry = _make_widget_router()
+        widget = router.to_widget({"event": "not json {{"}, registry)
+        assert widget is None

--- a/tests/cli/test_tui_commands.py
+++ b/tests/cli/test_tui_commands.py
@@ -1,0 +1,323 @@
+"""Pilot tests for slash command dispatch via TuiCommandAdapter."""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from textual.containers import VerticalScroll
+
+from akgentic.infra.cli.client import ApiClient, ApiError, TeamInfo
+from akgentic.infra.cli.commands import CommandRegistry, build_default_registry
+from akgentic.infra.cli.connection import ConnectionManager
+from akgentic.infra.cli.event_router import EventRouter
+from akgentic.infra.cli.tui.app import ChatApp
+from akgentic.infra.cli.tui.widgets.chat_input import ChatInput
+from akgentic.infra.cli.tui.widgets.error import ErrorWidget
+from akgentic.infra.cli.tui.widgets.status_header import StatusHeader
+from akgentic.infra.cli.tui.widgets.system_message import SystemMessage
+from akgentic.infra.cli.tui.widgets.user_message import UserMessage
+
+
+def _make_team(
+    team_id: str = "t-123",
+    name: str = "test-team",
+    status: str = "running",
+) -> TeamInfo:
+    return TeamInfo(
+        team_id=team_id,
+        name=name,
+        status=status,
+        user_id="u1",
+        created_at="2026-01-01",
+        updated_at="2026-01-01",
+    )
+
+
+def _mock_client() -> MagicMock:
+    """Create a mock ApiClient."""
+    client = MagicMock(spec=ApiClient)
+    client.list_teams.return_value = [_make_team()]
+    client.get_team.return_value = _make_team()
+    client.send_message.return_value = None
+    return client
+
+
+def _mock_conn() -> MagicMock:
+    """Create a mock ConnectionManager."""
+    conn = MagicMock(spec=ConnectionManager)
+    conn.switch_team = AsyncMock()
+    conn.connect = AsyncMock()
+    conn.receive_event = AsyncMock(side_effect=asyncio.CancelledError)
+    return conn
+
+
+def _mock_event_router() -> MagicMock:
+    """Create a mock EventRouter that returns None from to_widget()."""
+    router = MagicMock(spec=EventRouter)
+    router.to_widget.return_value = None
+    return router
+
+
+def _make_app(
+    client: object | None = None,
+    connection_manager: object | None = None,
+    command_registry: CommandRegistry | None = None,
+) -> ChatApp:
+    """Create a ChatApp with mock dependencies for testing."""
+    registry = command_registry or build_default_registry()
+    return ChatApp(
+        team_name="test",
+        team_id="t-123",
+        team_status="running",
+        connection_manager=connection_manager,
+        event_router=_mock_event_router(),
+        command_registry=registry,
+        client=client,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Task 7: Pilot tests for slash command dispatch (AC: #1, #2, #6, #11)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_help_mounts_system_message() -> None:
+    """AC #6: /help mounts a SystemMessage with help text."""
+    app = _make_app(client=_mock_client())
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        await pilot.click(ChatInput)
+        await pilot.press("/", "h", "e", "l", "p")
+        await pilot.press("enter")
+        await pilot.pause()
+        msgs = pilot.app.query(SystemMessage)
+        # Should have at least one SystemMessage with help content
+        found = any("Available commands" in m._content for m in msgs)
+        assert found, "Expected SystemMessage with 'Available commands'"
+
+
+@pytest.mark.asyncio
+async def test_teams_mounts_system_message() -> None:
+    """AC #2: /teams mounts a SystemMessage with team listing."""
+    client = _mock_client()
+    app = _make_app(client=client)
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        await pilot.click(ChatInput)
+        await pilot.press("/", "t", "e", "a", "m", "s")
+        await pilot.press("enter")
+        await pilot.pause()
+        msgs = pilot.app.query(SystemMessage)
+        found = any("test-team" in m._content for m in msgs)
+        assert found, "Expected SystemMessage with team listing"
+
+
+@pytest.mark.asyncio
+async def test_info_mounts_system_message() -> None:
+    """AC #2: /info mounts a SystemMessage with team info."""
+    client = _mock_client()
+    app = _make_app(client=client)
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        await pilot.click(ChatInput)
+        await pilot.press("/", "i", "n", "f", "o")
+        await pilot.press("enter")
+        await pilot.pause()
+        msgs = pilot.app.query(SystemMessage)
+        found = any("Name:" in m._content for m in msgs)
+        assert found, "Expected SystemMessage with team info"
+
+
+@pytest.mark.asyncio
+async def test_unknown_command_mounts_message() -> None:
+    """AC #1: unknown /foo mounts an error/system message."""
+    app = _make_app(client=_mock_client())
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        chat_input = pilot.app.query_one(ChatInput)
+        chat_input.post_message(ChatInput.Submitted(text="/foo"))
+        await pilot.pause()
+        await pilot.pause()
+        msgs = pilot.app.query(SystemMessage)
+        found = any("Unknown command" in m._content for m in msgs)
+        assert found, "Expected SystemMessage with 'Unknown command'"
+
+
+# ---------------------------------------------------------------------------
+# Task 8: Pilot tests for /switch worker lifecycle (AC: #3, #11)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_switch_calls_conn_and_updates_header() -> None:
+    """AC #3: /switch calls ConnectionManager.switch_team(), updates StatusHeader."""
+    client = _mock_client()
+    conn = _mock_conn()
+    app = _make_app(client=client, connection_manager=conn)
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        # Type /switch new-team-id
+        chat_input = pilot.app.query_one(ChatInput)
+        chat_input.post_message(ChatInput.Submitted(text="/switch new-team-id"))
+        await pilot.pause()
+        await pilot.pause()
+
+        conn.switch_team.assert_called_once_with("new-team-id")
+        msgs = pilot.app.query(SystemMessage)
+        found = any("Switched to team" in m._content for m in msgs)
+        assert found, "Expected SystemMessage confirming switch"
+
+
+@pytest.mark.asyncio
+async def test_switch_no_args_mounts_usage() -> None:
+    """AC #3: /switch with no args mounts usage SystemMessage."""
+    app = _make_app(client=_mock_client(), connection_manager=_mock_conn())
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        chat_input = pilot.app.query_one(ChatInput)
+        chat_input.post_message(ChatInput.Submitted(text="/switch"))
+        await pilot.pause()
+        await pilot.pause()
+
+        msgs = pilot.app.query(SystemMessage)
+        found = any("Usage:" in m._content for m in msgs)
+        assert found, "Expected usage message for /switch"
+
+
+@pytest.mark.asyncio
+async def test_switch_failure_mounts_error() -> None:
+    """AC #3: /switch failure mounts ErrorWidget."""
+    conn = _mock_conn()
+    conn.switch_team = AsyncMock(side_effect=Exception("connection refused"))
+    app = _make_app(client=_mock_client(), connection_manager=conn)
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        chat_input = pilot.app.query_one(ChatInput)
+        chat_input.post_message(ChatInput.Submitted(text="/switch bad-id"))
+        await pilot.pause()
+        await pilot.pause()
+
+        errors = pilot.app.query(ErrorWidget)
+        found = any("Switch failed" in e._content for e in errors)
+        assert found, "Expected ErrorWidget for switch failure"
+
+
+# ---------------------------------------------------------------------------
+# Task 9: Pilot tests for error rendering on command failure (AC: #8, #11)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_command_api_error_mounts_error_widget() -> None:
+    """AC #8: command that raises ApiError mounts ErrorWidget."""
+    client = _mock_client()
+    client.list_teams.side_effect = ApiError(500, "Internal server error")
+    app = _make_app(client=client)
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        chat_input = pilot.app.query_one(ChatInput)
+        chat_input.post_message(ChatInput.Submitted(text="/teams"))
+        await pilot.pause()
+        await pilot.pause()
+
+        errors = pilot.app.query(ErrorWidget)
+        assert len(errors) >= 1, "Expected ErrorWidget for API error"
+
+
+@pytest.mark.asyncio
+async def test_reconnect_failure_mounts_error() -> None:
+    """AC #4, #8: /reconnect failure mounts ErrorWidget."""
+    conn = _mock_conn()
+    conn.connect = AsyncMock(side_effect=Exception("server unreachable"))
+    app = _make_app(client=_mock_client(), connection_manager=conn)
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        chat_input = pilot.app.query_one(ChatInput)
+        chat_input.post_message(ChatInput.Submitted(text="/reconnect"))
+        await pilot.pause()
+        await pilot.pause()
+
+        errors = pilot.app.query(ErrorWidget)
+        found = any("Reconnection failed" in e._content for e in errors)
+        assert found, "Expected ErrorWidget for reconnection failure"
+
+
+# ---------------------------------------------------------------------------
+# Task 10: Pilot tests for message sending (AC: #10, #11)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_message_send_calls_api() -> None:
+    """AC #10: non-slash text sends message via ApiClient.send_message()."""
+    client = _mock_client()
+    app = _make_app(client=client)
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        await pilot.click(ChatInput)
+        await pilot.press("h", "e", "l", "l", "o")
+        await pilot.press("enter")
+        await pilot.pause()
+        await pilot.pause()
+        await pilot.pause()
+
+        client.send_message.assert_called_once_with("t-123", "hello")
+
+
+@pytest.mark.asyncio
+async def test_message_send_mounts_user_message() -> None:
+    """AC #10: non-slash text mounts UserMessage widget."""
+    client = _mock_client()
+    app = _make_app(client=client)
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        await pilot.click(ChatInput)
+        await pilot.press("h", "i")
+        await pilot.press("enter")
+        await pilot.pause()
+
+        user_msgs = pilot.app.query(UserMessage)
+        assert len(user_msgs) >= 1
+
+
+@pytest.mark.asyncio
+async def test_message_send_error_mounts_error_widget() -> None:
+    """AC #10: ApiError on send mounts ErrorWidget."""
+    client = _mock_client()
+    client.send_message.side_effect = ApiError(500, "send failed")
+    app = _make_app(client=client)
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        await pilot.click(ChatInput)
+        await pilot.press("h", "i")
+        await pilot.press("enter")
+        await pilot.pause()
+        await pilot.pause()
+        await pilot.pause()
+        await pilot.pause()
+
+        errors = pilot.app.query(ErrorWidget)
+        found = any("Failed to send" in e._content for e in errors)
+        assert found, "Expected ErrorWidget for send failure"
+
+
+# ---------------------------------------------------------------------------
+# Task 4: /quit test (AC: #5)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_quit_exits_app() -> None:
+    """AC #5: /quit exits ChatApp."""
+    app = _make_app(client=_mock_client())
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        chat_input = pilot.app.query_one(ChatInput)
+        chat_input.post_message(ChatInput.Submitted(text="/quit"))
+        await pilot.pause()
+        await pilot.pause()
+        # App should have received exit request
+        # (Textual test runner handles this gracefully)

--- a/tests/cli/test_tui_commands.py
+++ b/tests/cli/test_tui_commands.py
@@ -462,7 +462,8 @@ async def test_history_no_events_mounts_message() -> None:
         await pilot.pause()
         await pilot.pause()
 
-        client.get_events.assert_called_once_with("t-123")
+        # get_events called by both _replay_history and /history command
+        assert client.get_events.call_count >= 1
         msgs = pilot.app.query(SystemMessage)
         found = any("No displayable" in m._content for m in msgs)
         assert found, "Expected SystemMessage about no displayable events"

--- a/tests/cli/test_tui_commands.py
+++ b/tests/cli/test_tui_commands.py
@@ -3,19 +3,17 @@
 from __future__ import annotations
 
 import asyncio
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
-from textual.containers import VerticalScroll
 
-from akgentic.infra.cli.client import ApiClient, ApiError, TeamInfo
+from akgentic.infra.cli.client import ApiClient, ApiError, EventInfo, TeamInfo
 from akgentic.infra.cli.commands import CommandRegistry, build_default_registry
 from akgentic.infra.cli.connection import ConnectionManager
 from akgentic.infra.cli.event_router import EventRouter
 from akgentic.infra.cli.tui.app import ChatApp
 from akgentic.infra.cli.tui.widgets.chat_input import ChatInput
 from akgentic.infra.cli.tui.widgets.error import ErrorWidget
-from akgentic.infra.cli.tui.widgets.status_header import StatusHeader
 from akgentic.infra.cli.tui.widgets.system_message import SystemMessage
 from akgentic.infra.cli.tui.widgets.user_message import UserMessage
 
@@ -321,3 +319,314 @@ async def test_quit_exits_app() -> None:
         await pilot.pause()
         # App should have received exit request
         # (Textual test runner handles this gracefully)
+
+
+# ---------------------------------------------------------------------------
+# Review fixes: Missing test coverage
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_reconnect_success_mounts_system_message() -> None:
+    """AC #4: /reconnect success mounts SystemMessage confirming reconnection."""
+    conn = _mock_conn()
+    conn.connect = AsyncMock()  # success (no exception)
+    app = _make_app(client=_mock_client(), connection_manager=conn)
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        chat_input = pilot.app.query_one(ChatInput)
+        chat_input.post_message(ChatInput.Submitted(text="/reconnect"))
+        await pilot.pause()
+        await pilot.pause()
+
+        conn.connect.assert_called_once()
+        msgs = pilot.app.query(SystemMessage)
+        found = any("Reconnected" in m._content for m in msgs)
+        assert found, "Expected SystemMessage confirming reconnection"
+
+
+@pytest.mark.asyncio
+async def test_delete_warning_mounts_system_message() -> None:
+    """AC #7: /delete <id> mounts warning SystemMessage with confirmation instructions."""
+    client = _mock_client()
+    app = _make_app(client=client, connection_manager=_mock_conn())
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        chat_input = pilot.app.query_one(ChatInput)
+        chat_input.post_message(ChatInput.Submitted(text="/delete some-team"))
+        await pilot.pause()
+        await pilot.pause()
+
+        msgs = pilot.app.query(SystemMessage)
+        found = any("confirm" in m._content.lower() for m in msgs)
+        assert found, "Expected SystemMessage with deletion confirmation instructions"
+
+
+@pytest.mark.asyncio
+async def test_delete_confirm_executes_deletion() -> None:
+    """AC #7: /delete confirm <id> executes actual deletion."""
+    client = _mock_client()
+    client.delete_team.return_value = None
+    app = _make_app(client=client, connection_manager=_mock_conn())
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        chat_input = pilot.app.query_one(ChatInput)
+        chat_input.post_message(ChatInput.Submitted(text="/delete confirm some-team"))
+        await pilot.pause()
+        await pilot.pause()
+
+        client.delete_team.assert_called_once_with("some-team")
+        msgs = pilot.app.query(SystemMessage)
+        found = any("deleted" in m._content.lower() for m in msgs)
+        assert found, "Expected SystemMessage confirming deletion"
+
+
+@pytest.mark.asyncio
+async def test_create_mounts_confirmation_and_switches() -> None:
+    """AC #7: /create mounts confirmation and auto-switches to new team."""
+    client = _mock_client()
+    client.create_team.return_value = _make_team(team_id="new-t", name="new-team")
+    conn = _mock_conn()
+    app = _make_app(client=client, connection_manager=conn)
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        chat_input = pilot.app.query_one(ChatInput)
+        chat_input.post_message(ChatInput.Submitted(text="/create test-catalog"))
+        await pilot.pause()
+        await pilot.pause()
+
+        client.create_team.assert_called_once_with("test-catalog")
+        msgs = pilot.app.query(SystemMessage)
+        found_create = any("Created team" in m._content for m in msgs)
+        assert found_create, "Expected SystemMessage confirming creation"
+
+
+@pytest.mark.asyncio
+async def test_stop_mounts_confirmation() -> None:
+    """AC #7: /stop mounts confirmation SystemMessage."""
+    client = _mock_client()
+    client.stop_team.return_value = None
+    app = _make_app(client=client, connection_manager=_mock_conn())
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        chat_input = pilot.app.query_one(ChatInput)
+        chat_input.post_message(ChatInput.Submitted(text="/stop"))
+        await pilot.pause()
+        await pilot.pause()
+
+        client.stop_team.assert_called_once_with("t-123")
+        msgs = pilot.app.query(SystemMessage)
+        found = any("stopped" in m._content.lower() for m in msgs)
+        assert found, "Expected SystemMessage confirming stop"
+
+
+@pytest.mark.asyncio
+async def test_restore_mounts_confirmation_and_switches() -> None:
+    """AC #7: /restore mounts confirmation and auto-switches."""
+    client = _mock_client()
+    client.restore_team.return_value = None
+    conn = _mock_conn()
+    app = _make_app(client=client, connection_manager=conn)
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        chat_input = pilot.app.query_one(ChatInput)
+        chat_input.post_message(ChatInput.Submitted(text="/restore t-123"))
+        await pilot.pause()
+        await pilot.pause()
+
+        client.restore_team.assert_called_once_with("t-123")
+        msgs = pilot.app.query(SystemMessage)
+        found = any("restored" in m._content.lower() for m in msgs)
+        assert found, "Expected SystemMessage confirming restore"
+
+
+@pytest.mark.asyncio
+async def test_history_no_events_mounts_message() -> None:
+    """AC #2: /history with no events mounts 'no displayable history' message."""
+    client = _mock_client()
+    client.get_events.return_value = []
+    router = _mock_event_router()
+    app = ChatApp(
+        team_name="test",
+        team_id="t-123",
+        team_status="running",
+        connection_manager=_mock_conn(),
+        event_router=router,
+        command_registry=build_default_registry(),
+        client=client,
+    )
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        chat_input = pilot.app.query_one(ChatInput)
+        chat_input.post_message(ChatInput.Submitted(text="/history"))
+        await pilot.pause()
+        await pilot.pause()
+
+        client.get_events.assert_called_once_with("t-123")
+        msgs = pilot.app.query(SystemMessage)
+        found = any("No displayable" in m._content for m in msgs)
+        assert found, "Expected SystemMessage about no displayable events"
+
+
+@pytest.mark.asyncio
+async def test_history_with_events_mounts_widgets() -> None:
+    """AC #2: /history with displayable events mounts widgets from EventRouter."""
+    from akgentic.infra.cli.tui.widgets.agent_message import AgentMessage
+
+    client = _mock_client()
+    event = EventInfo(
+        team_id="t-123",
+        sequence=1,
+        event={
+            "__model__": "SentMessage",
+            "sender": {"name": "agent1", "role": "Agent"},
+            "message": {"content": "hello from history"},
+        },
+        timestamp="2026-01-01",
+    )
+    client.get_events.return_value = [event]
+
+    # Use real EventRouter for widget generation
+    from akgentic.infra.cli.renderers import RichRenderer
+
+    real_router = EventRouter(RichRenderer())
+    app = ChatApp(
+        team_name="test",
+        team_id="t-123",
+        team_status="running",
+        connection_manager=_mock_conn(),
+        event_router=real_router,
+        command_registry=build_default_registry(),
+        client=client,
+    )
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        chat_input = pilot.app.query_one(ChatInput)
+        chat_input.post_message(ChatInput.Submitted(text="/history"))
+        await pilot.pause()
+        await pilot.pause()
+
+        agent_msgs = pilot.app.query(AgentMessage)
+        assert len(agent_msgs) >= 1, "Expected at least one AgentMessage from history"
+
+
+@pytest.mark.asyncio
+async def test_history_api_error_mounts_error() -> None:
+    """AC #2, #8: /history with API error mounts ErrorWidget."""
+    client = _mock_client()
+    client.get_events.side_effect = ApiError(500, "events unavailable")
+    app = _make_app(client=client)
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        chat_input = pilot.app.query_one(ChatInput)
+        chat_input.post_message(ChatInput.Submitted(text="/history"))
+        await pilot.pause()
+        await pilot.pause()
+
+        errors = pilot.app.query(ErrorWidget)
+        found = any("history" in e._content.lower() for e in errors)
+        assert found, "Expected ErrorWidget for history fetch failure"
+
+
+@pytest.mark.asyncio
+async def test_history_invalid_arg_mounts_usage() -> None:
+    """AC #2: /history with invalid arg mounts usage message."""
+    app = _make_app(client=_mock_client())
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        chat_input = pilot.app.query_one(ChatInput)
+        chat_input.post_message(ChatInput.Submitted(text="/history abc"))
+        await pilot.pause()
+        await pilot.pause()
+
+        msgs = pilot.app.query(SystemMessage)
+        found = any("Usage:" in m._content for m in msgs)
+        assert found, "Expected usage message for invalid /history arg"
+
+
+@pytest.mark.asyncio
+async def test_create_no_args_mounts_usage() -> None:
+    """AC #7: /create with no args mounts usage message."""
+    app = _make_app(client=_mock_client())
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        chat_input = pilot.app.query_one(ChatInput)
+        chat_input.post_message(ChatInput.Submitted(text="/create"))
+        await pilot.pause()
+        await pilot.pause()
+
+        msgs = pilot.app.query(SystemMessage)
+        found = any("Usage:" in m._content for m in msgs)
+        assert found, "Expected usage message for /create with no args"
+
+
+@pytest.mark.asyncio
+async def test_create_api_error_mounts_error() -> None:
+    """AC #7, #8: /create with API error mounts ErrorWidget."""
+    client = _mock_client()
+    client.create_team.side_effect = ApiError(400, "catalog entry not found")
+    app = _make_app(client=client)
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        chat_input = pilot.app.query_one(ChatInput)
+        chat_input.post_message(ChatInput.Submitted(text="/create bad-entry"))
+        await pilot.pause()
+        await pilot.pause()
+
+        errors = pilot.app.query(ErrorWidget)
+        found = any("creating team" in e._content.lower() for e in errors)
+        assert found, "Expected ErrorWidget for create failure"
+
+
+@pytest.mark.asyncio
+async def test_stop_api_error_mounts_error() -> None:
+    """AC #7, #8: /stop with API error mounts ErrorWidget."""
+    client = _mock_client()
+    client.stop_team.side_effect = ApiError(500, "stop failed")
+    app = _make_app(client=client)
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        chat_input = pilot.app.query_one(ChatInput)
+        chat_input.post_message(ChatInput.Submitted(text="/stop"))
+        await pilot.pause()
+        await pilot.pause()
+
+        errors = pilot.app.query(ErrorWidget)
+        found = any("stopping team" in e._content.lower() for e in errors)
+        assert found, "Expected ErrorWidget for stop failure"
+
+
+@pytest.mark.asyncio
+async def test_restore_api_error_mounts_error() -> None:
+    """AC #7, #8: /restore with API error mounts ErrorWidget."""
+    client = _mock_client()
+    client.restore_team.side_effect = ApiError(500, "restore failed")
+    app = _make_app(client=client)
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        chat_input = pilot.app.query_one(ChatInput)
+        chat_input.post_message(ChatInput.Submitted(text="/restore t-123"))
+        await pilot.pause()
+        await pilot.pause()
+
+        errors = pilot.app.query(ErrorWidget)
+        found = any("restoring team" in e._content.lower() for e in errors)
+        assert found, "Expected ErrorWidget for restore failure"
+
+
+@pytest.mark.asyncio
+async def test_delete_confirm_api_error_mounts_error() -> None:
+    """AC #7, #8: /delete confirm with API error mounts ErrorWidget."""
+    client = _mock_client()
+    client.delete_team.side_effect = ApiError(500, "delete failed")
+    app = _make_app(client=client)
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        chat_input = pilot.app.query_one(ChatInput)
+        chat_input.post_message(ChatInput.Submitted(text="/delete confirm t-123"))
+        await pilot.pause()
+        await pilot.pause()
+
+        errors = pilot.app.query(ErrorWidget)
+        found = any("deleting team" in e._content.lower() for e in errors)
+        assert found, "Expected ErrorWidget for delete failure"

--- a/tests/cli/test_tui_input.py
+++ b/tests/cli/test_tui_input.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import pytest
 
-from akgentic.infra.cli.commands import CommandRegistry, SlashCommand, build_default_registry
+from akgentic.infra.cli.commands import CommandRegistry
 from akgentic.infra.cli.connection import ConnectionState
 from akgentic.infra.cli.tui.app import ChatApp
 from akgentic.infra.cli.tui.messages import ConnectionStateChanged
@@ -340,6 +340,100 @@ async def test_no_palette_without_registry() -> None:
         await pilot.pause()
         await pilot.pause()
         assert len(pilot.app.query(CommandPalette)) == 0
+
+
+@pytest.mark.asyncio
+async def test_enter_selects_palette_command_and_submits() -> None:
+    """Enter with palette visible selects the highlighted command and submits it."""
+    registry = _make_small_registry()
+    app = _make_app(command_registry=registry)
+    async with app.run_test(size=(80, 24)) as pilot:
+        await pilot.pause()
+        await pilot.click(ChatInput)
+        await pilot.press("/")
+        await pilot.pause()
+        await pilot.pause()
+        # Palette should be visible
+        assert len(pilot.app.query(CommandPalette)) == 1
+        # Press enter to select + submit
+        await pilot.press("enter")
+        await pilot.pause()
+        chat_input = pilot.app.query_one(ChatInput)
+        # After enter: input is cleared (submitted) and palette dismissed
+        assert chat_input.text.strip() == ""
+        assert len(pilot.app.query(CommandPalette)) == 0
+        # The selected command should have been submitted to history
+        assert len(chat_input._history) == 1
+        assert chat_input._history[0].startswith("/")
+
+
+# ---------------------------------------------------------------------------
+# Unit tests for CommandPalette
+# ---------------------------------------------------------------------------
+
+
+def test_command_palette_render() -> None:
+    """CommandPalette.render() produces correct Rich Text output."""
+    registry = _make_small_registry()
+    palette = CommandPalette(registry.commands)
+    output = palette.render()
+    text_str = str(output)
+    assert "/help" in text_str
+    assert "/teams" in text_str
+    assert "/test" in text_str
+
+
+def test_command_palette_render_empty_filter() -> None:
+    """CommandPalette with no matches renders placeholder text."""
+    registry = _make_small_registry()
+    palette = CommandPalette(registry.commands)
+    palette.filter_text = "zzz_no_match"
+    output = palette.render()
+    assert "no matching commands" in str(output)
+
+
+def test_command_palette_selected_command_empty() -> None:
+    """selected_command returns None when no commands match."""
+    registry = _make_small_registry()
+    palette = CommandPalette(registry.commands)
+    palette.filter_text = "zzz_no_match"
+    assert palette.selected_command is None
+
+
+def test_command_palette_move_up_at_top() -> None:
+    """move_up at index 0 stays at 0."""
+    registry = _make_small_registry()
+    palette = CommandPalette(registry.commands)
+    assert palette._selected_idx == 0
+    palette.move_up()
+    assert palette._selected_idx == 0
+
+
+def test_command_palette_move_down_at_bottom() -> None:
+    """move_down at last index stays at last index."""
+    registry = _make_small_registry()
+    palette = CommandPalette(registry.commands)
+    # Move to the last item
+    for _ in range(len(palette._filtered)):
+        palette.move_down()
+    last_idx = len(palette._filtered) - 1
+    assert palette._selected_idx == last_idx
+    palette.move_down()
+    assert palette._selected_idx == last_idx
+
+
+def test_command_palette_filter_clamps_index() -> None:
+    """filter_text clamps selected_idx when filtered list shrinks."""
+    registry = _make_small_registry()
+    palette = CommandPalette(registry.commands)
+    # Move to idx 2 (3 commands: help, teams, test)
+    palette.move_down()
+    palette.move_down()
+    assert palette._selected_idx == 2
+    # Filter to only 1 match
+    palette.filter_text = "help"
+    assert palette._selected_idx == 0
+    assert palette.selected_command == "help"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/cli/test_tui_input.py
+++ b/tests/cli/test_tui_input.py
@@ -1,0 +1,397 @@
+"""Pilot tests for ChatInput: Enter/Shift+Enter, history, palette, border titles."""
+
+from __future__ import annotations
+
+import pytest
+
+from akgentic.infra.cli.commands import CommandRegistry, SlashCommand, build_default_registry
+from akgentic.infra.cli.connection import ConnectionState
+from akgentic.infra.cli.tui.app import ChatApp
+from akgentic.infra.cli.tui.messages import ConnectionStateChanged
+from akgentic.infra.cli.tui.widgets.chat_input import ChatInput
+from akgentic.infra.cli.tui.widgets.command_palette import CommandPalette
+
+
+def _make_app(
+    command_registry: CommandRegistry | None = None,
+) -> ChatApp:
+    """Create a ChatApp with optional command registry."""
+    return ChatApp(
+        team_name="test",
+        team_id="123",
+        team_status="running",
+        command_registry=command_registry,
+    )
+
+
+def _make_small_registry() -> CommandRegistry:
+    """Create a small registry for testing palette filtering."""
+    registry = CommandRegistry()
+
+    async def _noop(args: str, session: object) -> None:
+        pass
+
+    registry.register("help", _noop, "Show commands", "/help")
+    registry.register("teams", _noop, "List teams", "/teams")
+    registry.register("test", _noop, "Run test", "/test")
+    return registry
+
+
+# ---------------------------------------------------------------------------
+# Task 8: Enter / Shift+Enter tests (AC #1, #9)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_enter_submits_message() -> None:
+    """Enter key submits the typed text and clears input."""
+    app = _make_app()
+    async with app.run_test(size=(80, 24)) as pilot:
+        await pilot.pause()
+        chat_input = pilot.app.query_one(ChatInput)
+        await pilot.click(ChatInput)
+        await pilot.press("h", "e", "l", "l", "o")
+        await pilot.press("enter")
+        await pilot.pause()
+        assert chat_input.text.strip() == ""
+        assert len(chat_input._history) == 1
+        assert chat_input._history[0] == "hello"
+
+
+@pytest.mark.asyncio
+async def test_shift_enter_does_not_submit() -> None:
+    """Shift+Enter does not submit (newline insertion is TextArea default).
+
+    Note: TextArea.pilot doesn't reliably simulate shift+enter in all
+    backends, so we verify the negative: that our _on_key handler only
+    intercepts plain 'enter' and lets shift+enter pass through.
+    """
+    app = _make_app()
+    async with app.run_test(size=(80, 24)) as pilot:
+        await pilot.pause()
+        chat_input = pilot.app.query_one(ChatInput)
+        await pilot.click(ChatInput)
+        await pilot.press("h", "i")
+        await pilot.pause()
+        # Verify text is present but not submitted
+        assert chat_input.text == "hi"
+        assert len(chat_input._history) == 0
+
+
+@pytest.mark.asyncio
+async def test_empty_input_not_submitted() -> None:
+    """Enter on empty input does not submit."""
+    app = _make_app()
+    async with app.run_test(size=(80, 24)) as pilot:
+        await pilot.pause()
+        chat_input = pilot.app.query_one(ChatInput)
+        await pilot.click(ChatInput)
+        await pilot.press("enter")
+        await pilot.pause()
+        assert len(chat_input._history) == 0
+
+
+# ---------------------------------------------------------------------------
+# Task 9: Input history cycling (AC #2, #9)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_up_arrow_recalls_last_input() -> None:
+    """Up arrow recalls the last submitted input when current input is empty."""
+    app = _make_app()
+    async with app.run_test(size=(80, 24)) as pilot:
+        await pilot.pause()
+        chat_input = pilot.app.query_one(ChatInput)
+        await pilot.click(ChatInput)
+        # Submit a message
+        await pilot.press("h", "e", "l", "l", "o")
+        await pilot.press("enter")
+        await pilot.pause()
+        assert chat_input.text == ""
+        # Press up to recall
+        await pilot.press("up")
+        await pilot.pause()
+        assert chat_input.text == "hello"
+
+
+@pytest.mark.asyncio
+async def test_multiple_up_arrows_cycle_backwards() -> None:
+    """Multiple up arrows cycle backwards through history."""
+    app = _make_app()
+    async with app.run_test(size=(80, 24)) as pilot:
+        await pilot.pause()
+        chat_input = pilot.app.query_one(ChatInput)
+        await pilot.click(ChatInput)
+        # Submit messages
+        await pilot.press("f", "i", "r", "s", "t")
+        await pilot.press("enter")
+        await pilot.pause()
+        await pilot.press("s", "e", "c", "o", "n", "d")
+        await pilot.press("enter")
+        await pilot.pause()
+        await pilot.press("t", "h", "i", "r", "d")
+        await pilot.press("enter")
+        await pilot.pause()
+        # Up should go: third -> second -> first
+        await pilot.press("up")
+        await pilot.pause()
+        assert chat_input.text == "third"
+        await pilot.press("up")
+        await pilot.pause()
+        assert chat_input.text == "second"
+        await pilot.press("up")
+        await pilot.pause()
+        assert chat_input.text == "first"
+
+
+@pytest.mark.asyncio
+async def test_down_arrow_after_up_moves_forward() -> None:
+    """Down arrow after up arrow moves forward through history."""
+    app = _make_app()
+    async with app.run_test(size=(80, 24)) as pilot:
+        await pilot.pause()
+        chat_input = pilot.app.query_one(ChatInput)
+        await pilot.click(ChatInput)
+        await pilot.press("f", "i", "r", "s", "t")
+        await pilot.press("enter")
+        await pilot.pause()
+        await pilot.press("s", "e", "c", "o", "n", "d")
+        await pilot.press("enter")
+        await pilot.pause()
+        # Go back twice
+        await pilot.press("up")
+        await pilot.pause()
+        await pilot.press("up")
+        await pilot.pause()
+        assert chat_input.text == "first"
+        # Go forward
+        await pilot.press("down")
+        await pilot.pause()
+        assert chat_input.text == "second"
+
+
+@pytest.mark.asyncio
+async def test_down_past_end_restores_empty() -> None:
+    """Down arrow past end of history restores empty input."""
+    app = _make_app()
+    async with app.run_test(size=(80, 24)) as pilot:
+        await pilot.pause()
+        chat_input = pilot.app.query_one(ChatInput)
+        await pilot.click(ChatInput)
+        await pilot.press("m", "s", "g")
+        await pilot.press("enter")
+        await pilot.pause()
+        await pilot.press("up")
+        await pilot.pause()
+        assert chat_input.text == "msg"
+        await pilot.press("down")
+        await pilot.pause()
+        assert chat_input.text == ""
+
+
+@pytest.mark.asyncio
+async def test_up_arrow_does_nothing_when_empty_history() -> None:
+    """Up arrow does nothing when history is empty."""
+    app = _make_app()
+    async with app.run_test(size=(80, 24)) as pilot:
+        await pilot.pause()
+        chat_input = pilot.app.query_one(ChatInput)
+        await pilot.click(ChatInput)
+        await pilot.press("up")
+        await pilot.pause()
+        assert chat_input.text == ""
+
+
+# ---------------------------------------------------------------------------
+# Task 10: Command palette (AC #3, #4, #5, #6, #9)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_palette_appears_on_slash() -> None:
+    """CommandPalette appears when user types /."""
+    registry = _make_small_registry()
+    app = _make_app(command_registry=registry)
+    async with app.run_test(size=(80, 24)) as pilot:
+        await pilot.pause()
+        await pilot.click(ChatInput)
+        await pilot.press("/")
+        await pilot.pause()
+        await pilot.pause()
+        palette = pilot.app.query(CommandPalette)
+        assert len(palette) == 1
+
+
+@pytest.mark.asyncio
+async def test_palette_filters_as_user_types() -> None:
+    """Palette filters commands as user types more characters."""
+    registry = _make_small_registry()
+    app = _make_app(command_registry=registry)
+    async with app.run_test(size=(80, 24)) as pilot:
+        await pilot.pause()
+        await pilot.click(ChatInput)
+        await pilot.press("/", "t", "e")
+        await pilot.pause()
+        await pilot.pause()
+        palette_widgets = pilot.app.query(CommandPalette)
+        assert len(palette_widgets) == 1
+        palette = palette_widgets[0]
+        # "te" should match "teams" and "test" but not "help"
+        assert len(palette._filtered) == 2
+        names = [c.name for c in palette._filtered]
+        assert "teams" in names
+        assert "test" in names
+        assert "help" not in names
+
+
+@pytest.mark.asyncio
+async def test_tab_selects_highlighted_command() -> None:
+    """Tab selects the highlighted command and replaces input text."""
+    registry = _make_small_registry()
+    app = _make_app(command_registry=registry)
+    async with app.run_test(size=(80, 24)) as pilot:
+        await pilot.pause()
+        await pilot.click(ChatInput)
+        await pilot.press("/")
+        await pilot.pause()
+        await pilot.pause()
+        chat_input = pilot.app.query_one(ChatInput)
+        await pilot.press("tab")
+        await pilot.pause()
+        # Should have replaced input with /<first_command> (trailing space)
+        assert chat_input.text.startswith("/")
+        assert chat_input.text.endswith(" ")
+        # Palette should be dismissed
+        palette = pilot.app.query(CommandPalette)
+        assert len(palette) == 0
+
+
+@pytest.mark.asyncio
+async def test_esc_dismisses_palette() -> None:
+    """Esc dismisses palette without changing input."""
+    registry = _make_small_registry()
+    app = _make_app(command_registry=registry)
+    async with app.run_test(size=(80, 24)) as pilot:
+        await pilot.pause()
+        await pilot.click(ChatInput)
+        await pilot.press("/")
+        await pilot.pause()
+        await pilot.pause()
+        assert len(pilot.app.query(CommandPalette)) == 1
+        await pilot.press("escape")
+        await pilot.pause()
+        assert len(pilot.app.query(CommandPalette)) == 0
+        # Input should still have /
+        chat_input = pilot.app.query_one(ChatInput)
+        assert chat_input.text == "/"
+
+
+@pytest.mark.asyncio
+async def test_up_down_navigate_palette() -> None:
+    """Up/down arrows navigate palette items when visible."""
+    registry = _make_small_registry()
+    app = _make_app(command_registry=registry)
+    async with app.run_test(size=(80, 24)) as pilot:
+        await pilot.pause()
+        await pilot.click(ChatInput)
+        await pilot.press("/")
+        await pilot.pause()
+        await pilot.pause()
+        palette_widgets = pilot.app.query(CommandPalette)
+        assert len(palette_widgets) == 1
+        palette = palette_widgets[0]
+        initial_idx = palette._selected_idx
+        assert initial_idx == 0
+        await pilot.press("down")
+        await pilot.pause()
+        assert palette._selected_idx == 1
+        await pilot.press("up")
+        await pilot.pause()
+        assert palette._selected_idx == 0
+
+
+@pytest.mark.asyncio
+async def test_palette_disappears_on_backspace_past_slash() -> None:
+    """Palette disappears when / is deleted."""
+    registry = _make_small_registry()
+    app = _make_app(command_registry=registry)
+    async with app.run_test(size=(80, 24)) as pilot:
+        await pilot.pause()
+        await pilot.click(ChatInput)
+        await pilot.press("/")
+        await pilot.pause()
+        await pilot.pause()
+        assert len(pilot.app.query(CommandPalette)) == 1
+        await pilot.press("backspace")
+        await pilot.pause()
+        await pilot.pause()
+        assert len(pilot.app.query(CommandPalette)) == 0
+
+
+@pytest.mark.asyncio
+async def test_no_palette_without_registry() -> None:
+    """No palette appears when no registry is provided."""
+    app = _make_app()
+    async with app.run_test(size=(80, 24)) as pilot:
+        await pilot.pause()
+        await pilot.click(ChatInput)
+        await pilot.press("/")
+        await pilot.pause()
+        await pilot.pause()
+        assert len(pilot.app.query(CommandPalette)) == 0
+
+
+# ---------------------------------------------------------------------------
+# Task 11: Mode-aware border title (AC #7)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_default_border_title() -> None:
+    """Default border title is '> '."""
+    app = _make_app()
+    async with app.run_test(size=(80, 24)) as pilot:
+        await pilot.pause()
+        chat_input = pilot.app.query_one(ChatInput)
+        assert chat_input.border_title == "> "
+
+
+@pytest.mark.asyncio
+async def test_disconnected_mode_border_title() -> None:
+    """Disconnected mode shows correct border title."""
+    app = _make_app()
+    async with app.run_test(size=(80, 24)) as pilot:
+        await pilot.pause()
+        chat_input = pilot.app.query_one(ChatInput)
+        pilot.app.post_message(ConnectionStateChanged(ConnectionState.DISCONNECTED))
+        await pilot.pause()
+        assert chat_input.border_title == "\\[disconnected] > "
+
+
+@pytest.mark.asyncio
+async def test_reconnecting_mode_border_title() -> None:
+    """Reconnecting mode shows correct border title."""
+    app = _make_app()
+    async with app.run_test(size=(80, 24)) as pilot:
+        await pilot.pause()
+        chat_input = pilot.app.query_one(ChatInput)
+        pilot.app.post_message(ConnectionStateChanged(ConnectionState.RECONNECTING))
+        await pilot.pause()
+        assert chat_input.border_title == "\\[reconnecting...] > "
+
+
+@pytest.mark.asyncio
+async def test_connected_mode_restores_border_title() -> None:
+    """Connected mode restores default border title."""
+    app = _make_app()
+    async with app.run_test(size=(80, 24)) as pilot:
+        await pilot.pause()
+        chat_input = pilot.app.query_one(ChatInput)
+        pilot.app.post_message(ConnectionStateChanged(ConnectionState.DISCONNECTED))
+        await pilot.pause()
+        assert chat_input.border_title == "\\[disconnected] > "
+        pilot.app.post_message(ConnectionStateChanged(ConnectionState.CONNECTED))
+        await pilot.pause()
+        await pilot.pause()
+        assert chat_input.border_title == "> "

--- a/tests/cli/test_tui_streaming.py
+++ b/tests/cli/test_tui_streaming.py
@@ -1,0 +1,346 @@
+"""Pilot tests for WebSocket streaming worker, ThinkingIndicator, and connection state."""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from akgentic.infra.cli.connection import ConnectionState
+from akgentic.infra.cli.tui.app import ChatApp
+from akgentic.infra.cli.tui.messages import ConnectionStateChanged
+from akgentic.infra.cli.tui.widgets.agent_message import AgentMessage
+from akgentic.infra.cli.tui.widgets.chat_input import ChatInput
+from akgentic.infra.cli.tui.widgets.status_header import StatusHeader
+from akgentic.infra.cli.tui.widgets.system_message import SystemMessage
+from akgentic.infra.cli.tui.widgets.thinking import ThinkingIndicator
+from akgentic.infra.cli.ws_client import WsConnectionError
+
+
+def _make_app(
+    connection_manager: object | None = None,
+    event_router: object | None = None,
+) -> ChatApp:
+    """Create a ChatApp with optional mock dependencies."""
+    return ChatApp(
+        team_name="test",
+        team_id="123",
+        team_status="running",
+        connection_manager=connection_manager,  # type: ignore[arg-type]
+        event_router=event_router,  # type: ignore[arg-type]
+    )
+
+
+# ---------------------------------------------------------------------------
+# ThinkingIndicator tests (Task 12)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_thinking_indicator_renders() -> None:
+    """ThinkingIndicator renders spinner text."""
+    app = _make_app()
+    async with app.run_test(size=(80, 24)) as pilot:
+        await pilot.pause()
+        conv = pilot.app.query_one("#conversation")
+        indicator = ThinkingIndicator()
+        await conv.mount(indicator)
+        rendered = str(indicator.render())
+        assert "Agent is thinking" in rendered
+
+
+@pytest.mark.asyncio
+async def test_thinking_indicator_mounted_on_send() -> None:
+    """ThinkingIndicator is mounted when user sends a message."""
+    app = _make_app()
+    async with app.run_test(size=(80, 24)) as pilot:
+        await pilot.pause()
+        await pilot.click(ChatInput)
+        await pilot.press("h", "i")
+        await pilot.press("enter")
+        await pilot.pause()
+        indicators = pilot.app.query(ThinkingIndicator)
+        assert len(indicators) == 1
+
+
+@pytest.mark.asyncio
+async def test_no_thinking_indicator_on_slash_command() -> None:
+    """ThinkingIndicator is NOT mounted for slash commands."""
+    app = _make_app()
+    async with app.run_test(size=(80, 24)) as pilot:
+        await pilot.pause()
+        await pilot.click(ChatInput)
+        await pilot.press("/", "h", "e", "l", "p")
+        await pilot.press("enter")
+        await pilot.pause()
+        indicators = pilot.app.query(ThinkingIndicator)
+        assert len(indicators) == 0
+
+
+@pytest.mark.asyncio
+async def test_thinking_indicator_removed_on_response() -> None:
+    """ThinkingIndicator is removed when first response widget is mounted."""
+    import asyncio
+
+    # Use an event to delay the first receive_event until ThinkingIndicator is mounted
+    gate = asyncio.Event()
+
+    async def _receive_event_delayed() -> dict[str, Any]:
+        # Wait until the test signals that the user message was sent
+        await gate.wait()
+        gate.clear()
+        return {
+            "event": {
+                "__model__": "SentMessage",
+                "sender": "bot",
+                "message": {"content": "hi"},
+            }
+        }
+
+    call_count = 0
+
+    async def _receive_side_effect() -> dict[str, Any]:
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            return await _receive_event_delayed()
+        raise WsConnectionError("done", retryable=False)
+
+    mock_cm = MagicMock()
+    mock_cm._on_state_change = None
+    mock_cm.receive_event = AsyncMock(side_effect=_receive_side_effect)
+
+    mock_router = MagicMock()
+    agent_msg = AgentMessage(sender="bot", content="hi", color="cyan")
+    mock_router.to_widget = MagicMock(return_value=agent_msg)
+
+    app = _make_app(connection_manager=mock_cm, event_router=mock_router)
+    async with app.run_test(size=(80, 24)) as pilot:
+        await pilot.pause()
+        # Send a message to mount ThinkingIndicator
+        await pilot.click(ChatInput)
+        await pilot.press("h", "i")
+        await pilot.press("enter")
+        await pilot.pause()
+
+        # Verify ThinkingIndicator is present
+        indicators = pilot.app.query(ThinkingIndicator)
+        assert len(indicators) == 1
+
+        # Release the gate so the worker can process the event
+        gate.set()
+        await pilot.pause()
+        await pilot.pause()
+        await pilot.pause()
+
+        # ThinkingIndicator should be gone (removed by stream_events)
+        indicators = pilot.app.query(ThinkingIndicator)
+        assert len(indicators) == 0
+
+
+# ---------------------------------------------------------------------------
+# stream_events worker tests (Task 11)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_stream_events_mounts_widgets() -> None:
+    """stream_events worker mounts AgentMessage widgets."""
+    mock_cm = MagicMock()
+    mock_cm._on_state_change = None
+    mock_cm.receive_event = AsyncMock(
+        side_effect=[
+            {
+                "event": {
+                    "__model__": "SentMessage",
+                    "sender": "bot",
+                    "message": {"content": "hello"},
+                }
+            },
+            WsConnectionError("done", retryable=False),
+        ]
+    )
+
+    agent_msg = AgentMessage(sender="bot", content="hello", color="cyan")
+    mock_router = MagicMock()
+    mock_router.to_widget = MagicMock(return_value=agent_msg)
+
+    app = _make_app(connection_manager=mock_cm, event_router=mock_router)
+    async with app.run_test(size=(80, 24)) as pilot:
+        # Wait for worker to start and process
+        await pilot.pause()
+        await pilot.pause()
+        await pilot.pause()
+
+        # Verify AgentMessage was mounted
+        messages = pilot.app.query(AgentMessage)
+        assert len(messages) >= 1
+
+
+@pytest.mark.asyncio
+async def test_stream_events_exits_on_ws_error() -> None:
+    """Worker exits gracefully on WsConnectionError, mounts SystemMessage."""
+    mock_cm = MagicMock()
+    mock_cm._on_state_change = None
+    mock_cm.receive_event = AsyncMock(
+        side_effect=WsConnectionError("disconnected", retryable=False)
+    )
+
+    mock_router = MagicMock()
+    mock_router.to_widget = MagicMock(return_value=None)
+
+    app = _make_app(connection_manager=mock_cm, event_router=mock_router)
+    async with app.run_test(size=(80, 24)) as pilot:
+        await pilot.pause()
+        await pilot.pause()
+        await pilot.pause()
+
+        # SystemMessage "Connection lost" should be mounted
+        sys_msgs = pilot.app.query(SystemMessage)
+        found = any("Connection lost" in m._content for m in sys_msgs)
+        assert found, "Expected 'Connection lost' SystemMessage after WsConnectionError"
+
+
+@pytest.mark.asyncio
+async def test_stream_events_skips_none_widgets() -> None:
+    """Worker skips events where to_widget returns None."""
+    mock_cm = MagicMock()
+    mock_cm._on_state_change = None
+    mock_cm.receive_event = AsyncMock(
+        side_effect=[
+            {"event": {"__model__": "UnknownEvent"}},
+            WsConnectionError("done", retryable=False),
+        ]
+    )
+
+    mock_router = MagicMock()
+    mock_router.to_widget = MagicMock(return_value=None)
+
+    app = _make_app(connection_manager=mock_cm, event_router=mock_router)
+    async with app.run_test(size=(80, 24)) as pilot:
+        await pilot.pause()
+        await pilot.pause()
+        await pilot.pause()
+
+        # No AgentMessage should be mounted
+        messages = pilot.app.query(AgentMessage)
+        assert len(messages) == 0
+
+
+@pytest.mark.asyncio
+async def test_no_streaming_without_deps() -> None:
+    """stream_events returns immediately without connection_manager/event_router."""
+    app = _make_app()
+    async with app.run_test(size=(80, 24)) as pilot:
+        await pilot.pause()
+        # No crash, app runs fine without deps
+        assert pilot.app.query_one("#conversation") is not None
+
+
+# ---------------------------------------------------------------------------
+# Connection state propagation tests (Task 13)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_status_header_updates_on_disconnected() -> None:
+    """StatusHeader updates connection indicator on DISCONNECTED."""
+    app = _make_app()
+    async with app.run_test(size=(80, 24)) as pilot:
+        await pilot.pause()
+        header = pilot.app.query_one(StatusHeader)
+        pilot.app.post_message(ConnectionStateChanged(ConnectionState.DISCONNECTED))
+        await pilot.pause()
+        assert header._connection_state == "disconnected"
+
+
+@pytest.mark.asyncio
+async def test_status_header_updates_on_reconnecting() -> None:
+    """StatusHeader updates connection indicator on RECONNECTING."""
+    app = _make_app()
+    async with app.run_test(size=(80, 24)) as pilot:
+        await pilot.pause()
+        header = pilot.app.query_one(StatusHeader)
+        pilot.app.post_message(ConnectionStateChanged(ConnectionState.RECONNECTING))
+        await pilot.pause()
+        assert header._connection_state == "reconnecting"
+
+
+@pytest.mark.asyncio
+async def test_status_header_updates_on_connected() -> None:
+    """StatusHeader restores connected state."""
+    app = _make_app()
+    async with app.run_test(size=(80, 24)) as pilot:
+        await pilot.pause()
+        header = pilot.app.query_one(StatusHeader)
+        # Set to disconnected first
+        pilot.app.post_message(ConnectionStateChanged(ConnectionState.DISCONNECTED))
+        await pilot.pause()
+        assert header._connection_state == "disconnected"
+        # Restore to connected
+        pilot.app.post_message(ConnectionStateChanged(ConnectionState.CONNECTED))
+        await pilot.pause()
+        await pilot.pause()
+        assert header._connection_state == "connected"
+
+
+@pytest.mark.asyncio
+async def test_chat_input_updates_on_disconnected() -> None:
+    """ChatInput updates border_title on DISCONNECTED."""
+    app = _make_app()
+    async with app.run_test(size=(80, 24)) as pilot:
+        await pilot.pause()
+        chat_input = pilot.app.query_one(ChatInput)
+        pilot.app.post_message(ConnectionStateChanged(ConnectionState.DISCONNECTED))
+        await pilot.pause()
+        assert chat_input.border_title == "\\[disconnected] > "
+
+
+@pytest.mark.asyncio
+async def test_chat_input_updates_on_reconnecting() -> None:
+    """ChatInput updates border_title on RECONNECTING."""
+    app = _make_app()
+    async with app.run_test(size=(80, 24)) as pilot:
+        await pilot.pause()
+        chat_input = pilot.app.query_one(ChatInput)
+        pilot.app.post_message(ConnectionStateChanged(ConnectionState.RECONNECTING))
+        await pilot.pause()
+        assert chat_input.border_title == "\\[reconnecting...] > "
+
+
+@pytest.mark.asyncio
+async def test_chat_input_updates_on_connected() -> None:
+    """ChatInput restores default border_title on CONNECTED."""
+    app = _make_app()
+    async with app.run_test(size=(80, 24)) as pilot:
+        await pilot.pause()
+        chat_input = pilot.app.query_one(ChatInput)
+        # Set to disconnected first
+        pilot.app.post_message(ConnectionStateChanged(ConnectionState.DISCONNECTED))
+        await pilot.pause()
+        assert chat_input.border_title == "\\[disconnected] > "
+        # Restore to connected
+        pilot.app.post_message(ConnectionStateChanged(ConnectionState.CONNECTED))
+        await pilot.pause()
+        await pilot.pause()
+        assert chat_input.border_title == "> "
+
+
+@pytest.mark.asyncio
+async def test_welcome_removed_on_first_message() -> None:
+    """Welcome placeholder is removed when first message is sent."""
+    app = _make_app()
+    async with app.run_test(size=(80, 24)) as pilot:
+        await pilot.pause()
+        # Welcome should exist
+        welcome = pilot.app.query("#welcome")
+        assert len(welcome) == 1
+        # Send a message
+        await pilot.click(ChatInput)
+        await pilot.press("h", "i")
+        await pilot.press("enter")
+        await pilot.pause()
+        # Welcome should be removed
+        welcome = pilot.app.query("#welcome")
+        assert len(welcome) == 0

--- a/tests/cli/test_tui_team_select.py
+++ b/tests/cli/test_tui_team_select.py
@@ -161,8 +161,8 @@ async def test_c_name_creates_team() -> None:
 
 
 @pytest.mark.asyncio
-async def test_q_dismisses_with_none() -> None:
-    """Entering 'q' dismisses the screen with None."""
+async def test_q_dismisses_with_quit() -> None:
+    """Entering 'q' dismisses the screen with __quit__ signal."""
     client = _mock_client(running=1, stopped=0, catalog=0)
     dismissed_with: list[str | None] = []
 
@@ -180,7 +180,7 @@ async def test_q_dismisses_with_none() -> None:
         await pilot.pause()
         await pilot.pause()
         await _submit_input(app, "q", pilot)
-        assert None in dismissed_with
+        assert "__quit__" in dismissed_with
 
 
 @pytest.mark.asyncio

--- a/tests/cli/test_tui_team_select.py
+++ b/tests/cli/test_tui_team_select.py
@@ -1,0 +1,338 @@
+"""Pilot tests for TeamSelectScreen and ChatApp integration."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+from textual.widgets import Input
+
+from akgentic.infra.cli.client import ApiClient, CatalogTeamInfo, TeamInfo
+from akgentic.infra.cli.tui.app import ChatApp
+from akgentic.infra.cli.tui.screens.team_select import TeamSelectScreen
+
+
+def _make_team(
+    team_id: str, name: str, status: str = "running"
+) -> TeamInfo:
+    return TeamInfo(
+        team_id=team_id,
+        name=name,
+        status=status,
+        user_id="u1",
+        created_at="2026-01-01",
+        updated_at="2026-01-01",
+    )
+
+
+def _mock_client(
+    running: int = 3, stopped: int = 2, catalog: int = 2
+) -> MagicMock:
+    """Create a mock ApiClient with configurable team counts."""
+    client = MagicMock(spec=ApiClient)
+    teams = [
+        _make_team(f"run-{i}", f"team-{i}", "running")
+        for i in range(1, running + 1)
+    ] + [
+        _make_team(f"stop-{i}", f"stopped-{i}", "stopped")
+        for i in range(1, stopped + 1)
+    ]
+    client.list_teams.return_value = teams
+    client.list_catalog_teams.return_value = [
+        CatalogTeamInfo(id=f"cat-{i}", name=f"catalog-{i}", description=f"Desc {i}")
+        for i in range(1, catalog + 1)
+    ]
+    return client
+
+
+def _get_team_list_text(app: ChatApp) -> str:
+    """Extract all rendered text from the team-list container."""
+    children = app.screen.query_one("#team-list").children
+    return " ".join(str(c.render()) for c in children)
+
+
+async def _submit_input(app: ChatApp, text: str, pilot: object) -> None:
+    """Set input value and post a Submitted message."""
+    inp = app.screen.query_one("#team-input", Input)
+    inp.value = text
+    app.screen.post_message(Input.Submitted(inp, text))
+    await pilot.pause()  # type: ignore[union-attr]
+
+
+# -- Task 6: Basic rendering and selection tests --
+
+
+@pytest.mark.asyncio
+async def test_screen_renders_teams_and_catalog() -> None:
+    """Screen renders running teams, stopped teams, and catalog entries."""
+    client = _mock_client(running=2, stopped=1, catalog=1)
+
+    class TestApp(ChatApp):
+        def on_mount(self) -> None:
+            self.push_screen(TeamSelectScreen(client=client))
+
+    app = TestApp(team_name="t", team_id="pre-set", team_status="running")
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        await pilot.pause()
+
+        all_text = _get_team_list_text(app)
+        assert "team-1" in all_text
+        assert "team-2" in all_text
+        assert "stopped-1" in all_text
+        assert "Desc 1" in all_text
+
+
+@pytest.mark.asyncio
+async def test_number_input_selects_running_team() -> None:
+    """Entering a number selects the corresponding running team."""
+    client = _mock_client(running=3, stopped=0, catalog=0)
+    dismissed_with: list[str | None] = []
+
+    class TrackingScreen(TeamSelectScreen):
+        def dismiss(self, result: str | None = None) -> None:
+            dismissed_with.append(result)
+            return super().dismiss(result)
+
+    class TestApp(ChatApp):
+        def on_mount(self) -> None:
+            self.push_screen(TrackingScreen(client=client))
+
+    app = TestApp(team_name="t", team_id="pre-set", team_status="running")
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        await pilot.pause()
+        await _submit_input(app, "2", pilot)
+        assert "run-2" in dismissed_with
+
+
+@pytest.mark.asyncio
+async def test_s_number_restores_stopped_team() -> None:
+    """Entering s<N> restores the corresponding stopped team."""
+    client = _mock_client(running=0, stopped=3, catalog=0)
+    client.restore_team.return_value = _make_team("stop-1", "stopped-1", "running")
+    dismissed_with: list[str | None] = []
+
+    class TrackingScreen(TeamSelectScreen):
+        def dismiss(self, result: str | None = None) -> None:
+            dismissed_with.append(result)
+            return super().dismiss(result)
+
+    class TestApp(ChatApp):
+        def on_mount(self) -> None:
+            self.push_screen(TrackingScreen(client=client))
+
+    app = TestApp(team_name="t", team_id="pre-set", team_status="running")
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        await pilot.pause()
+        await _submit_input(app, "s1", pilot)
+        await pilot.pause()  # wait for worker
+        await pilot.pause()
+        client.restore_team.assert_called_once_with("stop-1")
+        assert "stop-1" in dismissed_with
+
+
+@pytest.mark.asyncio
+async def test_c_name_creates_team() -> None:
+    """Entering 'c <name>' creates a team from catalog."""
+    client = _mock_client(running=0, stopped=0, catalog=1)
+    client.create_team.return_value = _make_team("new-1", "new-team", "running")
+    dismissed_with: list[str | None] = []
+
+    class TrackingScreen(TeamSelectScreen):
+        def dismiss(self, result: str | None = None) -> None:
+            dismissed_with.append(result)
+            return super().dismiss(result)
+
+    class TestApp(ChatApp):
+        def on_mount(self) -> None:
+            self.push_screen(TrackingScreen(client=client))
+
+    app = TestApp(team_name="t", team_id="pre-set", team_status="running")
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        await pilot.pause()
+        await _submit_input(app, "c cat-1", pilot)
+        await pilot.pause()  # wait for worker
+        await pilot.pause()
+        client.create_team.assert_called_once_with("cat-1")
+        assert "new-1" in dismissed_with
+
+
+@pytest.mark.asyncio
+async def test_q_dismisses_with_none() -> None:
+    """Entering 'q' dismisses the screen with None."""
+    client = _mock_client(running=1, stopped=0, catalog=0)
+    dismissed_with: list[str | None] = []
+
+    class TrackingScreen(TeamSelectScreen):
+        def dismiss(self, result: str | None = None) -> None:
+            dismissed_with.append(result)
+            return super().dismiss(result)
+
+    class TestApp(ChatApp):
+        def on_mount(self) -> None:
+            self.push_screen(TrackingScreen(client=client))
+
+    app = TestApp(team_name="t", team_id="pre-set", team_status="running")
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        await pilot.pause()
+        await _submit_input(app, "q", pilot)
+        assert None in dismissed_with
+
+
+@pytest.mark.asyncio
+async def test_invalid_number_shows_error() -> None:
+    """Entering an out-of-range number shows an error message."""
+    client = _mock_client(running=2, stopped=0, catalog=0)
+
+    class TestApp(ChatApp):
+        def on_mount(self) -> None:
+            self.push_screen(TeamSelectScreen(client=client))
+
+    app = TestApp(team_name="t", team_id="pre-set", team_status="running")
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        await pilot.pause()
+        await _submit_input(app, "99", pilot)
+        all_text = _get_team_list_text(app)
+        assert "Invalid selection" in all_text
+
+
+# -- Task 7: Pagination tests --
+
+
+@pytest.mark.asyncio
+async def test_pagination_indicator_with_many_teams() -> None:
+    """More than 5 running teams shows pagination indicator."""
+    client = _mock_client(running=12, stopped=0, catalog=0)
+
+    class TestApp(ChatApp):
+        def on_mount(self) -> None:
+            self.push_screen(TeamSelectScreen(client=client))
+
+    app = TestApp(team_name="t", team_id="pre-set", team_status="running")
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        await pilot.pause()
+        all_text = _get_team_list_text(app)
+        assert "1-5 of 12" in all_text
+
+
+@pytest.mark.asyncio
+async def test_n_advances_page() -> None:
+    """Typing 'n' advances to the next page with correct numbering."""
+    client = _mock_client(running=8, stopped=0, catalog=0)
+
+    class TestApp(ChatApp):
+        def on_mount(self) -> None:
+            self.push_screen(TeamSelectScreen(client=client))
+
+    app = TestApp(team_name="t", team_id="pre-set", team_status="running")
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        await pilot.pause()
+        await _submit_input(app, "n", pilot)
+        all_text = _get_team_list_text(app)
+        assert "6-8 of 8" in all_text
+
+
+@pytest.mark.asyncio
+async def test_p_goes_back() -> None:
+    """Typing 'p' goes back to previous page."""
+    client = _mock_client(running=8, stopped=0, catalog=0)
+
+    class TestApp(ChatApp):
+        def on_mount(self) -> None:
+            self.push_screen(TeamSelectScreen(client=client))
+
+    app = TestApp(team_name="t", team_id="pre-set", team_status="running")
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        await pilot.pause()
+        await _submit_input(app, "n", pilot)
+        await _submit_input(app, "p", pilot)
+        all_text = _get_team_list_text(app)
+        assert "1-5 of 8" in all_text
+
+
+@pytest.mark.asyncio
+async def test_right_arrow_advances_page() -> None:
+    """Right arrow key advances page."""
+    client = _mock_client(running=8, stopped=0, catalog=0)
+
+    class TestApp(ChatApp):
+        def on_mount(self) -> None:
+            self.push_screen(TeamSelectScreen(client=client))
+
+    app = TestApp(team_name="t", team_id="pre-set", team_status="running")
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        await pilot.pause()
+        await pilot.press("right")
+        await pilot.pause()
+        all_text = _get_team_list_text(app)
+        assert "6-8 of 8" in all_text
+
+
+@pytest.mark.asyncio
+async def test_first_page_no_prev() -> None:
+    """First page does not go back further."""
+    client = _mock_client(running=8, stopped=0, catalog=0)
+
+    class TestApp(ChatApp):
+        def on_mount(self) -> None:
+            self.push_screen(TeamSelectScreen(client=client))
+
+    app = TestApp(team_name="t", team_id="pre-set", team_status="running")
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        await pilot.pause()
+        await _submit_input(app, "p", pilot)
+        all_text = _get_team_list_text(app)
+        assert "1-5 of 8" in all_text
+
+
+@pytest.mark.asyncio
+async def test_last_page_no_next() -> None:
+    """Last page does not advance further."""
+    client = _mock_client(running=3, stopped=0, catalog=0)
+
+    class TestApp(ChatApp):
+        def on_mount(self) -> None:
+            self.push_screen(TeamSelectScreen(client=client))
+
+    app = TestApp(team_name="t", team_id="pre-set", team_status="running")
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        await pilot.pause()
+        await _submit_input(app, "n", pilot)
+        all_text = _get_team_list_text(app)
+        assert "1-3 of 3" in all_text
+
+
+# -- Task 8: ChatApp integration tests --
+
+
+@pytest.mark.asyncio
+async def test_chatapp_no_team_pushes_select_screen() -> None:
+    """ChatApp with no team_id pushes TeamSelectScreen on mount."""
+    client = _mock_client(running=1, stopped=0, catalog=0)
+
+    app = ChatApp(client=client)
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        await pilot.pause()
+        await pilot.pause()
+        assert isinstance(app.screen, TeamSelectScreen)
+
+
+@pytest.mark.asyncio
+async def test_chatapp_with_team_skips_select_screen() -> None:
+    """ChatApp with pre-set team_id skips TeamSelectScreen."""
+    app = ChatApp(team_name="test", team_id="abc123", team_status="running")
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        assert not isinstance(app.screen, TeamSelectScreen)

--- a/tests/cli/test_tui_team_select.py
+++ b/tests/cli/test_tui_team_select.py
@@ -7,7 +7,7 @@ from unittest.mock import MagicMock
 import pytest
 from textual.widgets import Input
 
-from akgentic.infra.cli.client import ApiClient, CatalogTeamInfo, TeamInfo
+from akgentic.infra.cli.client import ApiClient, ApiError, CatalogTeamInfo, TeamInfo
 from akgentic.infra.cli.tui.app import ChatApp
 from akgentic.infra.cli.tui.screens.team_select import TeamSelectScreen
 
@@ -199,6 +199,25 @@ async def test_invalid_number_shows_error() -> None:
         await _submit_input(app, "99", pilot)
         all_text = _get_team_list_text(app)
         assert "Invalid selection" in all_text
+
+
+@pytest.mark.asyncio
+async def test_api_error_during_fetch_shows_empty() -> None:
+    """ApiError during data fetch renders empty sections gracefully."""
+    client = MagicMock(spec=ApiClient)
+    client.list_teams.side_effect = ApiError(500, "connection refused")
+    client.list_catalog_teams.side_effect = ApiError(500, "connection refused")
+
+    class TestApp(ChatApp):
+        def on_mount(self) -> None:
+            self.push_screen(TeamSelectScreen(client=client))
+
+    app = TestApp(team_name="t", team_id="pre-set", team_status="running")
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        await pilot.pause()
+        all_text = _get_team_list_text(app)
+        assert "(none)" in all_text
 
 
 # -- Task 7: Pagination tests --

--- a/tests/cli/test_tui_team_select.py
+++ b/tests/cli/test_tui_team_select.py
@@ -329,7 +329,7 @@ async def test_last_page_no_next() -> None:
         await pilot.pause()
         await _submit_input(app, "n", pilot)
         all_text = _get_team_list_text(app)
-        assert "1-3 of 3" in all_text
+        assert "Running teams (3):" in all_text
 
 
 # -- Task 8: ChatApp integration tests --

--- a/tests/cli/test_tui_widgets.py
+++ b/tests/cli/test_tui_widgets.py
@@ -136,7 +136,8 @@ async def test_tool_call_expanded_shows_input() -> None:
         tool = ToolCallWidget("calc", '{"x": 1}', "result: 42")
         await conv.mount(tool)
         tool.collapsed = False
-        rendered = _render_to_str(tool.render())
+        await pilot.pause()
+        rendered = _render_to_str(tool._build_expanded())
         assert "calc" in rendered
         assert "result: 42" in rendered
 
@@ -150,7 +151,8 @@ async def test_tool_call_invalid_json_input() -> None:
         tool = ToolCallWidget("run", "not json", None)
         await conv.mount(tool)
         tool.collapsed = False
-        rendered = _render_to_str(tool.render())
+        await pilot.pause()
+        rendered = _render_to_str(tool._build_expanded())
         assert "not json" in rendered
 
 

--- a/tests/cli/test_tui_widgets.py
+++ b/tests/cli/test_tui_widgets.py
@@ -1,0 +1,217 @@
+"""Pilot tests for conversation widgets and AgentColorRegistry."""
+
+from __future__ import annotations
+
+import io
+
+import pytest
+from rich.console import Console
+
+from akgentic.infra.cli.tui.app import ChatApp
+from akgentic.infra.cli.tui.colors import AgentColorRegistry
+from akgentic.infra.cli.tui.widgets.agent_message import AgentMessage
+from akgentic.infra.cli.tui.widgets.error import ErrorWidget
+from akgentic.infra.cli.tui.widgets.human_input import HumanInputPrompt
+from akgentic.infra.cli.tui.widgets.system_message import HistorySeparator, SystemMessage
+from akgentic.infra.cli.tui.widgets.tool_call import ToolCallWidget
+from akgentic.infra.cli.tui.widgets.user_message import UserMessage
+
+
+def _render_to_str(renderable: object) -> str:
+    """Render a Rich renderable to plain text via Console."""
+    buf = io.StringIO()
+    console = Console(file=buf, force_terminal=True, width=120, no_color=True)
+    console.print(renderable)
+    return buf.getvalue()
+
+
+# ---------------------------------------------------------------------------
+# AgentColorRegistry tests (no TUI needed)
+# ---------------------------------------------------------------------------
+
+
+class TestAgentColorRegistry:
+    def test_assigns_first_color(self) -> None:
+        reg = AgentColorRegistry()
+        assert reg.get("Alice") == "cyan"
+
+    def test_round_robin_assignment(self) -> None:
+        reg = AgentColorRegistry()
+        expected = AgentColorRegistry._PALETTE
+        for i, name in enumerate(["a", "b", "c", "d", "e", "f"]):
+            assert reg.get(name) == expected[i]
+
+    def test_consistent_color_for_same_agent(self) -> None:
+        reg = AgentColorRegistry()
+        first = reg.get("Agent1")
+        second = reg.get("Agent1")
+        assert first == second
+
+    def test_wraps_around_palette(self) -> None:
+        reg = AgentColorRegistry()
+        for i in range(6):
+            reg.get(f"agent-{i}")
+        # 7th agent wraps to first color
+        assert reg.get("agent-6") == "cyan"
+
+    def test_reset_clears_state(self) -> None:
+        reg = AgentColorRegistry()
+        reg.get("Alpha")
+        reg.get("Beta")
+        reg.reset()
+        assert reg.get("Gamma") == "cyan"
+
+    def test_palette_matches_rich_renderer(self) -> None:
+        assert AgentColorRegistry._PALETTE == [
+            "cyan", "green", "magenta", "yellow", "blue", "red"
+        ]
+
+
+# ---------------------------------------------------------------------------
+# Widget pilot tests
+# ---------------------------------------------------------------------------
+
+
+def _make_app() -> ChatApp:
+    return ChatApp(team_name="test", team_id="123", team_status="running")
+
+
+@pytest.mark.asyncio
+async def test_agent_message_renders_sender_and_content() -> None:
+    app = _make_app()
+    async with app.run_test(size=(80, 24)) as pilot:
+        await pilot.pause()
+        conv = pilot.app.query_one("#conversation")
+        msg = AgentMessage(sender="Manager", content="Hello world", color="cyan")
+        await conv.mount(msg)
+        rendered = _render_to_str(msg.render())
+        assert "Manager" in rendered
+        assert "Hello world" in rendered
+
+
+@pytest.mark.asyncio
+async def test_agent_message_sender_format() -> None:
+    app = _make_app()
+    async with app.run_test(size=(80, 24)) as pilot:
+        await pilot.pause()
+        conv = pilot.app.query_one("#conversation")
+        msg = AgentMessage(sender="Analyst", content="data ready", color="green")
+        await conv.mount(msg)
+        rendered = _render_to_str(msg.render())
+        assert "[@Analyst]" in rendered
+
+
+@pytest.mark.asyncio
+async def test_tool_call_collapsed_shows_name() -> None:
+    app = _make_app()
+    async with app.run_test(size=(80, 24)) as pilot:
+        await pilot.pause()
+        conv = pilot.app.query_one("#conversation")
+        tool = ToolCallWidget("search", '{"query": "test"}', None)
+        await conv.mount(tool)
+        rendered = _render_to_str(tool.render())
+        assert "search" in rendered
+        assert "Tool:" in rendered
+
+
+@pytest.mark.asyncio
+async def test_tool_call_expand_on_click() -> None:
+    app = _make_app()
+    async with app.run_test(size=(80, 24)) as pilot:
+        await pilot.pause()
+        conv = pilot.app.query_one("#conversation")
+        tool = ToolCallWidget("search", '{"query": "test"}', None)
+        await conv.mount(tool)
+        assert tool.collapsed is True
+        tool.on_click()
+        assert tool.collapsed is False
+
+
+@pytest.mark.asyncio
+async def test_tool_call_expanded_shows_input() -> None:
+    app = _make_app()
+    async with app.run_test(size=(80, 24)) as pilot:
+        await pilot.pause()
+        conv = pilot.app.query_one("#conversation")
+        tool = ToolCallWidget("calc", '{"x": 1}', "result: 42")
+        await conv.mount(tool)
+        tool.collapsed = False
+        rendered = _render_to_str(tool.render())
+        assert "calc" in rendered
+        assert "result: 42" in rendered
+
+
+@pytest.mark.asyncio
+async def test_tool_call_invalid_json_input() -> None:
+    app = _make_app()
+    async with app.run_test(size=(80, 24)) as pilot:
+        await pilot.pause()
+        conv = pilot.app.query_one("#conversation")
+        tool = ToolCallWidget("run", "not json", None)
+        await conv.mount(tool)
+        tool.collapsed = False
+        rendered = _render_to_str(tool.render())
+        assert "not json" in rendered
+
+
+@pytest.mark.asyncio
+async def test_human_input_prompt_renders() -> None:
+    app = _make_app()
+    async with app.run_test(size=(80, 24)) as pilot:
+        await pilot.pause()
+        conv = pilot.app.query_one("#conversation")
+        prompt = HumanInputPrompt(prompt_text="Enter your name")
+        await conv.mount(prompt)
+        rendered = _render_to_str(prompt.render())
+        assert "Enter your name" in rendered
+        assert "Human Input Required" in rendered
+
+
+@pytest.mark.asyncio
+async def test_user_message_renders() -> None:
+    app = _make_app()
+    async with app.run_test(size=(80, 24)) as pilot:
+        await pilot.pause()
+        conv = pilot.app.query_one("#conversation")
+        msg = UserMessage(content="Hi there")
+        await conv.mount(msg)
+        rendered = _render_to_str(msg.render())
+        assert "[You]" in rendered
+        assert "Hi there" in rendered
+
+
+@pytest.mark.asyncio
+async def test_error_widget_renders() -> None:
+    app = _make_app()
+    async with app.run_test(size=(80, 24)) as pilot:
+        await pilot.pause()
+        conv = pilot.app.query_one("#conversation")
+        err = ErrorWidget(content="Something failed")
+        await conv.mount(err)
+        rendered = _render_to_str(err.render())
+        assert "error" in rendered
+        assert "Something failed" in rendered
+
+
+@pytest.mark.asyncio
+async def test_system_message_renders() -> None:
+    app = _make_app()
+    async with app.run_test(size=(80, 24)) as pilot:
+        await pilot.pause()
+        conv = pilot.app.query_one("#conversation")
+        sys_msg = SystemMessage(content="Connected to team")
+        await conv.mount(sys_msg)
+        rendered = _render_to_str(sys_msg.render())
+        assert "Connected to team" in rendered
+
+
+@pytest.mark.asyncio
+async def test_history_separator_renders() -> None:
+    app = _make_app()
+    async with app.run_test(size=(80, 24)) as pilot:
+        await pilot.pause()
+        conv = pilot.app.query_one("#conversation")
+        sep = HistorySeparator()
+        await conv.mount(sep)
+        rendered = _render_to_str(sep.render())
+        assert "history" in rendered

--- a/tests/server/models/test_server_settings.py
+++ b/tests/server/models/test_server_settings.py
@@ -6,6 +6,8 @@ import os
 import warnings
 from pathlib import Path
 
+import pytest
+
 from akgentic.infra.server.settings import CommunitySettings, ServerSettings
 
 
@@ -66,8 +68,9 @@ class TestServerSettingsEnvOverride:
 class TestServerSettingsLogLevel:
     """ServerSettings log_level field — validation and env override."""
 
-    def test_default_log_level(self) -> None:
+    def test_default_log_level(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Default log_level is INFO."""
+        monkeypatch.delenv("AKGENTIC_LOG_LEVEL", raising=False)
         settings = ServerSettings()
         assert settings.log_level == "INFO"
 
@@ -259,8 +262,9 @@ class TestCommunitySettingsDefaults:
         settings = CommunitySettings()
         assert settings.event_store_path == Path("data/event_store")
 
-    def test_default_catalog_path(self) -> None:
+    def test_default_catalog_path(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Default catalog_path is Path('data/catalog')."""
+        monkeypatch.delenv("AKGENTIC_CATALOG_PATH", raising=False)
         settings = CommunitySettings()
         assert settings.catalog_path == Path("data/catalog")
 


### PR DESCRIPTION
## Summary

- Wire all existing `CommandRegistry` handlers into TUI via `TuiCommandAdapter` with `redirect_stdout` capture
- TUI-specific overrides for `/switch`, `/reconnect`, `/quit`, `/delete`, `/create`, `/stop`, `/restore`, `/history`
- Non-slash messages sent via `ApiClient.send_message()` in `@work(thread=True)` worker
- `/delete` uses two-step confirmation flow (`/delete <id>` → `/delete confirm <id>`)
- `/history` renders events as TUI widgets via `EventRouter.to_widget()`

## Test plan

- 28 pilot tests covering all slash commands, error paths, and message sending
- Full suite: 963 passed, 0 failed, 30 skipped
- Coverage: 90.15% (meets 90% threshold)
- Ruff and mypy clean

Closes #149