### PR TITLE
TUI conversation UX corrections (ADR-011)

### DIFF
--- a/src/akgentic/infra/cli/event_router.py
+++ b/src/akgentic/infra/cli/event_router.py
@@ -123,7 +123,7 @@ class EventRouter:
 
         nested_model = nested.get("__model__", "")
 
-        if "tool_name" in nested:
+        if "ToolCallEvent" in nested_model:
             self._handle_tool_call(nested)
             return True
 
@@ -213,27 +213,33 @@ class EventRouter:
         color_registry: AgentColorRegistry,
         timestamp: str | None = None,
     ) -> Widget | None:
-        """Convert a SentMessage event to an AgentMessage widget.
-
-        Skips messages from @Human — those are echoes of the user's own
-        message, already displayed as a UserMessage widget.
-        """
+        """Convert a SentMessage event to an AgentMessage widget."""
         from akgentic.infra.cli.tui.widgets.agent_message import AgentMessage
 
         raw_sender = event.get("sender", "agent")
         sender = (
             raw_sender.get("name", "agent") if isinstance(raw_sender, dict) else str(raw_sender)
         )
-        if sender == "@Human":
-            return None
         message = event.get("message", {})
         content = message.get("content", "") if isinstance(message, dict) else ""
         if not content:
             return None
+
+        raw_recipient = event.get("recipient")
+        recipient: str | None = None
+        if isinstance(raw_recipient, dict):
+            recipient = raw_recipient.get("name")
+        elif isinstance(raw_recipient, str) and raw_recipient:
+            recipient = raw_recipient
+
         color: str = color_registry.get(sender)
         self._last_agent_color = color
         return AgentMessage(
-            sender=sender, content=str(content), color=color, timestamp=timestamp
+            sender=sender,
+            content=str(content),
+            color=color,
+            timestamp=timestamp,
+            recipient=recipient,
         )
 
     def _event_to_widget(self, event: dict[str, Any]) -> Widget | None:
@@ -247,10 +253,11 @@ class EventRouter:
         if not isinstance(nested, dict):
             return None
 
-        if "tool_name" in nested:
+        nested_model = nested.get("__model__", "")
+
+        if "ToolCallEvent" in nested_model:
             return self._tool_call_to_widget(nested)
 
-        nested_model = nested.get("__model__", "")
         if "HumanInput" in nested_model or "RequestInput" in nested_model:
             from akgentic.infra.cli.tui.widgets.human_input import HumanInputPrompt
 

--- a/src/akgentic/infra/cli/tui/widgets/agent_message.py
+++ b/src/akgentic/infra/cli/tui/widgets/agent_message.py
@@ -24,11 +24,13 @@ class AgentMessage(Static):
         content: str,
         color: str,
         timestamp: str | None = None,
+        recipient: str | None = None,
     ) -> None:
         self._sender = sender
         self._content = content
         self._color = color
         self._timestamp = timestamp
+        self._recipient = recipient
         super().__init__()
 
     def on_mount(self) -> None:
@@ -36,9 +38,13 @@ class AgentMessage(Static):
         self.styles.border_left = ("tall", self._color)
 
     def render(self) -> RenderableType:
-        """Render sender name with color, optional timestamp, and markdown body."""
+        """Render sender name with color, optional recipient, timestamp, and markdown body."""
         name = self._sender.lstrip("@")
         header = Text(f"[@{name}]", style=f"bold {self._color}")
+        if self._recipient:
+            recipient_name = self._recipient.lstrip("@")
+            header.append(" \u2192 ", style="dim")
+            header.append(f"[@{recipient_name}]", style="bold")
         if self._timestamp:
             header.append(f"  {self._timestamp}", style="dim")
         body = Markdown(self._content)

