### PR TITLE
Remove duplicate CLI replay -- WebSocket owns history

### DIFF
--- a/src/akgentic/infra/adapters/shared/null_event_stream.py
+++ b/src/akgentic/infra/adapters/shared/null_event_stream.py
@@ -31,15 +31,11 @@ class NullEventStream:
         """Discard event, return 0."""
         return 0
 
-    def read_from(
-        self, team_id: uuid.UUID, cursor: int = 0
-    ) -> list[Message]:
+    def read_from(self, team_id: uuid.UUID, cursor: int = 0) -> list[Message]:
         """Return empty list."""
         return []
 
-    def subscribe(
-        self, team_id: uuid.UUID, cursor: int = 0
-    ) -> NullStreamReader:
+    def subscribe(self, team_id: uuid.UUID, cursor: int = 0) -> NullStreamReader:
         """Return a NullStreamReader."""
         return NullStreamReader()
 

--- a/src/akgentic/infra/cli/client.py
+++ b/src/akgentic/infra/cli/client.py
@@ -213,9 +213,7 @@ class ApiClient:
 
     def send_message_to(self, team_id: str, agent_name: str, content: str) -> None:
         """POST /teams/{team_id}/message/{agent_name}."""
-        self._request(
-            "POST", f"/teams/{team_id}/message/{agent_name}", json={"content": content}
-        )
+        self._request("POST", f"/teams/{team_id}/message/{agent_name}", json={"content": content})
 
     def human_input(self, team_id: str, content: str, message_id: str) -> None:
         """POST /teams/{team_id}/human-input."""

--- a/src/akgentic/infra/cli/commands.py
+++ b/src/akgentic/infra/cli/commands.py
@@ -120,9 +120,7 @@ async def _create_handler(args: str, session: ChatSession) -> None:
 
     loop = asyncio.get_running_loop()
     try:
-        team = await loop.run_in_executor(
-            None, session.client.create_team, catalog_entry_id
-        )
+        team = await loop.run_in_executor(None, session.client.create_team, catalog_entry_id)
     except ApiError as exc:
         session.renderer.render_error(f"Error creating team: {exc.detail}")
         return
@@ -142,10 +140,7 @@ async def _delete_handler(args: str, session: ChatSession) -> None:
         session.renderer.render_error(f"Error fetching team info: {exc.detail}")
         return
 
-    prompt_text = (
-        f"Delete team {team.name} ({target_id})? "
-        "All event history will be lost. [y/N] "
-    )
+    prompt_text = f"Delete team {team.name} ({target_id})? All event history will be lost. [y/N] "
     try:
         response = await loop.run_in_executor(None, builtins.input, prompt_text)
     except (EOFError, KeyboardInterrupt):
@@ -265,14 +260,11 @@ async def _history_handler(args: str, session: ChatSession) -> None:
     from akgentic.core.messages.orchestrator import ErrorMessage, EventMessage, SentMessage
 
     displayable = [
-        e.event
-        for e in events
-        if isinstance(e.event, (SentMessage, ErrorMessage, EventMessage))
+        e.event for e in events if isinstance(e.event, (SentMessage, ErrorMessage, EventMessage))
     ]
     for evt in displayable[-limit:]:
         if isinstance(evt, Message):
             session._render_event(evt)
-
 
 
 # -- Workspace commands --
@@ -461,9 +453,7 @@ def build_default_registry() -> CommandRegistry:
     registry.register("read", _read_handler, "Read a workspace file", "/read <path>")
     registry.register("upload", _upload_handler, "Upload a file to workspace", "/upload <path>")
     registry.register("stop", _stop_handler, "Stop the team", "/stop")
-    registry.register(
-        "restore", _restore_handler, "Restore a stopped team", "/restore [team_id]"
-    )
+    registry.register("restore", _restore_handler, "Restore a stopped team", "/restore [team_id]")
     registry.register("switch", _switch_handler, "Switch to another team", "/switch <team_id>")
     registry.register("reconnect", _reconnect_handler, "Reconnect to server", "/reconnect")
     registry.register("quit", _quit_handler, "Exit the chat", "/quit")

--- a/src/akgentic/infra/cli/commands.py
+++ b/src/akgentic/infra/cli/commands.py
@@ -402,7 +402,7 @@ async def _switch_handler(args: str, session: ChatSession) -> None:
 
     session.team_id = new_team_id
 
