### PR TITLE
feat: add send-to-agent V2 endpoint and fix V1 abstraction leak

### DIFF
--- a/src/akgentic/infra/cli/client.py
+++ b/src/akgentic/infra/cli/client.py
@@ -193,6 +193,12 @@ class ApiClient:
         """POST /teams/{team_id}/message."""
         self._request("POST", f"/teams/{team_id}/message", json={"content": content})
 
+    def send_message_to(self, team_id: str, agent_name: str, content: str) -> None:
+        """POST /teams/{team_id}/message/{agent_name}."""
+        self._request(
+            "POST", f"/teams/{team_id}/message/{agent_name}", json={"content": content}
+        )
+
     def human_input(self, team_id: str, content: str, message_id: str) -> None:
         """POST /teams/{team_id}/human-input."""
         self._request(

--- a/src/akgentic/infra/cli/client.py
+++ b/src/akgentic/infra/cli/client.py
@@ -193,12 +193,6 @@ class ApiClient:
         """POST /teams/{team_id}/message."""
         self._request("POST", f"/teams/{team_id}/message", json={"content": content})
 
-    def send_message_to(self, team_id: str, agent_name: str, content: str) -> None:
-        """POST /teams/{team_id}/message/{agent_name}."""
-        self._request(
-            "POST", f"/teams/{team_id}/message/{agent_name}", json={"content": content}
-        )
-
     def human_input(self, team_id: str, content: str, message_id: str) -> None:
         """POST /teams/{team_id}/human-input."""
         self._request(

--- a/src/akgentic/infra/cli/repl.py
+++ b/src/akgentic/infra/cli/repl.py
@@ -213,24 +213,27 @@ class ChatSession:
                 continue
 
             # Send message via REST API (run in executor to avoid blocking)
-            # @mention routing: "@Agent hello" sends directly to that agent
             try:
-                s = line.strip()
-                if s.startswith("@") and " " in s:
-                    parts = s.split(None, 1)
-                    await loop.run_in_executor(
-                        None,
-                        self.client.send_message_to,
-                        self._state.team_id,
-                        parts[0],
-                        parts[1],
-                    )
-                else:
-                    await loop.run_in_executor(
-                        None, self.client.send_message, self._state.team_id, line
-                    )
+                await self._send_or_mention(loop, line)
             except ApiError:
                 self.renderer.render_error("Error sending message.")
+
+    async def _send_or_mention(self, loop: asyncio.AbstractEventLoop, line: str) -> None:
+        """Send a message, routing @mentions to a specific agent."""
+        s = line.strip()
+        if s.startswith("@") and " " in s:
+            parts = s.split(None, 1)
+            await loop.run_in_executor(
+                None,
+                self.client.send_message_to,
+                self._state.team_id,
+                parts[0],
+                parts[1],
+            )
+        else:
+            await loop.run_in_executor(
+                None, self.client.send_message, self._state.team_id, line
+            )
 
     async def _receive_loop(self) -> None:
         """Background coroutine: read WebSocket events and render them."""

--- a/src/akgentic/infra/cli/repl.py
+++ b/src/akgentic/infra/cli/repl.py
@@ -213,10 +213,22 @@ class ChatSession:
                 continue
 
             # Send message via REST API (run in executor to avoid blocking)
+            # @mention routing: "@Agent hello" sends directly to that agent
             try:
-                await loop.run_in_executor(
-                    None, self.client.send_message, self._state.team_id, line
-                )
+                s = line.strip()
+                if s.startswith("@") and " " in s:
+                    parts = s.split(None, 1)
+                    await loop.run_in_executor(
+                        None,
+                        self.client.send_message_to,
+                        self._state.team_id,
+                        parts[0],
+                        parts[1],
+                    )
+                else:
+                    await loop.run_in_executor(
+                        None, self.client.send_message, self._state.team_id, line
+                    )
             except ApiError:
                 self.renderer.render_error("Error sending message.")
 

--- a/src/akgentic/infra/cli/repl.py
+++ b/src/akgentic/infra/cli/repl.py
@@ -139,22 +139,6 @@ class ChatSession:
             return f"Reply to {self._state.reply_context.agent_name}: "
         return "> "
 
-    @staticmethod
-    def _parse_mention(line: str) -> tuple[str | None, str]:
-        """Parse an @mention prefix from user input.
-
-        Returns (agent_name, content) if line starts with @AgentName,
-        otherwise (None, original_line).
-        """
-        stripped = line.strip()
-        if stripped.startswith("@"):
-            parts = stripped.split(None, 1)
-            agent_name = parts[0]
-            content = parts[1] if len(parts) > 1 else ""
-            if content:
-                return agent_name, content
-        return None, line
-
     def _read_input(self) -> str:
         """Render bottom border, prompt for input, then status bar below."""
         self.renderer.render_border()
@@ -228,23 +212,11 @@ class ChatSession:
             if self._check_connection_gate(line):
                 continue
 
-            # Parse @mention for directed messaging
-            agent_name, content = self._parse_mention(line)
-
             # Send message via REST API (run in executor to avoid blocking)
             try:
-                if agent_name:
-                    await loop.run_in_executor(
-                        None,
-                        self.client.send_message_to,
-                        self._state.team_id,
-                        agent_name,
-                        content,
-                    )
-                else:
-                    await loop.run_in_executor(
-                        None, self.client.send_message, self._state.team_id, line
-                    )
+                await loop.run_in_executor(
+                    None, self.client.send_message, self._state.team_id, line
+                )
             except ApiError:
                 self.renderer.render_error("Error sending message.")
 

--- a/src/akgentic/infra/cli/repl.py
+++ b/src/akgentic/infra/cli/repl.py
@@ -139,6 +139,22 @@ class ChatSession:
             return f"Reply to {self._state.reply_context.agent_name}: "
         return "> "
 
+    @staticmethod
+    def _parse_mention(line: str) -> tuple[str | None, str]:
+        """Parse an @mention prefix from user input.
+
+        Returns (agent_name, content) if line starts with @AgentName,
+        otherwise (None, original_line).
+        """
+        stripped = line.strip()
+        if stripped.startswith("@"):
+            parts = stripped.split(None, 1)
+            agent_name = parts[0]
+            content = parts[1] if len(parts) > 1 else ""
+            if content:
+                return agent_name, content
+        return None, line
+
     def _read_input(self) -> str:
         """Render bottom border, prompt for input, then status bar below."""
         self.renderer.render_border()
@@ -212,11 +228,23 @@ class ChatSession:
             if self._check_connection_gate(line):
                 continue
 
+            # Parse @mention for directed messaging
+            agent_name, content = self._parse_mention(line)
+
             # Send message via REST API (run in executor to avoid blocking)
             try:
-                await loop.run_in_executor(
-                    None, self.client.send_message, self._state.team_id, line
-                )
+                if agent_name:
+                    await loop.run_in_executor(
+                        None,
+                        self.client.send_message_to,
+                        self._state.team_id,
+                        agent_name,
+                        content,
+                    )
+                else:
+                    await loop.run_in_executor(
+                        None, self.client.send_message, self._state.team_id, line
+                    )
             except ApiError:
                 self.renderer.render_error("Error sending message.")
 

--- a/src/akgentic/infra/server/routes/frontend_adapter/angular_v1/router.py
+++ b/src/akgentic/infra/server/routes/frontend_adapter/angular_v1/router.py
@@ -395,10 +395,10 @@ def update_agent_state(
 ) -> V1StatusResponse:
     """PATCH /state/{id}/of/{agent} -> send content to specific agent."""
     team_id = _parse_uuid(id)
-    handle = service.get_handle(team_id)
-    if handle is None:
-        raise HTTPException(status_code=404, detail="Team not found or not running")
-    handle.send_to(agent, body.content)
+    try:
+        service.send_message_to(team_id, agent, body.content)
+    except ValueError as exc:
+        _raise_action_error(exc)
     return V1StatusResponse(status="ok")
 
 

--- a/src/akgentic/infra/server/routes/teams.py
+++ b/src/akgentic/infra/server/routes/teams.py
@@ -117,6 +117,21 @@ def send_message(
         _raise_action_error(exc)
 
 
+@router.post("/{team_id}/message/{agent_name}", status_code=204)
+def send_message_to_agent(
+    team_id: uuid.UUID,
+    agent_name: str,
+    body: SendMessageRequest,
+    service: TeamService = Depends(get_team_service),
+) -> None:
+    """Send a message to a specific agent in a running team."""
+    logger.info("POST /teams/%s/message/%s", team_id, agent_name)
+    try:
+        service.send_message_to(team_id, agent_name, body.content)
+    except ValueError as exc:
+        _raise_action_error(exc)
+
+
 @router.post("/{team_id}/human-input", status_code=204)
 def human_input(
     team_id: uuid.UUID,

--- a/src/akgentic/infra/server/services/team_service.py
+++ b/src/akgentic/infra/server/services/team_service.py
@@ -90,6 +90,16 @@ class TeamService:
         handle.send(content)
         logger.debug("Message sent to team %s", team_id)
 
+    def send_message_to(self, team_id: uuid.UUID, agent_name: str, content: str) -> None:
+        """Send a message to a specific agent in a running team.
+
+        Raises:
+            ValueError: If team not found, not running, or agent not found.
+        """
+        handle = self._get_running_handle(team_id)
+        handle.send_to(agent_name, content)
+        logger.debug("Message sent to agent '%s' in team %s", agent_name, team_id)
+
     def process_human_input(
         self,
         team_id: uuid.UUID,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -144,3 +144,29 @@ def app(
 def client(app: FastAPI) -> TestClient:
     """Sync HTTP test client."""
     return TestClient(app)
+
+
+@pytest.fixture()
+def v1_seeded_settings(tmp_path: Path) -> CommunitySettings:
+    """Server settings with V1 frontend adapter enabled and pre-seeded catalog."""
+    settings = CommunitySettings(
+        workspaces_root=tmp_path / "workspaces",
+        event_store_path=tmp_path / "event_store",
+        catalog_path=tmp_path / "catalog",
+        frontend_adapter=(
+            "akgentic.infra.server.routes.frontend_adapter.angular_v1.AngularV1Adapter"
+        ),
+    )
+    _seed_catalog(settings.catalog_path)
+    return settings
+
+
+@pytest.fixture()
+def v1_client(
+    v1_seeded_settings: CommunitySettings,
+) -> Generator[TestClient, None, None]:
+    """Sync HTTP test client with V1 frontend adapter routes mounted."""
+    services = wire_community(v1_seeded_settings)
+    application = create_app(services, v1_seeded_settings)
+    yield TestClient(application)
+    services.actor_system.shutdown()

--- a/tests/server/routes/test_team_action_routes.py
+++ b/tests/server/routes/test_team_action_routes.py
@@ -33,6 +33,40 @@ def test_send_message_stopped_team(client: TestClient) -> None:
     assert resp.status_code == 409
 
 
+def test_send_message_to_agent_success(client: TestClient) -> None:
+    """POST /teams/{id}/message/{agent} on running team returns 204."""
+    create_resp = client.post("/teams/", json={"catalog_entry_id": "test-team"})
+    team_id = create_resp.json()["team_id"]
+    resp = client.post(f"/teams/{team_id}/message/@Manager", json={"content": "hello"})
+    assert resp.status_code == 204
+
+
+def test_send_message_to_agent_not_found_team(client: TestClient) -> None:
+    """POST /teams/{id}/message/{agent} on non-existent team returns 404."""
+    resp = client.post(
+        f"/teams/{uuid.uuid4()}/message/@Manager",
+        json={"content": "hello"},
+    )
+    assert resp.status_code == 404
+
+
+def test_send_message_to_agent_stopped_team(client: TestClient) -> None:
+    """POST /teams/{id}/message/{agent} on stopped team returns 409."""
+    create_resp = client.post("/teams/", json={"catalog_entry_id": "test-team"})
+    team_id = create_resp.json()["team_id"]
+    client.post(f"/teams/{team_id}/stop")
+    resp = client.post(f"/teams/{team_id}/message/@Manager", json={"content": "hello"})
+    assert resp.status_code == 409
+
+
+def test_send_message_to_agent_unknown_agent(client: TestClient) -> None:
+    """POST /teams/{id}/message/{agent} with unknown agent returns 404."""
+    create_resp = client.post("/teams/", json={"catalog_entry_id": "test-team"})
+    team_id = create_resp.json()["team_id"]
+    resp = client.post(f"/teams/{team_id}/message/ghost", json={"content": "hello"})
+    assert resp.status_code == 404
+
+
 def test_human_input_not_found_team(client: TestClient) -> None:
     """POST /teams/{id}/human-input on non-existent team returns 404."""
     resp = client.post(

--- a/tests/server/routes/test_v1_state_update_routes.py
+++ b/tests/server/routes/test_v1_state_update_routes.py
@@ -1,0 +1,51 @@
+"""Tests for V1 PATCH /state/{id}/of/{agent} endpoint."""
+
+from __future__ import annotations
+
+import uuid
+
+from fastapi.testclient import TestClient
+
+
+def test_v1_send_to_agent_success(v1_client: TestClient) -> None:
+    """PATCH /state/{id}/of/{agent} on running team returns 200 with status ok."""
+    create_resp = v1_client.post("/process/test-team")
+    team_id = create_resp.json()["id"]
+    resp = v1_client.patch(
+        f"/state/{team_id}/of/@Manager",
+        json={"content": "hello"},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "ok"
+
+
+def test_v1_send_to_agent_not_found_team(v1_client: TestClient) -> None:
+    """PATCH /state/{id}/of/{agent} on non-existent team returns 404."""
+    resp = v1_client.patch(
+        f"/state/{uuid.uuid4()}/of/@Manager",
+        json={"content": "hello"},
+    )
+    assert resp.status_code == 404
+
+
+def test_v1_send_to_agent_unknown_agent(v1_client: TestClient) -> None:
+    """PATCH /state/{id}/of/{agent} with unknown agent returns 404 (was 500 before fix)."""
+    create_resp = v1_client.post("/process/test-team")
+    team_id = create_resp.json()["id"]
+    resp = v1_client.patch(
+        f"/state/{team_id}/of/ghost",
+        json={"content": "hello"},
+    )
+    assert resp.status_code == 404
+
+
+def test_v1_send_to_agent_stopped_team(v1_client: TestClient) -> None:
+    """PATCH /state/{id}/of/{agent} on stopped team returns 409."""
+    create_resp = v1_client.post("/process/test-team")
+    team_id = create_resp.json()["id"]
+    v1_client.delete(f"/process/{team_id}/archive")
+    resp = v1_client.patch(
+        f"/state/{team_id}/of/@Manager",
+        json={"content": "hello"},
+    )
+    assert resp.status_code == 409

--- a/tests/server/services/test_team_action_service.py
+++ b/tests/server/services/test_team_action_service.py
@@ -31,6 +31,27 @@ def test_send_message_stopped_team(team_service: TeamService) -> None:
         team_service.send_message(process.team_id, "hello")
 
 
+def test_send_message_to_success(team_service: TeamService) -> None:
+    """send_message_to delivers to a specific agent without error."""
+    process = team_service.create_team("test-team", user_id="anonymous")
+    # @Manager is a valid agent in the test-team catalog entry
+    team_service.send_message_to(process.team_id, "@Manager", "hello")
+
+
+def test_send_message_to_not_found_team(team_service: TeamService) -> None:
+    """send_message_to raises ValueError for non-existent team."""
+    with pytest.raises(ValueError, match="not found"):
+        team_service.send_message_to(uuid.uuid4(), "@Manager", "hello")
+
+
+def test_send_message_to_stopped_team(team_service: TeamService) -> None:
+    """send_message_to raises ValueError for stopped team."""
+    process = team_service.create_team("test-team", user_id="anonymous")
+    team_service.stop_team(process.team_id)
+    with pytest.raises(ValueError, match="not running"):
+        team_service.send_message_to(process.team_id, "@Manager", "hello")
+
+
 def test_stop_team_success(team_service: TeamService) -> None:
     """stop_team transitions a running team to stopped."""
     process = team_service.create_team("test-team", user_id="anonymous")


### PR DESCRIPTION
## Summary
- Add `TeamService.send_message_to()` method mirroring `send_message()` pattern
- Add V2 endpoint `POST /{team_id}/message/{agent_name}` with proper error handling
- Refactor V1 `PATCH /state/{id}/of/{agent}` to use service method instead of direct handle access
- Fix V1 bug: unknown agent name now returns 404 instead of unhandled 500

Relates to #157

## Test plan
- [x] All existing tests pass (848 passed)
- [x] 3 service-level tests for send_message_to (success, not found, stopped)
- [x] 4 V2 route tests (success, not found, stopped, unknown agent)
- [x] 4 V1 route tests (success, not found, unknown agent, stopped)