### PR TITLE
feat: auto-restore running teams on server startup

### DIFF
--- a/src/akgentic/infra/adapters/community/local_runtime_cache.py
+++ b/src/akgentic/infra/adapters/community/local_runtime_cache.py
@@ -4,8 +4,13 @@ from __future__ import annotations
 
 import logging
 import uuid
+from typing import TYPE_CHECKING
 
 from akgentic.infra.protocols.team_handle import TeamHandle
+
+if TYPE_CHECKING:
+    from akgentic.infra.adapters.community.local_worker_handle import LocalWorkerHandle
+    from akgentic.team.repositories.yaml import YamlEventStore
 
 logger = logging.getLogger(__name__)
 
@@ -18,6 +23,9 @@ class LocalRuntimeCache:
     be pre-populated from disk: if it were, stopped teams would appear as
     ghost handles (stale ``TeamHandle`` proxies that point to dead actors).
     Teams are added only after successful creation or resumption.
+
+    Call ``warm()`` after construction to auto-restore teams that were
+    running before a server restart (community tier only).
     """
 
     def __init__(self) -> None:
@@ -36,3 +44,38 @@ class LocalRuntimeCache:
         """Remove a team handle from the cache (no-op if absent)."""
         logger.debug("Cache remove: team_id=%s", team_id)
         self._handles.pop(team_id, None)
+
+    def warm(
+        self,
+        worker_handle: LocalWorkerHandle,
+        event_store: YamlEventStore,
+    ) -> None:
+        """Auto-restore teams that were running before a server restart.
+
+        Community tier only: runtimes are in-process and lost on restart.
+        For each team marked RUNNING in the event store, stop it first
+        (RUNNING → STOPPED) then resume (STOPPED → RUNNING) to create
+        live actors and store the handle in the cache.
+
+        Failures are logged and skipped — one broken team must not block
+        server startup.
+        """
+        from akgentic.team.models import TeamStatus
+
+        all_teams = event_store.list_teams()
+        running = [t for t in all_teams if t.status == TeamStatus.RUNNING]
+        if not running:
+            return
+        logger.info("Warming cache: restoring %d running team(s)", len(running))
+        for process in running:
+            try:
+                worker_handle.stop_team(process.team_id)
+                handle = worker_handle.resume_team(process.team_id)
+                self.store(process.team_id, handle)
+                logger.info("Restored team: %s", process.team_id)
+            except Exception:  # noqa: BLE001
+                logger.warning(
+                    "Failed to restore team %s, skipping",
+                    process.team_id,
+                    exc_info=True,
+                )

--- a/src/akgentic/infra/wiring.py
+++ b/src/akgentic/infra/wiring.py
@@ -61,13 +61,16 @@ def wire_community(settings: CommunitySettings) -> CommunityServices:
         type(local_placement).__name__,
         type(local_worker_handle).__name__,
     )
+    runtime_cache = LocalRuntimeCache()
+    runtime_cache.warm(local_worker_handle, event_store)
+
     return CommunityServices(
         placement=local_placement,
         worker_handle=local_worker_handle,
         service_registry=service_registry,
         auth=NoAuth(),
         event_store=event_store,
-        runtime_cache=LocalRuntimeCache(),
+        runtime_cache=runtime_cache,
         ingestion=LocalIngestion(),
         channel_registry=(
             YamlChannelRegistry(registry_path=settings.channel_registry_path)

--- a/tests/adapters/community/test_local_runtime_cache.py
+++ b/tests/adapters/community/test_local_runtime_cache.py
@@ -7,6 +7,7 @@ from unittest.mock import MagicMock
 
 from akgentic.infra.adapters.community.local_runtime_cache import LocalRuntimeCache
 from akgentic.infra.protocols.runtime_cache import RuntimeCache
+from akgentic.team.models import Process, TeamStatus
 
 
 class TestLocalRuntimeCacheProtocolConformance:
@@ -78,3 +79,85 @@ class TestLocalRuntimeCacheStoreCycle:
         cache.remove(id1)
         assert cache.get(id1) is None
         assert cache.get(id2) is h2
+
+
+def _make_process(
+    team_id: uuid.UUID, status: TeamStatus = TeamStatus.RUNNING
+) -> Process:
+    """Create a minimal Process fixture using model_construct to skip validation."""
+    from datetime import UTC, datetime
+
+    return Process.model_construct(
+        team_id=team_id,
+        team_card=MagicMock(),
+        status=status,
+        user_id="u1",
+        user_email="",
+        created_at=datetime.now(tz=UTC),
+        updated_at=datetime.now(tz=UTC),
+    )
+
+
+class TestLocalRuntimeCacheWarm:
+    """warm() auto-restores running teams on startup."""
+
+    def test_warm_restores_running_teams(self) -> None:
+        """Running teams are stopped then resumed, handle stored in cache."""
+        cache = LocalRuntimeCache()
+        team_id = uuid.uuid4()
+        handle = MagicMock()
+
+        worker = MagicMock()
+        worker.resume_team.return_value = handle
+
+        event_store = MagicMock()
+        event_store.list_teams.return_value = [_make_process(team_id, TeamStatus.RUNNING)]
+
+        cache.warm(worker, event_store)
+
+        worker.stop_team.assert_called_once_with(team_id)
+        worker.resume_team.assert_called_once_with(team_id)
+        assert cache.get(team_id) is handle
+
+    def test_warm_skips_stopped_teams(self) -> None:
+        """Stopped teams are not restored."""
+        cache = LocalRuntimeCache()
+        team_id = uuid.uuid4()
+
+        worker = MagicMock()
+        event_store = MagicMock()
+        event_store.list_teams.return_value = [_make_process(team_id, TeamStatus.STOPPED)]
+
+        cache.warm(worker, event_store)
+
+        worker.stop_team.assert_not_called()
+        worker.resume_team.assert_not_called()
+        assert cache.get(team_id) is None
+
+    def test_warm_skips_on_failure(self) -> None:
+        """Failed restores are skipped, cache stays empty for that team."""
+        cache = LocalRuntimeCache()
+        team_id = uuid.uuid4()
+
+        worker = MagicMock()
+        worker.resume_team.side_effect = ValueError("broken")
+
+        event_store = MagicMock()
+        event_store.list_teams.return_value = [_make_process(team_id, TeamStatus.RUNNING)]
+
+        cache.warm(worker, event_store)  # should not raise
+
+        assert cache.get(team_id) is None
+
+    def test_warm_no_running_teams(self) -> None:
+        """No running teams → no calls to worker."""
+        cache = LocalRuntimeCache()
+
+        worker = MagicMock()
+        event_store = MagicMock()
+        event_store.list_teams.return_value = []
+
+        cache.warm(worker, event_store)
+
+        worker.stop_team.assert_not_called()
+        worker.resume_team.assert_not_called()


### PR DESCRIPTION
## Summary
- `LocalRuntimeCache.warm()` restores teams that were running before a server restart
- Called from `wire_community()` during startup — community-tier only
- Stops each stale team (RUNNING → STOPPED) then resumes (STOPPED → RUNNING) to create live actors
- Failures logged and skipped — one broken team does not block startup

## Changes
- `adapters/community/local_runtime_cache.py`: add `warm()` method
- `wiring.py`: call `warm()` after constructing services
- `tests/adapters/community/test_local_runtime_cache.py`: 4 new tests for warm()