-    # Cancel old receive loop before replaying history
+    # Cancel old receive loop before starting new one
     if session._receive_task is not None:
         session._receive_task.cancel()
         try:
@@ -410,10 +410,9 @@ async def _switch_handler(args: str, session: ChatSession) -> None:
         except asyncio.CancelledError:
             pass
 
-    # Refresh team info for status bar and replay history
+    # Refresh team info for status bar
     session._fetch_team_info()
     session.renderer.render_border()
-    await session.replay_history_async()
 
     session._receive_task = asyncio.create_task(session._receive_loop())
 

--- a/src/akgentic/infra/cli/renderers.py
+++ b/src/akgentic/infra/cli/renderers.py
@@ -139,10 +139,7 @@ class RichRenderer:
         self._console.print("  [bold]Create new:[/bold]")
         for entry_id, description in entries:
             desc = description or ""
-            self._console.print(
-                f"    [bold white]\\[c {entry_id}][/bold white]  "
-                f"[dim]{desc}[/dim]"
-            )
+            self._console.print(f"    [bold white]\\[c {entry_id}][/bold white]  [dim]{desc}[/dim]")
         self._console.print()
 
     def render_startup_hints(self, max_num: int, has_stopped: bool) -> None:

--- a/src/akgentic/infra/cli/repl.py
+++ b/src/akgentic/infra/cli/repl.py
@@ -107,11 +107,10 @@ class ChatSession:
             pass  # Keep defaults "(unknown)" and "?"
 
     async def run(self) -> None:
-        """Main REPL loop: connect WS, replay history, read input, stream events."""
+        """Main REPL loop: connect WS, read input, stream events."""
         async with self.conn:
             self._fetch_team_info()
             self.renderer.render_border()
-            self._replay_history()
 
             self._receive_task = asyncio.create_task(self._receive_loop())
             try:
@@ -255,32 +254,6 @@ class ChatSession:
                 self.client.send_message(self._state.team_id, msg)
             except ApiError:
                 self.renderer.render_error(f"Failed to send buffered message: {msg[:50]}")
-
-    def _replay_history(self) -> None:
-        """Fetch and display past events before starting the REPL."""
-        try:
-            events = self.client.get_events(self._state.team_id)
-        except ApiError:
-            return
-        self._display_events([e.model_dump() for e in events])
-
-    async def replay_history_async(self) -> None:
-        """Async version of _replay_history — uses run_in_executor to avoid blocking."""
-        loop = asyncio.get_running_loop()
-        try:
-            events = await loop.run_in_executor(None, self.client.get_events, self._state.team_id)
-        except ApiError:
-            return
-        self._display_events([e.model_dump() for e in events])
-
-    def _display_events(self, events: list[dict[str, Any]]) -> None:
-        """Render a list of events, adding a history separator if any were displayed."""
-        displayed = False
-        for evt in events:
-            if self._render_event(evt):
-                displayed = True
-        if displayed:
-            self.renderer.render_history_separator()
 
     def _render_event(self, data: dict[str, Any]) -> bool:
         """Format and render a single event. Returns True if something was rendered."""

--- a/src/akgentic/infra/cli/repl.py
+++ b/src/akgentic/infra/cli/repl.py
@@ -14,7 +14,7 @@ from prompt_toolkit.history import InMemoryHistory
 from pydantic import BaseModel
 
 from akgentic.core.messages.message import Message
-from akgentic.infra.cli.client import ApiClient, ApiError, EventInfo
+from akgentic.infra.cli.client import ApiClient, ApiError
 from akgentic.infra.cli.commands import CommandRegistry, build_default_registry
 from akgentic.infra.cli.connection import ConnectionManager, ConnectionState
 from akgentic.infra.cli.event_router import EventRouter
@@ -231,9 +231,7 @@ class ChatSession:
                 parts[1],
             )
         else:
-            await loop.run_in_executor(
-                None, self.client.send_message, self._state.team_id, line
-            )
+            await loop.run_in_executor(None, self.client.send_message, self._state.team_id, line)
 
     async def _receive_loop(self) -> None:
         """Background coroutine: read WebSocket events and render them."""

