### PR TITLE
feat: dual-format WS events for V1 adapter CLI compatibility

### DIFF
--- a/src/akgentic/infra/server/routes/frontend_adapter/angular_v1/ws.py
+++ b/src/akgentic/infra/server/routes/frontend_adapter/angular_v1/ws.py
@@ -180,8 +180,19 @@ def _build_error_envelope(event: ErrorMessage, timestamp: str) -> ErrorPayload:
     )
 
 
+class _DualFormatWsEvent(WrappedWsEvent):
+    """Extended envelope carrying both V1 payload and raw V2 event.
+
+    Angular V1 frontend reads ``payload`` (V1 format).
+    V2 clients (CLI) read ``event`` (raw V2 format with ``__model__``).
+    Subclasses ``WrappedWsEvent`` so it satisfies the ``FrontendAdapter`` protocol.
+    """
+
+    event: dict[str, Any] = {}
+
+
 def wrap_event(event: PersistedEvent) -> WrappedWsEvent:
-    """Translate a V2 persisted event into a V1 WebSocket envelope.
+    """Translate a V2 persisted event into a dual-format WebSocket envelope.
 
     This is the main entry point called by ``AngularV1Adapter.wrap_ws_event``.
 
@@ -189,7 +200,8 @@ def wrap_event(event: PersistedEvent) -> WrappedWsEvent:
         event: The V2 persisted event to translate.
 
     Returns:
-        A ``WrappedWsEvent`` containing the V1-formatted payload.
+        A ``_DualFormatWsEvent`` containing both V1 payload (for Angular)
+        and raw V2 event data (for CLI and other V2 clients).
     """
     msg = event.event
     timestamp = event.timestamp.isoformat()
@@ -207,4 +219,5 @@ def wrap_event(event: PersistedEvent) -> WrappedWsEvent:
     else:
         payload = _build_message_envelope(msg, timestamp)
 
-    return WrappedWsEvent(payload=payload)
+    raw_v2 = msg.model_dump(mode="json")
+    return _DualFormatWsEvent(payload=payload, event=raw_v2)

--- a/tests/frontend_adapter/test_angular_v1_ws.py
+++ b/tests/frontend_adapter/test_angular_v1_ws.py
@@ -4,11 +4,9 @@ from __future__ import annotations
 
 import uuid
 from datetime import UTC, datetime
-from unittest.mock import MagicMock
-
 import pydantic
 import pytest
-from akgentic.core.actor_address import ActorAddress
+from akgentic.core.actor_address_impl import ActorAddressProxy
 from akgentic.core.agent_config import BaseConfig
 from akgentic.core.agent_state import BaseState
 from akgentic.core.messages.message import Message, ResultMessage, UserMessage
@@ -44,11 +42,18 @@ _NOW = datetime(2026, 3, 28, 12, 0, 0, tzinfo=UTC)
 _TEAM_ID = uuid.UUID("00000000-0000-0000-0000-000000000001")
 
 
-def _make_sender(name: str = "@Agent") -> MagicMock:
-    """Create a mock ActorAddress with a name attribute."""
-    sender = MagicMock(spec=ActorAddress)
-    sender.name = name
-    return sender
+def _make_sender(name: str = "@Agent") -> ActorAddressProxy:
+    """Create a serializable ActorAddress with a name attribute."""
+    return ActorAddressProxy({
+        "__actor_address__": "",
+        "agent_id": str(uuid.uuid4()),
+        "name": name,
+        "role": "Agent",
+        "address": "",
+        "team_id": "",
+        "squad_id": "",
+        "user_message": "",
+    })
 
 
 def _make_persisted_event(


### PR DESCRIPTION
## Summary
- V1 adapter now returns both V1 payload and raw V2 event data in WebSocket events
- CLI works correctly when V1 frontend adapter is configured
- No changes to core WS route or Angular frontend required

## Changes
- `angular_v1/ws.py`: Add `_DualFormatWsEvent` subclass with raw V2 `event` field
- `test_angular_v1_ws.py`: Replace `MagicMock` with serializable `ActorAddressProxy`