--- a/tests/cli/test_cli_event_router.py
+++ b/tests/cli/test_cli_event_router.py
@@ -256,6 +256,7 @@ class TestToolCallArgFormats:
             "event": {
                 "__model__": "EventMessage",
                 "event": {
+                    "__model__": "akgentic.llm.event.ToolCallEvent",
                     "tool_name": "search",
                     "arguments": {"query": "test", "limit": 10},
                     "result": {"items": ["a", "b"]},
@@ -274,6 +275,7 @@ class TestToolCallArgFormats:
             "event": {
                 "__model__": "EventMessage",
                 "event": {
+                    "__model__": "akgentic.llm.event.ToolCallEvent",
                     "tool_name": "multi_search",
                     "arguments": ["query1", "query2"],
                     "result": None,
@@ -293,7 +295,12 @@ class TestNestedEventJsonString:
 
         renderer, buf = _captured_renderer()
         router = EventRouter(renderer)
-        nested = json.dumps({"tool_name": "calc", "arguments": "2+2", "result": "4"})
+        nested = json.dumps({
+            "__model__": "akgentic.llm.event.ToolCallEvent",
+            "tool_name": "calc",
+            "arguments": "2+2",
+            "result": "4",
+        })
         data = {
             "event": {
                 "__model__": "EventMessage",
@@ -388,6 +395,7 @@ class TestToWidgetToolCall:
             "event": {
                 "__model__": "EventMessage",
                 "event": {
+                    "__model__": "akgentic.llm.event.ToolCallEvent",
                     "tool_name": "calc",
                     "arguments": {"x": 1},
                     "result": {"answer": 42},
@@ -457,7 +465,12 @@ class TestToWidgetJsonStringEvent:
         import json
 
         router, registry = _make_widget_router()
-        nested = json.dumps({"tool_name": "calc", "arguments": "2+2", "result": "4"})
+        nested = json.dumps({
+            "__model__": "akgentic.llm.event.ToolCallEvent",
+            "tool_name": "calc",
+            "arguments": "2+2",
+            "result": "4",
+        })
         data = {
             "event": {
                 "__model__": "EventMessage",

--- a/tests/cli/test_cli_event_router.py
+++ b/tests/cli/test_cli_event_router.py
@@ -18,6 +18,7 @@ from tests.fixtures.events import (
     make_sent_message,
     make_start_message,
     make_tool_call_event,
+    make_tool_return_event,
 )
 
 from .conftest import captured_renderer as _captured_renderer
@@ -295,12 +296,14 @@ class TestNestedEventJsonString:
 
         renderer, buf = _captured_renderer()
         router = EventRouter(renderer)
-        nested = json.dumps({
-            "__model__": "akgentic.llm.event.ToolCallEvent",
-            "tool_name": "calc",
-            "arguments": "2+2",
-            "result": "4",
-        })
+        nested = json.dumps(
+            {
+                "__model__": "akgentic.llm.event.ToolCallEvent",
+                "tool_name": "calc",
+                "arguments": "2+2",
+                "result": "4",
+            }
+        )
         data = {
             "event": {
                 "__model__": "EventMessage",
@@ -373,6 +376,54 @@ class TestToWidgetSentMessage:
         # sender from make_sent_message defaults to "sender"
         assert "sender" in registry._map
 
+    def test_recipient_extracted_from_dict(self) -> None:
+        """AC #1/#4: recipient dict is extracted and passed to AgentMessage."""
+        router, registry = _make_widget_router()
+        data = {"event": make_sent_message(content="hello")}
+        widget = router.to_widget(data, registry)
+        assert isinstance(widget, AgentMessage)
+        # make_sent_message default recipient is _make_proxy(name="recipient")
+        assert widget._recipient == "recipient"
+
+    def test_recipient_none_when_absent(self) -> None:
+        """AC #3: when recipient is absent, AgentMessage._recipient is None."""
+        router, registry = _make_widget_router()
+        event = {
+            "__model__": "some.module.SentMessage",
+            "sender": {"name": "@Manager"},
+            "message": {"content": "no recipient here"},
+        }
+        widget = router.to_widget({"event": event}, registry)
+        assert isinstance(widget, AgentMessage)
+        assert widget._recipient is None
+
+    def test_recipient_string_form(self) -> None:
+        """AC #4: recipient as a plain string is extracted."""
+        router, registry = _make_widget_router()
+        event = {
+            "__model__": "some.module.SentMessage",
+            "sender": {"name": "@Manager"},
+            "message": {"content": "with string recipient"},
+            "recipient": "@Developer",
+        }
+        widget = router.to_widget({"event": event}, registry)
+        assert isinstance(widget, AgentMessage)
+        assert widget._recipient == "@Developer"
+
+    def test_human_sender_produces_widget(self) -> None:
+        """AC #5: @Human SentMessage events are no longer filtered."""
+        router, registry = _make_widget_router()
+        event = {
+            "__model__": "some.module.SentMessage",
+            "sender": {"name": "@Human"},
+            "message": {"content": "directed message"},
+            "recipient": {"name": "@Developer"},
+        }
+        widget = router.to_widget({"event": event}, registry)
+        assert isinstance(widget, AgentMessage)
+        assert widget._sender == "@Human"
+        assert widget._recipient == "@Developer"
+
 
 class TestToWidgetErrorMessage:
     def test_returns_error_widget(self) -> None:
@@ -404,6 +455,25 @@ class TestToWidgetToolCall:
         }
         widget = router.to_widget(data, registry)
         assert isinstance(widget, ToolCallWidget)
+
+    def test_tool_return_event_does_not_produce_widget(self) -> None:
+        """AC #6: ToolReturnEvent must NOT produce a ToolCallWidget (no duplicates)."""
+        router, registry = _make_widget_router()
+        data = {
+            "event": make_event_message(event=make_tool_return_event(tool_name="search")),
+        }
+        widget = router.to_widget(data, registry)
+        assert widget is None
+
+    def test_tool_return_event_not_routed(self) -> None:
+        """AC #6: ToolReturnEvent must NOT be rendered via route() either."""
+        renderer, _buf = _captured_renderer()
+        router = EventRouter(renderer)
+        data = {
+            "event": make_event_message(event=make_tool_return_event(tool_name="search")),
+        }
+        result = router.route(data)
+        assert result is False
 
 
 class TestToWidgetHumanInput:
@@ -465,12 +535,14 @@ class TestToWidgetJsonStringEvent:
         import json
 
         router, registry = _make_widget_router()
-        nested = json.dumps({
-            "__model__": "akgentic.llm.event.ToolCallEvent",
-            "tool_name": "calc",
-            "arguments": "2+2",
-            "result": "4",
-        })
+        nested = json.dumps(
+            {
+                "__model__": "akgentic.llm.event.ToolCallEvent",
+                "tool_name": "calc",
+                "arguments": "2+2",
+                "result": "4",
+            }
+        )
         data = {
             "event": {
                 "__model__": "EventMessage",

--- a/tests/fixtures/events.py
+++ b/tests/fixtures/events.py
@@ -139,7 +139,11 @@ def make_processed_message(**overrides: Any) -> dict[str, Any]:
 
 
 def make_tool_call_event(**overrides: Any) -> dict[str, Any]:
-    """Create a ``ToolCallEvent`` fixture dict from a real dataclass instance."""
+    """Create a ``ToolCallEvent`` fixture dict from a real dataclass instance.
+
+    Adds ``__model__`` to match the real serialization contract
+    (``akgentic.core.utils.serializer.serialize`` adds it for dataclasses).
+    """
     defaults: dict[str, Any] = {
         "run_id": "run-001",
         "tool_name": "test_tool",
@@ -147,11 +151,16 @@ def make_tool_call_event(**overrides: Any) -> dict[str, Any]:
         "arguments": '{"key": "value"}',
     }
     defaults.update(overrides)
-    return dataclasses.asdict(ToolCallEvent(**defaults))
+    result = dataclasses.asdict(ToolCallEvent(**defaults))
+    result["__model__"] = "akgentic.llm.event.ToolCallEvent"
+    return result
 
 
 def make_tool_return_event(**overrides: Any) -> dict[str, Any]:
-    """Create a ``ToolReturnEvent`` fixture dict from a real dataclass instance."""
+    """Create a ``ToolReturnEvent`` fixture dict from a real dataclass instance.
+
+    Adds ``__model__`` to match the real serialization contract.
+    """
     defaults: dict[str, Any] = {
         "run_id": "run-001",
         "tool_name": "test_tool",
@@ -159,7 +168,9 @@ def make_tool_return_event(**overrides: Any) -> dict[str, Any]:
         "success": True,
     }
     defaults.update(overrides)
-    return dataclasses.asdict(ToolReturnEvent(**defaults))
+    result = dataclasses.asdict(ToolReturnEvent(**defaults))
+    result["__model__"] = "akgentic.llm.event.ToolReturnEvent"
+    return result
 
 
 def make_llm_usage_event(**overrides: Any) -> dict[str, Any]:

--- a/tests/fixtures/test_fixture_factories.py
+++ b/tests/fixtures/test_fixture_factories.py
@@ -176,12 +176,14 @@ class TestToolCallEventFactory:
 
     def test_round_trip_defaults(self) -> None:
         data = make_tool_call_event()
-        event = ToolCallEvent(**data)
+        fields = {k: v for k, v in data.items() if k != "__model__"}
+        event = ToolCallEvent(**fields)
         assert event.tool_name == "test_tool"
 
     def test_round_trip_with_overrides(self) -> None:
         data = make_tool_call_event(tool_name="search", arguments='{"q": "hello"}')
-        event = ToolCallEvent(**data)
+        fields = {k: v for k, v in data.items() if k != "__model__"}
+        event = ToolCallEvent(**fields)
         assert event.tool_name == "search"
         assert event.arguments == '{"q": "hello"}'
 
@@ -189,23 +191,33 @@ class TestToolCallEventFactory:
         data = make_tool_call_event(tool_name="my_tool")
         assert data["tool_name"] == "my_tool"
 
+    def test_model_tag_present(self) -> None:
+        data = make_tool_call_event()
+        assert data["__model__"] == "akgentic.llm.event.ToolCallEvent"
+
 
 class TestToolReturnEventFactory:
     """Round-trip tests for make_tool_return_event."""
 
     def test_round_trip_defaults(self) -> None:
         data = make_tool_return_event()
-        event = ToolReturnEvent(**data)
+        fields = {k: v for k, v in data.items() if k != "__model__"}
+        event = ToolReturnEvent(**fields)
         assert event.success is True
 
     def test_round_trip_with_overrides(self) -> None:
         data = make_tool_return_event(success=False)
-        event = ToolReturnEvent(**data)
+        fields = {k: v for k, v in data.items() if k != "__model__"}
+        event = ToolReturnEvent(**fields)
         assert event.success is False
 
     def test_override_appears_in_output(self) -> None:
         data = make_tool_return_event(success=False)
         assert data["success"] is False
+
+    def test_model_tag_present(self) -> None:
+        data = make_tool_return_event()
+        assert data["__model__"] == "akgentic.llm.event.ToolReturnEvent"
 
 
 class TestLlmUsageEventFactory:


### PR DESCRIPTION
## Summary

- Display recipient in `AgentMessage` header: `[@Manager] -> [@Human] 17:57` with dim arrow and bold recipient
- Extract `recipient.name` from serialized `SentMessage` events in `EventRouter._sent_to_widget()`
- Remove `@Human` SentMessage filter so directed human messages render with routing context
- Fix duplicate `ToolCallWidget` by using `__model__` discriminator instead of `tool_name` key presence
- Add `__model__` tag to `make_tool_call_event` and `make_tool_return_event` fixture factories

## Review fixes

Added 6 tests for missing coverage identified during code review:
- Recipient extraction from dict and string forms (AC #1/#4)
- None-recipient fallback path (AC #3)
- @Human sender SentMessage rendering (AC #5)
- ToolReturnEvent negative tests proving no duplicate widgets (AC #6)

**Tests:** 1057 passed, 89.73% coverage

Closes #169