--- a/src/akgentic/infra/cli/tui/app.py
+++ b/src/akgentic/infra/cli/tui/app.py
@@ -13,7 +13,6 @@ from textual.containers import Container, VerticalScroll
 from textual.widget import Widget
 from textual.widgets import Static
 
-from akgentic.core.messages.message import Message
 from akgentic.infra.cli.client import ApiError
 from akgentic.infra.cli.connection import ConnectionState
 from akgentic.infra.cli.tui.colors import AgentColorRegistry
@@ -101,9 +100,7 @@ class ChatApp(App[None]):
             self._palette.remove()
             self._palette = None
 
-    def on_chat_input_palette_filter_changed(
-        self, event: ChatInput.PaletteFilterChanged
-    ) -> None:
+    def on_chat_input_palette_filter_changed(self, event: ChatInput.PaletteFilterChanged) -> None:
         """Update the palette filter text."""
         if self._palette is not None:
             self._palette.filter_text = event.filter_text
@@ -270,9 +267,7 @@ class ChatApp(App[None]):
         else:
             self.query_one(ScrollIndicator).count += 1
 
-    def on_scroll_indicator_scroll_to_bottom(
-        self, _event: ScrollIndicator.ScrollToBottom
-    ) -> None:
+    def on_scroll_indicator_scroll_to_bottom(self, _event: ScrollIndicator.ScrollToBottom) -> None:
         """Handle click on scroll indicator — jump to bottom."""
         conversation = self.query_one("#conversation", VerticalScroll)
         conversation.scroll_end(animate=False)

--- a/src/akgentic/infra/cli/tui/app.py
+++ b/src/akgentic/infra/cli/tui/app.py
@@ -298,8 +298,7 @@ class ChatApp(App[None]):
                 pass
 
         conversation = self.query_one("#conversation", VerticalScroll)
-        has_history = await self._replay_history(conversation)
-        if not has_history and not conversation.query(".welcome-msg, #welcome"):
+        if not conversation.query(".welcome-msg, #welcome"):
             welcome = Static(
                 "Welcome to Akgentic Chat. Send a message to begin.",
                 classes="welcome-msg",
@@ -324,41 +323,6 @@ class ChatApp(App[None]):
         msg = SystemMessage(content="Connection lost. Use /reconnect to try again.")
         await conversation.mount(msg)
         msg.scroll_visible(animate=False)
-
-    async def _replay_history(self, conversation: VerticalScroll) -> bool:
-        """Fetch and mount past events as dimmed widgets. Returns True if any displayed."""
-        if self._client is None or self._event_router is None:
-            return False
-        import asyncio
-
-        loop = asyncio.get_running_loop()
-        try:
-            events = await loop.run_in_executor(
-                None, self._client.get_events, self._team_id
-            )
-        except ApiError:
-            return False
-        if not events:
-            return False
-
-        displayed = False
-        for evt in events:
-            widget = self._event_router.to_widget(
-                evt.model_dump(), self._color_registry
-            )
-            if widget is not None:
-                widget.add_class("history")
-                await conversation.mount(widget)
-                displayed = True
-
-        if displayed:
-            from akgentic.infra.cli.tui.widgets.system_message import SystemMessage
-
-            sep = SystemMessage(content="── history ──")
-            sep.add_class("history")
-            await conversation.mount(sep)
-            sep.scroll_visible(animate=False)
-        return displayed
 
     def _remove_thinking_indicator(self, conversation: VerticalScroll) -> None:
         """Remove ThinkingIndicator if present."""

--- a/src/akgentic/infra/cli/tui/command_adapter.py
+++ b/src/akgentic/infra/cli/tui/command_adapter.py
@@ -85,9 +85,6 @@ class _TuiSession:
         """No-op stub -- TUI uses EventRouter.to_widget() instead."""
         return False
 
-    async def replay_history_async(self) -> None:
-        """No-op stub -- TUI replays via stream_events()."""
-
 
 class _MinimalState:
     """Minimal state object exposing team_id for command handlers."""

--- a/src/akgentic/infra/cli/tui/command_adapter.py
+++ b/src/akgentic/infra/cli/tui/command_adapter.py
@@ -436,9 +436,7 @@ class TuiCommandAdapter:
         """Handle /history by fetching events and mounting them as TUI widgets."""
         limit = self._parse_history_limit(args)
         if limit is None:
-            await self._mount_system(
-                app, "Usage: /history [N] — N must be a positive integer."
-            )
+            await self._mount_system(app, "Usage: /history [N] — N must be a positive integer.")
             return True
 
         client = app._client  # noqa: SLF001
@@ -449,7 +447,9 @@ class TuiCommandAdapter:
         loop = asyncio.get_running_loop()
         try:
             events = await loop.run_in_executor(
-                None, client.get_events, app._team_id  # noqa: SLF001
+                None,
+                client.get_events,
+                app._team_id,  # noqa: SLF001
             )
         except ApiError as exc:
             await self._mount_error(app, f"Error fetching history: {exc.detail}")

--- a/src/akgentic/infra/cli/tui/screens/team_select.py
+++ b/src/akgentic/infra/cli/tui/screens/team_select.py
@@ -138,9 +138,7 @@ class TeamSelectScreen(Screen[str | None]):
         self._render_catalog_section(container)
         self._update_hints()
 
-    def _render_running_section(
-        self, container: VerticalScroll, start: int, end: int
-    ) -> None:
+    def _render_running_section(self, container: VerticalScroll, start: int, end: int) -> None:
         """Render the running teams section."""
         if not self._running_teams:
             container.mount(Static("Running teams: (none)", classes="section-header"))
@@ -164,9 +162,7 @@ class TeamSelectScreen(Screen[str | None]):
             line.append("  > running", style="green")
             container.mount(Static(line, classes="team-entry"))
 
-    def _render_stopped_section(
-        self, container: VerticalScroll, start: int, end: int
-    ) -> None:
+    def _render_stopped_section(self, container: VerticalScroll, start: int, end: int) -> None:
         """Render the stopped teams section."""
         if not self._stopped_teams:
             container.mount(Static("Stopped teams: (none)", classes="section-header"))

--- a/src/akgentic/infra/cli/tui/widgets/chat_input.py
+++ b/src/akgentic/infra/cli/tui/widgets/chat_input.py
@@ -174,11 +174,7 @@ class ChatInput(TextArea):
             return
         text = self.text
         # Only show palette for command name completion (before the first space).
-        if (
-            text.startswith("/")
-            and " " not in text
-            and self._command_registry is not None
-        ):
+        if text.startswith("/") and " " not in text and self._command_registry is not None:
             if not self._palette_visible:
                 self._palette_visible = True
                 self.post_message(self.PaletteRequested())

--- a/src/akgentic/infra/cli/ws_client.py
+++ b/src/akgentic/infra/cli/ws_client.py
@@ -49,22 +49,14 @@ class WsClient:
                 additional_headers=self._headers,
             )
         except (ConnectionRefusedError, OSError) as exc:
-            raise WsConnectionError(
-                f"Connection error: {exc}", retryable=True
-            ) from exc
+            raise WsConnectionError(f"Connection error: {exc}", retryable=True) from exc
         except websockets.exceptions.InvalidStatus as exc:
             status = exc.response.status_code
             if status == 404 or status == 403:
-                raise WsConnectionError(
-                    "Team not found", retryable=False
-                ) from exc
-            raise WsConnectionError(
-                f"WebSocket rejected: HTTP {status}", retryable=True
-            ) from exc
+                raise WsConnectionError("Team not found", retryable=False) from exc
+            raise WsConnectionError(f"WebSocket rejected: HTTP {status}", retryable=True) from exc
         except websockets.exceptions.InvalidHandshake as exc:
-            raise WsConnectionError(
-                f"WebSocket handshake failed: {exc}", retryable=True
-            ) from exc
+            raise WsConnectionError(f"WebSocket handshake failed: {exc}", retryable=True) from exc
         return self
 
     async def receive_event(self) -> Message:

--- a/src/akgentic/infra/protocols/event_stream.py
+++ b/src/akgentic/infra/protocols/event_stream.py
@@ -55,9 +55,7 @@ class EventStream(Protocol):
         """
         ...
 
-    def read_from(
-        self, team_id: uuid.UUID, cursor: int = 0
-    ) -> list[Message]:
+    def read_from(self, team_id: uuid.UUID, cursor: int = 0) -> list[Message]:
         """Read all events from cursor position (non-blocking snapshot).
 
         Args:
@@ -69,9 +67,7 @@ class EventStream(Protocol):
         """
         ...
 
-    def subscribe(
-        self, team_id: uuid.UUID, cursor: int = 0
-    ) -> StreamReader:
+    def subscribe(self, team_id: uuid.UUID, cursor: int = 0) -> StreamReader:
         """Create a cursor-based blocking reader.
 
         Args:

--- a/tests/cli/test_cli_repl.py
+++ b/tests/cli/test_cli_repl.py
@@ -6,7 +6,7 @@ import asyncio
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
-from akgentic.infra.cli.client import ApiError, EventInfo
+from akgentic.infra.cli.client import ApiError
 from akgentic.infra.cli.commands import build_default_registry
 from akgentic.infra.cli.connection import ConnectionState
 from akgentic.infra.cli.formatters import OutputFormat
@@ -56,54 +56,6 @@ def _make_session(
     if conn is None:
         conn = _mock_conn()
     return ChatSession(client, conn, "t1", OutputFormat.table, renderer=renderer)
-
-
-class TestReplayHistory:
-    def test_replay_displays_sent_messages(self) -> None:
-        renderer, buf = _captured_renderer()
-        client = _mock_client(
-            get_events=MagicMock(
-                return_value=[
-                    EventInfo(
-                        team_id="t1",
-                        sequence=1,
-                        event=make_sent_message(content="hello"),
-                        timestamp="2026-01-01T00:00:00",
-                    ),
-                    EventInfo(
-                        team_id="t1",
-                        sequence=2,
-                        event={
-                            "__model__": "StateChangedMessage",
-                            "state": "running",
-                        },
-                        timestamp="2026-01-01T00:00:00",
-                    ),
-                ]
-            )
-        )
-        session = _make_session(client=client, renderer=renderer)
-        session._replay_history()
-        out = buf.getvalue()
-        assert "sender" in out
-        assert "hello" in out
-        assert "history" in out  # separator
-        assert "StateChanged" not in out
-
-    def test_replay_no_events(self) -> None:
-        renderer, buf = _captured_renderer()
-        client = _mock_client()
-        session = _make_session(client=client, renderer=renderer)
-        session._replay_history()
-        out = buf.getvalue()
-        assert "history" not in out
-
-    def test_replay_handles_error(self) -> None:
-        renderer, buf = _captured_renderer()
-        client = _mock_client()
-        client.get_events.side_effect = ApiError(500, "test error")
-        session = _make_session(client=client, renderer=renderer)
-        session._replay_history()  # Should not raise
 
 
 class TestQuitHandling:

--- a/tests/cli/test_cli_repl.py
+++ b/tests/cli/test_cli_repl.py
@@ -40,9 +40,7 @@ _PROMPT_PATH = "prompt_toolkit.PromptSession.prompt"
 
 def _mock_client(**overrides: Any) -> MagicMock:
     """Build a mock ApiClient with minimal defaults for REPL tests."""
-    defaults: dict[str, Any] = {"get_events": MagicMock(return_value=[])}
-    defaults.update(overrides)
-    return _shared_mock_client(**defaults)
+    return _shared_mock_client(**overrides)
 
 
 def _make_session(

--- a/tests/cli/test_tui_commands.py
+++ b/tests/cli/test_tui_commands.py
@@ -462,7 +462,7 @@ async def test_history_no_events_mounts_message() -> None:
         await pilot.pause()
         await pilot.pause()
 
-        # get_events called by both _replay_history and /history command
+        # get_events called by /history command
         assert client.get_events.call_count >= 1
         msgs = pilot.app.query(SystemMessage)
         found = any("No displayable" in m._content for m in msgs)


### PR DESCRIPTION
## Summary

- Removed `_replay_history()`, `replay_history_async()`, and `_display_events()` from REPL `ChatSession`
- Removed `_replay_history()` from TUI `ChatApp.stream_events()`
- Removed `replay_history_async()` call from `/switch` command handler
- Removed `replay_history_async()` no-op stub from TUI `_TuiSession`
- WebSocket `subscribe(cursor=0)` is now the single source for event replay in interactive sessions
- `/history` slash command and non-interactive CLI paths preserved unchanged

Closes #175