### PR TITLE
Typed event deserialization at WebSocket boundary

### DIFF
--- a/src/akgentic/infra/cli/client.py
+++ b/src/akgentic/infra/cli/client.py
@@ -2,10 +2,16 @@
 
 from __future__ import annotations
 
+import logging
 from typing import Any
 
 import httpx
-from pydantic import BaseModel
+from pydantic import BaseModel, model_validator
+
+from akgentic.core.messages.message import Message
+from akgentic.core.utils.deserializer import deserialize_object
+
+_log = logging.getLogger(__name__)
 
 # -- CLI-side response models (independent of server models) --
 
@@ -32,8 +38,20 @@ class EventInfo(BaseModel):
 
     team_id: str
     sequence: int
-    event: dict[str, object]
+    event: dict[str, object] | Message
     timestamp: str
+
+    @model_validator(mode="after")
+    def _deserialize_event(self) -> EventInfo:
+        """Deserialize raw event dict into a typed Message if possible."""
+        if isinstance(self.event, dict) and "__model__" in self.event:
+            try:
+                result = deserialize_object(dict(self.event))
+                if isinstance(result, Message):
+                    self.event = result
+            except ValueError:
+                _log.debug("EventInfo: failed to deserialize event dict", exc_info=True)
+        return self
 
 
 class EventListInfo(BaseModel):

--- a/src/akgentic/infra/cli/commands.py
+++ b/src/akgentic/infra/cli/commands.py
@@ -260,11 +260,18 @@ async def _history_handler(args: str, session: ChatSession) -> None:
         session.renderer.render_error(f"Error fetching history: {exc.detail}")
         return
 
-    # Convert EventInfo models to dicts for the rendering pipeline
-    event_dicts = [e.model_dump() for e in events]
-    displayable = [e for e in event_dicts if _is_displayable(e)]
+    # Pass typed Message instances to the rendering pipeline
+    from akgentic.core.messages.message import Message
+    from akgentic.core.messages.orchestrator import ErrorMessage, EventMessage, SentMessage
+
+    displayable = [
+        e.event
+        for e in events
+        if isinstance(e.event, (SentMessage, ErrorMessage, EventMessage))
+    ]
     for evt in displayable[-limit:]:
-        session._render_event(evt)
+        if isinstance(evt, Message):
+            session._render_event(evt)
 
 
 def _is_displayable(data: dict[str, Any]) -> bool:

--- a/src/akgentic/infra/cli/commands.py
+++ b/src/akgentic/infra/cli/commands.py
@@ -8,7 +8,7 @@ import json as json_mod
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 from akgentic.infra.cli.client import ApiError
 from akgentic.infra.cli.ws_client import WsConnectionError
@@ -211,6 +211,8 @@ async def _events_handler(args: str, session: ChatSession) -> None:
 
 async def _agents_handler(args: str, session: ChatSession) -> None:
     """List team members with roles and state."""
+    from akgentic.core.messages.orchestrator import StartMessage
+
     loop = asyncio.get_running_loop()
     try:
         events = await loop.run_in_executor(None, session.client.get_events, session.team_id)
@@ -220,11 +222,9 @@ async def _agents_handler(args: str, session: ChatSession) -> None:
 
     seen: dict[str, str] = {}
     for e in events:
-        evt = e.model_dump().get("event", {})
-        if evt.get("__model__", "").endswith("StartMessage"):
-            sender = evt.get("sender", {})
-            name = sender.get("name", "")
-            role = sender.get("role", "")
+        if isinstance(e.event, StartMessage):
+            name = e.event.config.name
+            role = e.event.config.role
             if name and name != "orchestrator":
                 seen[name] = role
 
@@ -273,20 +273,6 @@ async def _history_handler(args: str, session: ChatSession) -> None:
         if isinstance(evt, Message):
             session._render_event(evt)
 
-
-def _is_displayable(data: dict[str, Any]) -> bool:
-    """Check if an event is displayable (SentMessage or ErrorMessage)."""
-    event = data.get("event", data)
-    if isinstance(event, str):
-        try:
-            event = json_mod.loads(event)
-        except (json_mod.JSONDecodeError, TypeError):
-            return False
-    model = event.get("__model__", "")
-    # Match short suffix from fully qualified model names
-    model = model.rsplit(".", 1)[-1] if model else ""
-    # Keep in sync with repl._DISPLAY_EVENTS
-    return model in {"SentMessage", "ErrorMessage", "EventMessage"}
 
 
 # -- Workspace commands --

--- a/src/akgentic/infra/cli/connection.py
+++ b/src/akgentic/infra/cli/connection.py
@@ -6,10 +6,10 @@ import asyncio
 import time
 from collections.abc import Callable
 from enum import Enum
-from typing import Any
 
 import websockets.exceptions
 
+from akgentic.core.messages.message import Message
 from akgentic.infra.cli.ws_client import WsClient, WsConnectionError
 
 
@@ -95,7 +95,7 @@ class ConnectionManager:
             retryable=False,
         )
 
-    async def receive_event(self) -> dict[str, Any]:
+    async def receive_event(self) -> Message:
         """Read next event. Triggers reconnect on disconnect.
 
         Raises WsConnectionError only after max_retries exhausted.

--- a/src/akgentic/infra/cli/event_router.py
+++ b/src/akgentic/infra/cli/event_router.py
@@ -5,48 +5,21 @@ from __future__ import annotations
 import json
 import logging
 from collections.abc import Callable
-from datetime import datetime
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
+from akgentic.core.messages.message import Message
+from akgentic.core.messages.orchestrator import ErrorMessage, EventMessage, SentMessage
 from akgentic.infra.cli.renderers import RichRenderer
+from akgentic.llm.event import ToolCallEvent, ToolReturnEvent
 
 if TYPE_CHECKING:
     from textual.widget import Widget
 
     from akgentic.infra.cli.tui.colors import AgentColorRegistry
 
-# Event types to display vs skip
-_DISPLAY_EVENTS = {"SentMessage", "ErrorMessage", "EventMessage"}
-
-
-def _extract_timestamp(data: dict[str, Any]) -> str | None:
-    """Extract a HH:MM timestamp from an event dict, trying multiple paths."""
-    try:
-        event = data.get("event", data)
-        if isinstance(event, str):
-            event = json.loads(event)
-        candidates: list[object] = []
-        if isinstance(event, dict):
-            msg = event.get("message", {})
-            if isinstance(msg, dict):
-                candidates.append(msg.get("timestamp"))
-            candidates.append(event.get("timestamp"))
-        candidates.append(data.get("timestamp"))
-        for raw in candidates:
-            if raw is None:
-                continue
-            try:
-                dt = datetime.fromisoformat(str(raw))
-                return dt.strftime("%H:%M")
-            except (ValueError, TypeError, OverflowError):
-                continue
-    except Exception:  # noqa: BLE001
-        pass
-    return None
-
 
 class EventRouter:
-    """Parse raw event dicts and dispatch to the renderer."""
+    """Route typed Message instances and dispatch to the renderer."""
 
     def __init__(
         self,
@@ -59,92 +32,69 @@ class EventRouter:
         self._log = logger or logging.getLogger(__name__)
         self._last_agent_color: str | None = None
 
-    def route(self, data: dict[str, Any]) -> bool:
-        """Parse, classify, and render an event. Returns True if rendered.
+    def route(self, event: Message) -> bool:
+        """Classify and render a typed event. Returns True if rendered.
 
         Malformed events are logged at DEBUG and skipped -- never raised.
         """
         try:
-            return self._route_inner(data)
-        except (KeyError, json.JSONDecodeError, TypeError) as exc:
+            if isinstance(event, SentMessage):
+                return self._handle_sent_message(event)
+            if isinstance(event, ErrorMessage):
+                return self._handle_error_message(event)
+            if isinstance(event, EventMessage):
+                return self._handle_event_message(event)
+            return False
+        except Exception as exc:  # noqa: BLE001
             self._log.debug("Malformed event skipped: %s", exc)
             return False
 
-    def _route_inner(self, data: dict[str, Any]) -> bool:
-        """Core dispatch logic -- classify by __model__ suffix and delegate."""
-        event = data.get("event", data)
-        if isinstance(event, str):
-            event = json.loads(event)
-
-        model = event.get("__model__", "")
-        short_model = model.rsplit(".", 1)[-1] if model else ""
-        if short_model not in _DISPLAY_EVENTS:
-            return False
-
-        if short_model == "ErrorMessage":
-            return self._handle_error_message(event)
-
-        if short_model == "EventMessage":
-            return self._handle_event_message(event, data)
-
-        # SentMessage
-        return self._handle_sent_message(event)
-
-    def _handle_error_message(self, event: dict[str, Any]) -> bool:
+    def _handle_error_message(self, event: ErrorMessage) -> bool:
         """Render an ErrorMessage event."""
-        content = event.get("exception_value", event.get("content", event.get("error", "")))
-        self._renderer.render_error(str(content))
+        self._renderer.render_error(event.exception_value)
         return True
 
-    def _handle_sent_message(self, event: dict[str, Any]) -> bool:
+    def _handle_sent_message(self, event: SentMessage) -> bool:
         """Render a SentMessage -- agent response with sender and content."""
-        raw_sender = event.get("sender", "agent")
-        sender = (
-            raw_sender.get("name", "agent") if isinstance(raw_sender, dict) else str(raw_sender)
-        )
-        message = event.get("message", {})
-        content = message.get("content", "") if isinstance(message, dict) else ""
+        sender_name = event.sender.name if event.sender else "agent"
+        content = getattr(event.message, "content", "")
         if content:
-            self._renderer.render_agent_message(sender, str(content))
+            self._renderer.render_agent_message(sender_name, str(content))
             return True
         return False
 
-    def _handle_event_message(self, event: dict[str, Any], outer_data: dict[str, Any]) -> bool:
+    def _handle_event_message(self, event: EventMessage) -> bool:
         """Handle EventMessage -- inspect nested event for tool calls / human input."""
-        nested = event.get("event", {})
-        if isinstance(nested, str):
-            try:
-                nested = json.loads(nested)
-            except (json.JSONDecodeError, TypeError):
-                return False
+        nested = event.event
 
-        if not isinstance(nested, dict):
-            return False
-
-        nested_model = nested.get("__model__", "")
-
-        if "ToolCallEvent" in nested_model:
+        if isinstance(nested, ToolCallEvent):
             self._handle_tool_call(nested)
             return True
 
-        if "HumanInput" in nested_model or "RequestInput" in nested_model:
-            prompt_text = str(nested.get("prompt", nested.get("content", "Input requested")))
+        if isinstance(nested, ToolReturnEvent):
+            return False
+
+        # Duck-type check for HumanInput / RequestInput
+        if hasattr(nested, "prompt") or hasattr(nested, "content"):
+            prompt_text = str(
+                getattr(nested, "prompt", None) or getattr(nested, "content", "Input requested")
+            )
             self._renderer.render_human_input_request(prompt_text)
             if self._on_human_input is not None:
-                self._notify_human_input(outer_data)
+                self._notify_human_input(event)
             return True
 
         return False
 
-    def _handle_tool_call(self, nested: dict[str, Any]) -> None:
+    def _handle_tool_call(self, tool_event: ToolCallEvent) -> None:
         """Extract and render a tool call event."""
-        tool_name = str(nested["tool_name"])
-        raw_input = nested.get("arguments", nested.get("args", nested.get("input", "")))
+        tool_name = tool_event.tool_name
+        raw_input = tool_event.arguments
         if isinstance(raw_input, dict | list):
             tool_input = json.dumps(raw_input, indent=2)
         else:
             tool_input = str(raw_input)
-        raw_output = nested.get("result")
+        raw_output = getattr(tool_event, "result", None)
         if raw_output is None:
             tool_output = None
         elif isinstance(raw_output, dict | list):
@@ -153,84 +103,62 @@ class EventRouter:
             tool_output = str(raw_output)
         self._renderer.render_tool_call(tool_name, tool_input, tool_output)
 
-    def _notify_human_input(self, outer_data: dict[str, Any]) -> None:
-        """Extract message_id and agent_name from outer event data and invoke callback."""
-        raw_id = outer_data.get("id")
+    def _notify_human_input(self, event: Message) -> None:
+        """Extract message_id and agent_name from the event and invoke callback."""
+        raw_id = str(event.id)
         if not raw_id:
             return
-        message_id = str(raw_id)
-        raw_sender = outer_data.get("sender", "Agent")
-        if isinstance(raw_sender, dict):
-            agent_name = str(raw_sender.get("name", "Agent"))
-        else:
-            agent_name = str(raw_sender)
+        sender_name = event.sender.name if event.sender else "Agent"
         if self._on_human_input is not None:
-            self._on_human_input(message_id, agent_name)
+            self._on_human_input(raw_id, sender_name)
 
     def to_widget(
         self,
-        data: dict[str, Any],
+        event: Message,
         color_registry: AgentColorRegistry,
     ) -> Widget | None:
-        """Parse a raw event dict and return the appropriate Textual widget.
+        """Parse a typed event and return the appropriate Textual widget.
 
         Returns ``None`` for unrecognized or malformed events.
         This method does NOT invoke callbacks or use the renderer -- it is
         a pure event-to-widget translation for TUI usage.
         """
         try:
-            event = data.get("event", data)
-            if isinstance(event, str):
-                event = json.loads(event)
-
-            model = event.get("__model__", "")
-            short_model = model.rsplit(".", 1)[-1] if model else ""
-            if short_model not in _DISPLAY_EVENTS:
-                return None
-
-            timestamp = _extract_timestamp(data)
-
-            if short_model == "ErrorMessage":
+            if isinstance(event, ErrorMessage):
                 return self._error_to_widget(event)
-            if short_model == "SentMessage":
-                return self._sent_to_widget(event, color_registry, timestamp)
-            if short_model == "EventMessage":
+            if isinstance(event, SentMessage):
+                return self._sent_to_widget(event, color_registry)
+            if isinstance(event, EventMessage):
                 return self._event_to_widget(event)
         except Exception as exc:  # noqa: BLE001
             self._log.debug("to_widget: malformed event skipped: %s", exc)
         return None
 
-    def _error_to_widget(self, event: dict[str, Any]) -> Widget:
+    def _error_to_widget(self, event: ErrorMessage) -> Widget:
         """Convert an ErrorMessage event to an ErrorWidget."""
         from akgentic.infra.cli.tui.widgets.error import ErrorWidget
 
-        content = event.get("exception_value", event.get("content", event.get("error", "")))
-        return ErrorWidget(content=str(content))
+        return ErrorWidget(content=event.exception_value)
 
     def _sent_to_widget(
         self,
-        event: dict[str, Any],
+        event: SentMessage,
         color_registry: AgentColorRegistry,
-        timestamp: str | None = None,
     ) -> Widget | None:
         """Convert a SentMessage event to an AgentMessage widget."""
         from akgentic.infra.cli.tui.widgets.agent_message import AgentMessage
 
-        raw_sender = event.get("sender", "agent")
-        sender = (
-            raw_sender.get("name", "agent") if isinstance(raw_sender, dict) else str(raw_sender)
-        )
-        message = event.get("message", {})
-        content = message.get("content", "") if isinstance(message, dict) else ""
+        sender = event.sender.name if event.sender else "agent"
+        content = getattr(event.message, "content", "")
         if not content:
             return None
 
-        raw_recipient = event.get("recipient")
-        recipient: str | None = None
-        if isinstance(raw_recipient, dict):
-            recipient = raw_recipient.get("name")
-        elif isinstance(raw_recipient, str) and raw_recipient:
-            recipient = raw_recipient
+        recipient: str | None = event.recipient.name if event.recipient else None
+
+        timestamp: str | None = None
+        ts = event.message.timestamp or event.timestamp
+        if ts is not None:
+            timestamp = ts.strftime("%H:%M")
 
         color: str = color_registry.get(sender)
         self._last_agent_color = color
@@ -242,40 +170,37 @@ class EventRouter:
             recipient=recipient,
         )
 
-    def _event_to_widget(self, event: dict[str, Any]) -> Widget | None:
+    def _event_to_widget(self, event: EventMessage) -> Widget | None:
         """Convert an EventMessage event to a ToolCallWidget or HumanInputPrompt."""
-        nested = event.get("event", {})
-        if isinstance(nested, str):
-            try:
-                nested = json.loads(nested)
-            except (json.JSONDecodeError, TypeError):
-                return None
-        if not isinstance(nested, dict):
-            return None
+        nested = event.event
 
-        nested_model = nested.get("__model__", "")
-
-        if "ToolCallEvent" in nested_model:
+        if isinstance(nested, ToolCallEvent):
             return self._tool_call_to_widget(nested)
 
-        if "HumanInput" in nested_model or "RequestInput" in nested_model:
+        if isinstance(nested, ToolReturnEvent):
+            return None
+
+        # Duck-type check for HumanInput / RequestInput
+        if hasattr(nested, "prompt") or hasattr(nested, "content"):
             from akgentic.infra.cli.tui.widgets.human_input import HumanInputPrompt
 
-            prompt_text = str(nested.get("prompt", nested.get("content", "Input requested")))
+            prompt_text = str(
+                getattr(nested, "prompt", None) or getattr(nested, "content", "Input requested")
+            )
             return HumanInputPrompt(prompt_text=prompt_text)
         return None
 
-    def _tool_call_to_widget(self, nested: dict[str, Any]) -> Widget:
-        """Convert a tool call nested event to a ToolCallWidget."""
+    def _tool_call_to_widget(self, tool_event: ToolCallEvent) -> Widget:
+        """Convert a ToolCallEvent dataclass to a ToolCallWidget."""
         from akgentic.infra.cli.tui.widgets.tool_call import ToolCallWidget
 
-        tool_name = str(nested["tool_name"])
-        raw_input = nested.get("arguments", nested.get("args", nested.get("input", "")))
+        tool_name = tool_event.tool_name
+        raw_input = tool_event.arguments
         if isinstance(raw_input, dict | list):
             tool_input = json.dumps(raw_input, indent=2)
         else:
             tool_input = str(raw_input)
-        raw_output = nested.get("result")
+        raw_output = getattr(tool_event, "result", None)
         if raw_output is None:
             tool_output = None
         elif isinstance(raw_output, dict | list):

--- a/src/akgentic/infra/cli/repl.py
+++ b/src/akgentic/infra/cli/repl.py
@@ -13,7 +13,8 @@ from prompt_toolkit.completion import Completer, Completion
 from prompt_toolkit.history import InMemoryHistory
 from pydantic import BaseModel
 
-from akgentic.infra.cli.client import ApiClient, ApiError
+from akgentic.core.messages.message import Message
+from akgentic.infra.cli.client import ApiClient, ApiError, EventInfo
 from akgentic.infra.cli.commands import CommandRegistry, build_default_registry
 from akgentic.infra.cli.connection import ConnectionManager, ConnectionState
 from akgentic.infra.cli.event_router import EventRouter
@@ -262,7 +263,7 @@ class ChatSession:
             events = self.client.get_events(self._state.team_id)
         except ApiError:
             return
-        self._display_events([e.model_dump() for e in events])
+        self._display_events(events)
 
     async def replay_history_async(self) -> None:
         """Async version of _replay_history — uses run_in_executor to avoid blocking."""
@@ -271,19 +272,19 @@ class ChatSession:
             events = await loop.run_in_executor(None, self.client.get_events, self._state.team_id)
         except ApiError:
             return
-        self._display_events([e.model_dump() for e in events])
+        self._display_events(events)
 
-    def _display_events(self, events: list[dict[str, Any]]) -> None:
+    def _display_events(self, events: list[EventInfo]) -> None:
         """Render a list of events, adding a history separator if any were displayed."""
         displayed = False
         for evt in events:
-            if self._render_event(evt):
+            if isinstance(evt.event, Message) and self._render_event(evt.event):
                 displayed = True
         if displayed:
             self.renderer.render_history_separator()
 
-    def _render_event(self, data: dict[str, Any]) -> bool:
-        """Format and render a single event. Returns True if something was rendered."""
+    def _render_event(self, event: Message) -> bool:
+        """Format and render a single typed event. Returns True if something was rendered."""
 
         def _set_pending(message_id: str, agent_name: str) -> None:
             self._state = self._state.model_copy(
@@ -296,7 +297,7 @@ class ChatSession:
             )
 
         self._event_router._on_human_input = _set_pending
-        return self._event_router.route(data)
+        return self._event_router.route(event)
 
 
 class _SlashCompleter(Completer):
@@ -324,19 +325,19 @@ class _SlashCompleter(Completer):
 
 
 def _render_event_impl(
-    data: dict[str, Any],
+    event: Message,
     renderer: RichRenderer,
     on_human_input: Callable[[str, str], None] | None = None,
 ) -> bool:
     """Backward-compatible wrapper -- delegates to EventRouter."""
     router = EventRouter(renderer, on_human_input=on_human_input)
-    return router.route(data)
+    return router.route(event)
 
 
 _default_renderer = RichRenderer()
 _default_event_router = EventRouter(_default_renderer)
 
 
-def _print_event(data: dict[str, Any]) -> bool:
+def _print_event(event: Message) -> bool:
     """Backward-compatible module-level event printer."""
-    return _default_event_router.route(data)
+    return _default_event_router.route(event)

--- a/src/akgentic/infra/cli/tui/app.py
+++ b/src/akgentic/infra/cli/tui/app.py
@@ -13,6 +13,7 @@ from textual.containers import Container, VerticalScroll
 from textual.widget import Widget
 from textual.widgets import Static
 
+from akgentic.core.messages.message import Message
 from akgentic.infra.cli.client import ApiError
 from akgentic.infra.cli.connection import ConnectionState
 from akgentic.infra.cli.tui.colors import AgentColorRegistry
@@ -343,8 +344,10 @@ class ChatApp(App[None]):
 
         displayed = False
         for evt in events:
+            if not isinstance(evt.event, Message):
+                continue
             widget = self._event_router.to_widget(
-                evt.model_dump(), self._color_registry
+                evt.event, self._color_registry
             )
             if widget is not None:
                 widget.add_class("history")

--- a/src/akgentic/infra/cli/tui/command_adapter.py
+++ b/src/akgentic/infra/cli/tui/command_adapter.py
@@ -6,7 +6,7 @@ import asyncio
 import io
 import logging
 from contextlib import redirect_stdout
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 from akgentic.infra.cli.client import ApiClient, ApiError
 from akgentic.infra.cli.commands import CommandRegistry
@@ -84,7 +84,7 @@ class _TuiSession:
     def _fetch_team_info(self) -> None:
         """No-op stub -- TUI uses StatusHeader.update_team() instead."""
 
-    def _render_event(self, _data: dict[str, Any]) -> bool:
+    def _render_event(self, _event: object) -> bool:
         """No-op stub -- TUI uses EventRouter.to_widget() instead."""
         return False
 

--- a/src/akgentic/infra/cli/tui/command_adapter.py
+++ b/src/akgentic/infra/cli/tui/command_adapter.py
@@ -13,7 +13,10 @@ from akgentic.infra.cli.commands import CommandRegistry
 from akgentic.infra.cli.renderers import RichRenderer
 
 if TYPE_CHECKING:
+    from akgentic.infra.cli.client import EventInfo
+    from akgentic.infra.cli.event_router import EventRouter
     from akgentic.infra.cli.tui.app import ChatApp
+    from akgentic.infra.cli.tui.colors import AgentColorRegistry
 
 _log = logging.getLogger(__name__)
 
@@ -434,20 +437,12 @@ class TuiCommandAdapter:
 
     async def _handle_history(self, args: str, app: ChatApp) -> bool:
         """Handle /history by fetching events and mounting them as TUI widgets."""
-        limit = 20
-        if args.strip():
-            try:
-                limit = int(args.strip())
-            except ValueError:
-                await self._mount_system(
-                    app, "Usage: /history [N] — N must be a positive integer."
-                )
-                return True
-            if limit <= 0:
-                await self._mount_system(
-                    app, "Usage: /history [N] — N must be a positive integer."
-                )
-                return True
+        limit = self._parse_history_limit(args)
+        if limit is None:
+            await self._mount_system(
+                app, "Usage: /history [N] — N must be a positive integer."
+            )
+            return True
 
         client = app._client  # noqa: SLF001
         if client is None:
@@ -469,22 +464,49 @@ class TuiCommandAdapter:
             await self._mount_system(app, "No event router available for history rendering.")
             return True
 
-        from textual.containers import VerticalScroll
-
-        conversation = app.query_one("#conversation", VerticalScroll)
-        event_dicts = [e.model_dump() for e in events]
-        displayed = 0
-        for evt in event_dicts[-limit:]:
-            widget = event_router.to_widget(evt, color_registry)
-            if widget is not None:
-                await conversation.mount(widget)
-                widget.scroll_visible(animate=False)
-                displayed += 1
-
+        displayed = await self._render_history_events(
+            app, events[-limit:], event_router, color_registry
+        )
         if displayed == 0:
             await self._mount_system(app, "No displayable history events found.")
 
         return True
+
+    @staticmethod
+    def _parse_history_limit(args: str) -> int | None:
+        """Parse the optional limit argument for /history. Returns None on invalid input."""
+        stripped = args.strip()
+        if not stripped:
+            return 20
+        try:
+            value = int(stripped)
+        except ValueError:
+            return None
+        return value if value > 0 else None
+
+    @staticmethod
+    async def _render_history_events(
+        app: ChatApp,
+        events: list[EventInfo],
+        event_router: EventRouter,
+        color_registry: AgentColorRegistry,
+    ) -> int:
+        """Render history events as TUI widgets. Returns count of displayed widgets."""
+        from textual.containers import VerticalScroll
+
+        from akgentic.core.messages.message import Message
+
+        conversation = app.query_one("#conversation", VerticalScroll)
+        displayed = 0
+        for e in events:
+            if not isinstance(e.event, Message):
+                continue
+            widget = event_router.to_widget(e.event, color_registry)
+            if widget is not None:
+                await conversation.mount(widget)
+                widget.scroll_visible(animate=False)
+                displayed += 1
+        return displayed
 
     async def _mount_system(self, app: ChatApp, text: str) -> None:
         """Mount a SystemMessage widget in the conversation area."""

--- a/src/akgentic/infra/cli/ws_client.py
+++ b/src/akgentic/infra/cli/ws_client.py
@@ -3,10 +3,16 @@
 from __future__ import annotations
 
 import json
-from typing import Any
+import logging
+import warnings
 
 import websockets.asyncio.client
 import websockets.exceptions
+
+from akgentic.core.messages.message import Message
+from akgentic.core.utils.deserializer import deserialize_object
+
+_log = logging.getLogger(__name__)
 
 
 class WsConnectionError(Exception):
@@ -28,6 +34,7 @@ class WsClient:
         if api_key:
             self._headers.append(("Authorization", f"Bearer {api_key}"))
         self._ws: websockets.asyncio.client.ClientConnection | None = None
+        self._v1_warned: bool = False
 
     @property
     def url(self) -> str:
@@ -60,13 +67,49 @@ class WsClient:
             ) from exc
         return self
 
-    async def receive_event(self) -> dict[str, Any]:
-        """Read next JSON message from WebSocket."""
+    async def receive_event(self) -> Message:
+        """Read next JSON message from WebSocket and deserialize to a typed Message.
+
+        Returns:
+            Deserialized ``Message`` instance.
+
+        Raises:
+            RuntimeError: If not connected.
+            WsConnectionError: If deserialization fails persistently (event skipped
+                internally; this is only raised by the caller for connection issues).
+        """
         if self._ws is None:
             raise RuntimeError("Not connected")
-        raw = await self._ws.recv()
-        text = raw if isinstance(raw, str) else raw.decode("utf-8")
-        return json.loads(text)  # type: ignore[no-any-return]
+        while True:
+            raw = await self._ws.recv()
+            text = raw if isinstance(raw, str) else raw.decode("utf-8")
+            parsed = json.loads(text)
+
+            # DEPRECATED: V1 dual-format envelope unwrapping — remove when
+            # AngularV1Adapter is retired.
+            if isinstance(parsed, dict) and "payload" in parsed:
+                if not self._v1_warned:
+                    warnings.warn(
+                        "V1 dual-format envelope detected; this path is deprecated",
+                        DeprecationWarning,
+                        stacklevel=2,
+                    )
+                    self._v1_warned = True
+                raw_dict = parsed.get("event", parsed)
+            else:
+                raw_dict = parsed
+
+            try:
+                result = deserialize_object(raw_dict)
+            except ValueError:
+                _log.warning("Skipping malformed event: deserialization failed", exc_info=True)
+                continue
+
+            if not isinstance(result, Message):
+                _log.warning("Skipping event: deserialized to %s, expected Message", type(result))
+                continue
+
+            return result
 
     async def ping(self) -> None:
         """Send a WebSocket ping frame. Raises if not connected."""

--- a/tests/cli/test_cli_commands_insession.py
+++ b/tests/cli/test_cli_commands_insession.py
@@ -39,7 +39,12 @@ from akgentic.infra.cli.commands import (
     build_default_registry,
 )
 from akgentic.infra.cli.ws_client import WsConnectionError
-from tests.fixtures.events import _make_proxy, make_sent_message, make_start_message
+from tests.fixtures.events import (
+    _make_proxy,
+    build_start_message,
+    make_sent_message,
+    make_start_message,
+)
 
 from .conftest import captured_renderer as _captured_renderer
 from .conftest import make_session as _make_session
@@ -470,15 +475,19 @@ class TestEventsHandler:
 
 class TestAgentsHandler:
     async def test_shows_agents_from_events(self, capsys: pytest.CaptureFixture[str]) -> None:
+        from akgentic.core.agent_config import BaseConfig
+
         client = _mock_client()
+        typed_start = build_start_message(
+            config=BaseConfig(name="@Manager", role="Manager"),
+            sender=_make_proxy(name="@Manager", role="Manager"),
+        )
         client.get_events.return_value = [
             EventInfo(
                 team_id="t1",
                 sequence=1,
                 timestamp="2026-01-01T00:00:00",
-                event=make_start_message(
-                    sender=_make_proxy(name="@Manager", role="Manager"),
-                ),
+                event=typed_start,
             ),
         ]
         session = _make_session(client=client)

--- a/tests/cli/test_cli_connection.py
+++ b/tests/cli/test_cli_connection.py
@@ -348,7 +348,8 @@ class TestCheckHealth:
         mock_ws.ping = AsyncMock(side_effect=ConnectionError("dead"))
         cm._ws_client = mock_ws
         cm._state = ConnectionState.CONNECTED
-        cm._last_event_time = 0.0
+        # Ensure the 60s idle threshold is exceeded even on fresh CI runners
+        cm._last_event_time = time.monotonic() - 120.0
 
         cm._reconnect = AsyncMock()  # type: ignore[method-assign]
 

--- a/tests/cli/test_cli_event_router.py
+++ b/tests/cli/test_cli_event_router.py
@@ -1,24 +1,28 @@
-"""Tests for EventRouter -- event routing and dispatch."""
+"""Tests for EventRouter -- typed event routing and dispatch."""
 
 from __future__ import annotations
 
 import logging
+from dataclasses import dataclass
 from typing import Any
 from unittest.mock import MagicMock
 
+from akgentic.core.messages.message import Message
+from akgentic.core.messages.orchestrator import ErrorMessage, EventMessage, SentMessage
 from akgentic.infra.cli.event_router import EventRouter
 from akgentic.infra.cli.tui.colors import AgentColorRegistry
 from akgentic.infra.cli.tui.widgets.agent_message import AgentMessage
 from akgentic.infra.cli.tui.widgets.error import ErrorWidget
 from akgentic.infra.cli.tui.widgets.human_input import HumanInputPrompt
 from akgentic.infra.cli.tui.widgets.tool_call import ToolCallWidget
+from akgentic.llm.event import ToolCallEvent, ToolReturnEvent
 from tests.fixtures.events import (
-    make_error_message,
-    make_event_message,
-    make_sent_message,
-    make_start_message,
-    make_tool_call_event,
-    make_tool_return_event,
+    build_error_message,
+    build_event_message,
+    build_sent_message,
+    build_start_message,
+    build_tool_call_event,
+    build_tool_return_event,
 )
 
 from .conftest import captured_renderer as _captured_renderer
@@ -37,11 +41,17 @@ def _make_router(
     return router, buf
 
 
+# ---------------------------------------------------------------------------
+# route() tests — all accept typed Message instances
+# ---------------------------------------------------------------------------
+
+
 class TestRouteSentMessage:
     def test_valid_sent_message_renders(self) -> None:
         renderer, buf = _captured_renderer()
         router = EventRouter(renderer)
-        result = router.route({"event": make_sent_message(content="hello")})
+        event = build_sent_message(content="hello")
+        result = router.route(event)
         assert result is True
         out = buf.getvalue()
         assert "sender" in out
@@ -50,24 +60,27 @@ class TestRouteSentMessage:
     def test_sent_message_empty_content_returns_false(self) -> None:
         renderer, buf = _captured_renderer()
         router = EventRouter(renderer)
-        result = router.route({"event": make_sent_message(content="")})
+        event = build_sent_message(content="")
+        result = router.route(event)
         assert result is False
 
-    def test_sent_message_dict_sender(self) -> None:
+    def test_sent_message_sender_name_extracted(self) -> None:
         renderer, buf = _captured_renderer()
         router = EventRouter(renderer)
-        result = router.route({"event": make_sent_message(content="from dict sender")})
+        event = build_sent_message(content="from typed sender")
+        result = router.route(event)
         assert result is True
         out = buf.getvalue()
         assert "sender" in out
-        assert "from dict sender" in out
+        assert "from typed sender" in out
 
 
 class TestRouteErrorMessage:
     def test_valid_error_message_renders(self) -> None:
         renderer, buf = _captured_renderer()
         router = EventRouter(renderer)
-        result = router.route({"event": make_error_message(exception_value="something broke")})
+        event = build_error_message(exception_value="something broke")
+        result = router.route(event)
         assert result is True
         out = buf.getvalue()
         assert "error" in out
@@ -78,9 +91,8 @@ class TestRouteToolCall:
     def test_tool_call_renders(self) -> None:
         renderer, buf = _captured_renderer()
         router = EventRouter(renderer)
-        result = router.route(
-            {"event": make_event_message(event=make_tool_call_event(tool_name="search"))}
-        )
+        event = build_event_message(event=build_tool_call_event(tool_name="search"))
+        result = router.route(event)
         assert result is True
         out = buf.getvalue()
         assert "search" in out
@@ -91,37 +103,29 @@ class TestRouteHumanInput:
         renderer, buf = _captured_renderer()
         callback = MagicMock()
         router = EventRouter(renderer, on_human_input=callback)
-        data = {
-            "id": "msg-123",
-            "sender": {"name": "Agent"},
-            "event": {
-                "__model__": "EventMessage",
-                "event": {
-                    "__model__": "HumanInputRequest",
-                    "prompt": "Enter your name",
-                },
-            },
-        }
-        result = router.route(data)
+
+        @dataclass
+        class FakeHumanInput:
+            prompt: str
+
+        event = build_event_message(event=FakeHumanInput(prompt="Enter your name"))
+        result = router.route(event)
         assert result is True
         out = buf.getvalue()
         assert "Human Input Required" in out
         assert "Enter your name" in out
-        callback.assert_called_once_with("msg-123", "Agent")
+        callback.assert_called_once()
 
     def test_human_input_renders_without_callback(self) -> None:
         renderer, buf = _captured_renderer()
         router = EventRouter(renderer, on_human_input=None)
-        data = {
-            "event": {
-                "__model__": "EventMessage",
-                "event": {
-                    "__model__": "HumanInputRequest",
-                    "prompt": "Please provide input",
-                },
-            },
-        }
-        result = router.route(data)
+
+        @dataclass
+        class FakeHumanInput:
+            prompt: str
+
+        event = build_event_message(event=FakeHumanInput(prompt="Please provide input"))
+        result = router.route(event)
         assert result is True
         out = buf.getvalue()
         assert "Human Input Required" in out
@@ -131,48 +135,27 @@ class TestRouteUnknownModel:
     def test_unknown_model_returns_false(self) -> None:
         renderer, buf = _captured_renderer()
         router = EventRouter(renderer)
-        result = router.route({"event": make_start_message()})
+        event = build_start_message()
+        result = router.route(event)
         assert result is False
 
 
 class TestRouteMalformedEvents:
-    def test_missing_model_returns_false(self) -> None:
+    def test_base_message_returns_false(self) -> None:
         renderer, buf = _captured_renderer()
         logger = logging.getLogger("test.event_router")
         router = EventRouter(renderer, logger=logger)
-        result = router.route({"event": {"data": "no model"}})
-        assert result is False
-
-    def test_empty_dict_returns_false(self) -> None:
-        renderer, buf = _captured_renderer()
-        router = EventRouter(renderer)
-        result = router.route({})
+        event = Message()
+        result = router.route(event)
         assert result is False
 
 
-class TestRouteJsonStringEvent:
-    def test_json_string_event_payload(self) -> None:
+class TestRouteToolReturn:
+    def test_tool_return_not_rendered(self) -> None:
         renderer, buf = _captured_renderer()
         router = EventRouter(renderer)
-        import json
-
-        event_payload = json.dumps(
-            {
-                "__model__": "some.module.SentMessage",
-                "sender": "Agent",
-                "message": {"content": "hi"},
-            }
-        )
-        result = router.route({"event": event_payload})
-        assert result is True
-        out = buf.getvalue()
-        assert "hi" in out
-
-    def test_invalid_json_string_returns_false(self) -> None:
-        renderer, buf = _captured_renderer()
-        logger = logging.getLogger("test.event_router")
-        router = EventRouter(renderer, logger=logger)
-        result = router.route({"event": "not valid json {{"})
+        event = build_event_message(event=build_tool_return_event(tool_name="search"))
+        result = router.route(event)
         assert result is False
 
 
@@ -181,170 +164,44 @@ class TestNotifyHumanInput:
         renderer, buf = _captured_renderer()
         callback = MagicMock()
         router = EventRouter(renderer, on_human_input=callback)
-        data = {
-            "id": "msg-456",
-            "sender": {"name": "BotX"},
-            "event": {
-                "__model__": "EventMessage",
-                "event": {
-                    "__model__": "HumanInputRequest",
-                    "prompt": "question?",
-                },
-            },
-        }
-        router.route(data)
-        callback.assert_called_once_with("msg-456", "BotX")
 
-    def test_missing_id_callback_not_invoked(self) -> None:
-        renderer, buf = _captured_renderer()
-        callback = MagicMock()
-        router = EventRouter(renderer, on_human_input=callback)
-        data = {
-            "sender": {"name": "BotX"},
-            "event": {
-                "__model__": "EventMessage",
-                "event": {
-                    "__model__": "HumanInputRequest",
-                    "prompt": "question?",
-                },
-            },
-        }
-        router.route(data)
-        callback.assert_not_called()
+        @dataclass
+        class FakeHumanInput:
+            prompt: str
 
-    def test_none_id_callback_not_invoked(self) -> None:
-        renderer, buf = _captured_renderer()
-        callback = MagicMock()
-        router = EventRouter(renderer, on_human_input=callback)
-        data = {
-            "id": None,
-            "sender": {"name": "BotX"},
-            "event": {
-                "__model__": "EventMessage",
-                "event": {
-                    "__model__": "HumanInputRequest",
-                    "prompt": "question?",
-                },
-            },
-        }
-        router.route(data)
-        callback.assert_not_called()
+        from akgentic.core.actor_address_impl import ActorAddressProxy
 
-    def test_string_sender_extracted(self) -> None:
-        renderer, buf = _captured_renderer()
-        callback = MagicMock()
-        router = EventRouter(renderer, on_human_input=callback)
-        data = {
-            "id": "msg-789",
-            "sender": "SimpleAgent",
-            "event": {
-                "__model__": "EventMessage",
-                "event": {
-                    "__model__": "HumanInputRequest",
-                    "prompt": "q?",
-                },
-            },
-        }
-        router.route(data)
-        callback.assert_called_once_with("msg-789", "SimpleAgent")
+        from tests.fixtures.events import _make_address_dict
+
+        sender = ActorAddressProxy(_make_address_dict(name="BotX"))
+        event = build_event_message(
+            event=FakeHumanInput(prompt="question?"),
+            sender=sender,
+        )
+        router.route(event)
+        callback.assert_called_once()
+        args = callback.call_args[0]
+        assert args[1] == "BotX"
 
 
 class TestToolCallArgFormats:
-    def test_dict_arguments_rendered_as_json(self) -> None:
+    def test_string_arguments_rendered(self) -> None:
         renderer, buf = _captured_renderer()
         router = EventRouter(renderer)
-        data = {
-            "event": {
-                "__model__": "EventMessage",
-                "event": {
-                    "__model__": "akgentic.llm.event.ToolCallEvent",
-                    "tool_name": "search",
-                    "arguments": {"query": "test", "limit": 10},
-                    "result": {"items": ["a", "b"]},
-                },
-            },
-        }
-        result = router.route(data)
+        event = build_event_message(
+            event=build_tool_call_event(
+                tool_name="search",
+                arguments='{"query": "test", "limit": 10}',
+            )
+        )
+        result = router.route(event)
         assert result is True
         out = buf.getvalue()
         assert "search" in out
 
-    def test_list_arguments_rendered_as_json(self) -> None:
-        renderer, buf = _captured_renderer()
-        router = EventRouter(renderer)
-        data = {
-            "event": {
-                "__model__": "EventMessage",
-                "event": {
-                    "__model__": "akgentic.llm.event.ToolCallEvent",
-                    "tool_name": "multi_search",
-                    "arguments": ["query1", "query2"],
-                    "result": None,
-                },
-            },
-        }
-        result = router.route(data)
-        assert result is True
-        out = buf.getvalue()
-        assert "multi_search" in out
-
-
-class TestNestedEventJsonString:
-    def test_nested_event_json_string_parsed(self) -> None:
-        """EventMessage with a JSON-string nested event should be parsed."""
-        import json
-
-        renderer, buf = _captured_renderer()
-        router = EventRouter(renderer)
-        nested = json.dumps(
-            {
-                "__model__": "akgentic.llm.event.ToolCallEvent",
-                "tool_name": "calc",
-                "arguments": "2+2",
-                "result": "4",
-            }
-        )
-        data = {
-            "event": {
-                "__model__": "EventMessage",
-                "event": nested,
-            },
-        }
-        result = router.route(data)
-        assert result is True
-        out = buf.getvalue()
-        assert "calc" in out
-
-    def test_nested_event_invalid_json_string_returns_false(self) -> None:
-        renderer, buf = _captured_renderer()
-        router = EventRouter(renderer)
-        data = {
-            "event": {
-                "__model__": "EventMessage",
-                "event": "not valid json {{",
-            },
-        }
-        result = router.route(data)
-        assert result is False
-
-    def test_nested_event_non_dict_returns_false(self) -> None:
-        """If nested event parses to a non-dict (e.g., list), return False."""
-        import json
-
-        renderer, buf = _captured_renderer()
-        router = EventRouter(renderer)
-        data = {
-            "event": {
-                "__model__": "EventMessage",
-                "event": json.dumps([1, 2, 3]),
-            },
-        }
-        result = router.route(data)
-        assert result is False
-
 
 # ---------------------------------------------------------------------------
-# to_widget() tests
+# to_widget() tests — all accept typed Message instances
 # ---------------------------------------------------------------------------
 
 
@@ -359,67 +216,50 @@ def _make_widget_router() -> tuple[EventRouter, AgentColorRegistry]:
 class TestToWidgetSentMessage:
     def test_returns_agent_message(self) -> None:
         router, registry = _make_widget_router()
-        data = {"event": make_sent_message(content="hello")}
-        widget = router.to_widget(data, registry)
+        event = build_sent_message(content="hello")
+        widget = router.to_widget(event, registry)
         assert isinstance(widget, AgentMessage)
 
     def test_empty_content_returns_none(self) -> None:
         router, registry = _make_widget_router()
-        data = {"event": make_sent_message(content="")}
-        widget = router.to_widget(data, registry)
+        event = build_sent_message(content="")
+        widget = router.to_widget(event, registry)
         assert widget is None
 
     def test_uses_color_registry(self) -> None:
         router, registry = _make_widget_router()
-        data = {"event": make_sent_message(content="hi")}
-        router.to_widget(data, registry)
-        # sender from make_sent_message defaults to "sender"
+        event = build_sent_message(content="hi")
+        router.to_widget(event, registry)
         assert "sender" in registry._map
 
-    def test_recipient_extracted_from_dict(self) -> None:
-        """AC #1/#4: recipient dict is extracted and passed to AgentMessage."""
+    def test_recipient_extracted(self) -> None:
+        """AC #1/#4: recipient is extracted and passed to AgentMessage."""
         router, registry = _make_widget_router()
-        data = {"event": make_sent_message(content="hello")}
-        widget = router.to_widget(data, registry)
+        event = build_sent_message(content="hello")
+        widget = router.to_widget(event, registry)
         assert isinstance(widget, AgentMessage)
-        # make_sent_message default recipient is _make_proxy(name="recipient")
         assert widget._recipient == "recipient"
 
-    def test_recipient_none_when_absent(self) -> None:
-        """AC #3: when recipient is absent, AgentMessage._recipient is None."""
+    def test_recipient_name_extracted(self) -> None:
+        """SentMessage.recipient.name is extracted and passed to AgentMessage."""
         router, registry = _make_widget_router()
-        event = {
-            "__model__": "some.module.SentMessage",
-            "sender": {"name": "@Manager"},
-            "message": {"content": "no recipient here"},
-        }
-        widget = router.to_widget({"event": event}, registry)
+        event = build_sent_message(content="with recipient")
+        widget = router.to_widget(event, registry)
         assert isinstance(widget, AgentMessage)
-        assert widget._recipient is None
-
-    def test_recipient_string_form(self) -> None:
-        """AC #4: recipient as a plain string is extracted."""
-        router, registry = _make_widget_router()
-        event = {
-            "__model__": "some.module.SentMessage",
-            "sender": {"name": "@Manager"},
-            "message": {"content": "with string recipient"},
-            "recipient": "@Developer",
-        }
-        widget = router.to_widget({"event": event}, registry)
-        assert isinstance(widget, AgentMessage)
-        assert widget._recipient == "@Developer"
+        # default recipient is _make_proxy(name="recipient")
+        assert widget._recipient == "recipient"
 
     def test_human_sender_produces_widget(self) -> None:
-        """AC #5: @Human SentMessage events are no longer filtered."""
+        """AC #5: @Human SentMessage events are not filtered."""
+        from tests.fixtures.events import _make_proxy
+
         router, registry = _make_widget_router()
-        event = {
-            "__model__": "some.module.SentMessage",
-            "sender": {"name": "@Human"},
-            "message": {"content": "directed message"},
-            "recipient": {"name": "@Developer"},
-        }
-        widget = router.to_widget({"event": event}, registry)
+        sender = _make_proxy(name="@Human")
+        recipient = _make_proxy(name="@Developer")
+        event = build_sent_message(
+            content="directed message", sender=sender, recipient=recipient
+        )
+        widget = router.to_widget(event, registry)
         assert isinstance(widget, AgentMessage)
         assert widget._sender == "@Human"
         assert widget._recipient == "@Developer"
@@ -428,143 +268,77 @@ class TestToWidgetSentMessage:
 class TestToWidgetErrorMessage:
     def test_returns_error_widget(self) -> None:
         router, registry = _make_widget_router()
-        data = {"event": make_error_message(exception_value="boom")}
-        widget = router.to_widget(data, registry)
+        event = build_error_message(exception_value="boom")
+        widget = router.to_widget(event, registry)
         assert isinstance(widget, ErrorWidget)
 
 
 class TestToWidgetToolCall:
     def test_returns_tool_call_widget(self) -> None:
         router, registry = _make_widget_router()
-        data = {"event": make_event_message(event=make_tool_call_event(tool_name="search"))}
-        widget = router.to_widget(data, registry)
+        event = build_event_message(event=build_tool_call_event(tool_name="search"))
+        widget = router.to_widget(event, registry)
         assert isinstance(widget, ToolCallWidget)
 
-    def test_tool_call_with_dict_args(self) -> None:
+    def test_tool_call_with_string_args(self) -> None:
         router, registry = _make_widget_router()
-        data = {
-            "event": {
-                "__model__": "EventMessage",
-                "event": {
-                    "__model__": "akgentic.llm.event.ToolCallEvent",
-                    "tool_name": "calc",
-                    "arguments": {"x": 1},
-                    "result": {"answer": 42},
-                },
-            },
-        }
-        widget = router.to_widget(data, registry)
+        event = build_event_message(
+            event=build_tool_call_event(tool_name="calc", arguments='{"x": 1}')
+        )
+        widget = router.to_widget(event, registry)
         assert isinstance(widget, ToolCallWidget)
 
     def test_tool_return_event_does_not_produce_widget(self) -> None:
-        """AC #6: ToolReturnEvent must NOT produce a ToolCallWidget (no duplicates)."""
+        """AC #6: ToolReturnEvent must NOT produce a ToolCallWidget."""
         router, registry = _make_widget_router()
-        data = {
-            "event": make_event_message(event=make_tool_return_event(tool_name="search")),
-        }
-        widget = router.to_widget(data, registry)
+        event = build_event_message(event=build_tool_return_event(tool_name="search"))
+        widget = router.to_widget(event, registry)
         assert widget is None
 
     def test_tool_return_event_not_routed(self) -> None:
         """AC #6: ToolReturnEvent must NOT be rendered via route() either."""
         renderer, _buf = _captured_renderer()
         router = EventRouter(renderer)
-        data = {
-            "event": make_event_message(event=make_tool_return_event(tool_name="search")),
-        }
-        result = router.route(data)
+        event = build_event_message(event=build_tool_return_event(tool_name="search"))
+        result = router.route(event)
         assert result is False
 
 
 class TestToWidgetHumanInput:
     def test_returns_human_input_prompt(self) -> None:
         router, registry = _make_widget_router()
-        data = {
-            "event": {
-                "__model__": "EventMessage",
-                "event": {
-                    "__model__": "HumanInputRequest",
-                    "prompt": "Enter name",
-                },
-            },
-        }
-        widget = router.to_widget(data, registry)
+
+        @dataclass
+        class FakeHumanInput:
+            prompt: str
+
+        event = build_event_message(event=FakeHumanInput(prompt="Enter name"))
+        widget = router.to_widget(event, registry)
         assert isinstance(widget, HumanInputPrompt)
 
     def test_request_input_model(self) -> None:
         router, registry = _make_widget_router()
-        data = {
-            "event": {
-                "__model__": "EventMessage",
-                "event": {
-                    "__model__": "RequestInput",
-                    "prompt": "provide data",
-                },
-            },
-        }
-        widget = router.to_widget(data, registry)
+
+        @dataclass
+        class FakeRequestInput:
+            prompt: str
+
+        event = build_event_message(event=FakeRequestInput(prompt="provide data"))
+        widget = router.to_widget(event, registry)
         assert isinstance(widget, HumanInputPrompt)
 
 
 class TestToWidgetUnknown:
     def test_unknown_model_returns_none(self) -> None:
         router, registry = _make_widget_router()
-        data = {"event": make_start_message()}
-        widget = router.to_widget(data, registry)
+        event = build_start_message()
+        widget = router.to_widget(event, registry)
         assert widget is None
-
-
-class TestToWidgetJsonStringEvent:
-    def test_json_string_outer_event(self) -> None:
-        """to_widget handles a JSON-string 'event' field (same as route)."""
-        import json
-
-        router, registry = _make_widget_router()
-        event_payload = json.dumps(
-            {
-                "__model__": "some.module.SentMessage",
-                "sender": "Agent",
-                "message": {"content": "via json string"},
-            }
-        )
-        widget = router.to_widget({"event": event_payload}, registry)
-        assert isinstance(widget, AgentMessage)
-
-    def test_nested_event_json_string_returns_tool_widget(self) -> None:
-        """to_widget handles a JSON-string nested event inside EventMessage."""
-        import json
-
-        router, registry = _make_widget_router()
-        nested = json.dumps(
-            {
-                "__model__": "akgentic.llm.event.ToolCallEvent",
-                "tool_name": "calc",
-                "arguments": "2+2",
-                "result": "4",
-            }
-        )
-        data = {
-            "event": {
-                "__model__": "EventMessage",
-                "event": nested,
-            },
-        }
-        widget = router.to_widget(data, registry)
-        assert isinstance(widget, ToolCallWidget)
 
 
 class TestToWidgetMalformed:
-    def test_empty_dict_returns_none(self) -> None:
+    def test_base_message_returns_none(self) -> None:
         router, registry = _make_widget_router()
-        widget = router.to_widget({}, registry)
-        assert widget is None
-
-    def test_missing_model_returns_none(self) -> None:
-        router, registry = _make_widget_router()
-        widget = router.to_widget({"event": {"data": "no model"}}, registry)
-        assert widget is None
-
-    def test_invalid_json_event_returns_none(self) -> None:
-        router, registry = _make_widget_router()
-        widget = router.to_widget({"event": "not json {{"}, registry)
+        event = Message()
+        widget = router.to_widget(event, registry)
         assert widget is None

--- a/tests/cli/test_cli_repl.py
+++ b/tests/cli/test_cli_repl.py
@@ -6,6 +6,8 @@ import asyncio
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
+from akgentic.core.messages.message import Message
+from akgentic.core.messages.orchestrator import EventMessage
 from akgentic.infra.cli.client import ApiError, EventInfo
 from akgentic.infra.cli.commands import build_default_registry
 from akgentic.infra.cli.connection import ConnectionState
@@ -22,13 +24,13 @@ from akgentic.infra.cli.repl import (
 )
 from akgentic.infra.cli.ws_client import WsConnectionError
 from tests.fixtures.events import (
-    make_error_message,
-    make_event_message,
-    make_processed_message,
-    make_received_message,
+    _make_proxy,
+    build_error_message,
+    build_event_message,
+    build_sent_message,
+    build_start_message,
+    build_tool_call_event,
     make_sent_message,
-    make_start_message,
-    make_tool_call_event,
 )
 
 from .conftest import captured_renderer as _captured_renderer
@@ -61,13 +63,14 @@ def _make_session(
 class TestReplayHistory:
     def test_replay_displays_sent_messages(self) -> None:
         renderer, buf = _captured_renderer()
+        sent_event = build_sent_message(content="hello")
         client = _mock_client(
             get_events=MagicMock(
                 return_value=[
                     EventInfo(
                         team_id="t1",
                         sequence=1,
-                        event=make_sent_message(content="hello"),
+                        event=sent_event,
                         timestamp="2026-01-01T00:00:00",
                     ),
                     EventInfo(
@@ -177,21 +180,21 @@ class TestMessageSending:
 class TestReceiveLoop:
     async def test_renders_sent_message(self) -> None:
         renderer, buf = _captured_renderer()
-        events = [
-            {"event": make_sent_message(content="hi there")},
+        typed_events: list[Message] = [
+            build_sent_message(content="hi there"),
         ]
         client = _mock_client()
         conn = _mock_conn()
         call_count = 0
 
-        async def recv_events() -> dict[str, Any]:
+        async def recv_events() -> Message:
             nonlocal call_count
-            if call_count < len(events):
-                evt = events[call_count]
+            if call_count < len(typed_events):
+                evt = typed_events[call_count]
                 call_count += 1
                 return evt
             await asyncio.sleep(10)
-            return {}
+            return Message()
 
         conn.receive_event = AsyncMock(side_effect=recv_events)
         session = _make_session(client=client, conn=conn, renderer=renderer)
@@ -206,23 +209,23 @@ class TestReceiveLoop:
         assert "sender" in out
         assert "hi there" in out
 
-    async def test_skips_state_changed(self) -> None:
+    async def test_skips_unknown_message(self) -> None:
         renderer, buf = _captured_renderer()
-        events = [
-            {"event": {"__model__": "StateChangedMessage", "state": "running"}},
+        typed_events: list[Message] = [
+            build_start_message(),
         ]
         client = _mock_client()
         conn = _mock_conn()
         call_count = 0
 
-        async def recv_events() -> dict[str, Any]:
+        async def recv_events() -> Message:
             nonlocal call_count
-            if call_count < len(events):
-                evt = events[call_count]
+            if call_count < len(typed_events):
+                evt = typed_events[call_count]
                 call_count += 1
                 return evt
             await asyncio.sleep(10)
-            return {}
+            return Message()
 
         conn.receive_event = AsyncMock(side_effect=recv_events)
         session = _make_session(client=client, conn=conn, renderer=renderer)
@@ -260,7 +263,7 @@ class TestRenderEvent:
     def test_sent_message(self) -> None:
         renderer, buf = _captured_renderer()
         session = _make_session(renderer=renderer)
-        result = session._render_event({"event": make_sent_message(content="reply")})
+        result = session._render_event(build_sent_message(content="reply"))
         assert result is True
         out = buf.getvalue()
         assert "sender" in out
@@ -270,7 +273,7 @@ class TestRenderEvent:
         renderer, buf = _captured_renderer()
         session = _make_session(renderer=renderer)
         result = session._render_event(
-            {"event": make_error_message(exception_value="something broke")}
+            build_error_message(exception_value="something broke")
         )
         assert result is True
         out = buf.getvalue()
@@ -280,80 +283,63 @@ class TestRenderEvent:
     def test_skip_start_message(self) -> None:
         renderer, buf = _captured_renderer()
         session = _make_session(renderer=renderer)
-        result = session._render_event({"event": make_start_message()})
-        assert result is False
-
-    def test_skip_received_message(self) -> None:
-        renderer, buf = _captured_renderer()
-        session = _make_session(renderer=renderer)
-        result = session._render_event({"event": make_received_message()})
-        assert result is False
-
-    def test_skip_processed_message(self) -> None:
-        renderer, buf = _captured_renderer()
-        session = _make_session(renderer=renderer)
-        result = session._render_event({"event": make_processed_message()})
+        result = session._render_event(build_start_message())
         assert result is False
 
     def test_sent_message_no_content(self) -> None:
         renderer, buf = _captured_renderer()
         session = _make_session(renderer=renderer)
-        result = session._render_event({"event": make_sent_message(content="")})
+        result = session._render_event(build_sent_message(content=""))
         assert result is False
 
-    def test_empty_event(self) -> None:
+    def test_base_message_returns_false(self) -> None:
         renderer, buf = _captured_renderer()
         session = _make_session(renderer=renderer)
-        result = session._render_event({})
+        result = session._render_event(Message())
         assert result is False
 
-    def test_sent_message_dict_sender(self) -> None:
-        """Verify renderer extracts sender name from dict-format sender (ActorAddressProxy)."""
+    def test_sent_message_sender_name(self) -> None:
+        """Verify renderer extracts sender name from ActorAddressProxy."""
         renderer, buf = _captured_renderer()
         session = _make_session(renderer=renderer)
-        # make_sent_message produces sender as dict with name/role fields
-        result = session._render_event({"event": make_sent_message(content="from dict sender")})
+        result = session._render_event(build_sent_message(content="from typed sender"))
         assert result is True
         out = buf.getvalue()
-        # Renderer extracts sender.get("name") from the dict-format sender
         assert "sender" in out
-        assert "from dict sender" in out
+        assert "from typed sender" in out
 
     def test_event_message_tool_call(self) -> None:
         renderer, buf = _captured_renderer()
         session = _make_session(renderer=renderer)
         result = session._render_event(
-            {"event": make_event_message(event=make_tool_call_event(tool_name="search"))}
+            build_event_message(event=build_tool_call_event(tool_name="search"))
         )
         assert result is True
         out = buf.getvalue()
         assert "search" in out
 
     def test_event_message_tool_call_with_arguments_field(self) -> None:
-        """Verify renderer handles ToolCallEvent with 'arguments' field (not legacy 'args')."""
+        """Verify renderer handles ToolCallEvent with 'arguments' field."""
         renderer, buf = _captured_renderer()
         session = _make_session(renderer=renderer)
-        # make_tool_call_event produces 'arguments' key (JSON string), not 'args'
         result = session._render_event(
-            {"event": make_event_message(event=make_tool_call_event(tool_name="web_search"))}
+            build_event_message(event=build_tool_call_event(tool_name="web_search"))
         )
         assert result is True
         out = buf.getvalue()
         assert "web_search" in out
 
     def test_event_message_human_input(self) -> None:
+        from dataclasses import dataclass as _dc
+
+        @_dc
+        class _FakeHumanInput:
+            prompt: str
+
         renderer, buf = _captured_renderer()
         session = _make_session(renderer=renderer)
         result = session._render_event(
-            {
-                "event": {
-                    "__model__": "EventMessage",
-                    "event": {
-                        "__model__": "HumanInputRequest",
-                        "prompt": "Enter your name",
-                    },
-                }
-            }
+            build_event_message(event=_FakeHumanInput(prompt="Enter your name"))
         )
         assert result is True
         out = buf.getvalue()
@@ -363,13 +349,9 @@ class TestRenderEvent:
     def test_event_message_unknown_nested(self) -> None:
         renderer, buf = _captured_renderer()
         session = _make_session(renderer=renderer)
+        # Unknown nested event (plain dict, no prompt/content attrs)
         result = session._render_event(
-            {
-                "event": {
-                    "__model__": "EventMessage",
-                    "event": {"__model__": "SomeOtherEvent", "data": "xyz"},
-                }
-            }
+            build_event_message(event={"data": "xyz"})
         )
         assert result is False
 
@@ -378,15 +360,15 @@ class TestPrintEventBackwardCompat:
     """Test the module-level _print_event backward compatibility wrapper."""
 
     def test_sent_message(self) -> None:
-        result = _print_event({"event": make_sent_message(content="reply")})
+        result = _print_event(build_sent_message(content="reply"))
         assert result is True
 
     def test_skip_unknown(self) -> None:
-        result = _print_event({"event": make_start_message()})
+        result = _print_event(build_start_message())
         assert result is False
 
-    def test_empty_event(self) -> None:
-        result = _print_event({})
+    def test_base_message(self) -> None:
+        result = _print_event(Message())
         assert result is False
 
 
@@ -427,50 +409,52 @@ class TestSlashCompleter:
 class TestImplicitHumanInputReplyRouting:
     """Tests for story 10.2: implicit human-input reply routing."""
 
+    @staticmethod
     def _human_input_event(
-        self,
-        message_id: str = "msg-uuid-123",
         agent_name: str = "AgentX",
-        model: str = "HumanInputRequest",
         prompt: str = "What should I do?",
-    ) -> dict[str, Any]:
-        """Build a top-level event dict simulating a HumanInput WS event."""
-        return {
-            "id": message_id,
-            "sender": {"name": agent_name, "role": "helper"},
-            "event": {
-                "__model__": "EventMessage",
-                "event": {
-                    "__model__": model,
-                    "prompt": prompt,
-                },
-            },
-        }
+    ) -> EventMessage:
+        """Build a typed EventMessage simulating a HumanInput WS event."""
+        from dataclasses import dataclass as _dc
+
+        @_dc
+        class _FakeHumanInput:
+            prompt: str
+
+        sender = _make_proxy(name=agent_name)
+        return build_event_message(
+            event=_FakeHumanInput(prompt=prompt),
+            sender=sender,
+        )
 
     # -- AC #1: pending state set on HumanInput event --
 
     def test_pending_set_on_human_input_event(self) -> None:
         renderer, buf = _captured_renderer()
         session = _make_session(renderer=renderer)
-        data = self._human_input_event()
-        session._render_event(data)
+        event = self._human_input_event()
+        session._render_event(event)
         assert session._state.input_mode == InputMode.REPLY
         assert session._state.reply_context is not None
-        assert session._state.reply_context.reply_id == "msg-uuid-123"
         assert session._state.reply_context.agent_name == "AgentX"
 
     def test_pending_set_on_request_input_event(self) -> None:
+        from dataclasses import dataclass as _dc
+
+        @_dc
+        class _FakeRequestInput:
+            prompt: str
+
         renderer, buf = _captured_renderer()
         session = _make_session(renderer=renderer)
-        data = self._human_input_event(
-            model="RequestInputSomething",
-            message_id="req-456",
-            agent_name="BotY",
+        sender = _make_proxy(name="BotY")
+        event = build_event_message(
+            event=_FakeRequestInput(prompt="provide data"),
+            sender=sender,
         )
-        session._render_event(data)
+        session._render_event(event)
         assert session._state.input_mode == InputMode.REPLY
         assert session._state.reply_context is not None
-        assert session._state.reply_context.reply_id == "req-456"
         assert session._state.reply_context.agent_name == "BotY"
 
     # -- AC #2: pending reply state --
@@ -535,7 +519,7 @@ class TestImplicitHumanInputReplyRouting:
             await session.run()
 
         client.human_input.assert_called_once_with("t1", "my answer", "msg-abc")
-        # Pending should still be set — not cleared on error
+        # Pending should still be set -- not cleared on error
         assert session._state.input_mode == InputMode.REPLY
         assert session._state.reply_context is not None
         assert session._state.reply_context.reply_id == "msg-abc"
@@ -585,70 +569,32 @@ class TestImplicitHumanInputReplyRouting:
 
     def test_render_event_impl_without_callback(self) -> None:
         renderer, buf = _captured_renderer()
-        data = self._human_input_event()
-        result = _render_event_impl(data, renderer, on_human_input=None)
+        event = self._human_input_event()
+        result = _render_event_impl(event, renderer, on_human_input=None)
         assert result is True
         out = buf.getvalue()
         assert "Human Input Required" in out
 
-    # -- sender as string fallback --
+    # -- sender name extraction --
 
-    def test_pending_set_with_string_sender(self) -> None:
+    def test_pending_set_with_sender(self) -> None:
+        from dataclasses import dataclass as _dc
+
+        @_dc
+        class _FakeHumanInput:
+            prompt: str
+
         renderer, buf = _captured_renderer()
         session = _make_session(renderer=renderer)
-        data = {
-            "id": "msg-str-sender",
-            "sender": "SimpleAgent",
-            "event": {
-                "__model__": "EventMessage",
-                "event": {
-                    "__model__": "HumanInputRequest",
-                    "prompt": "question?",
-                },
-            },
-        }
-        session._render_event(data)
+        sender = _make_proxy(name="SimpleAgent")
+        event = build_event_message(
+            event=_FakeHumanInput(prompt="question?"),
+            sender=sender,
+        )
+        session._render_event(event)
         assert session._state.input_mode == InputMode.REPLY
         assert session._state.reply_context is not None
-        assert session._state.reply_context.reply_id == "msg-str-sender"
         assert session._state.reply_context.agent_name == "SimpleAgent"
-
-    def test_pending_not_set_when_id_is_none(self) -> None:
-        """Verify that a None id in the outer event data does not set pending state."""
-        renderer, buf = _captured_renderer()
-        session = _make_session(renderer=renderer)
-        data = {
-            "id": None,
-            "sender": {"name": "AgentX"},
-            "event": {
-                "__model__": "EventMessage",
-                "event": {
-                    "__model__": "HumanInputRequest",
-                    "prompt": "question?",
-                },
-            },
-        }
-        session._render_event(data)
-        assert session._state.input_mode == InputMode.CHAT
-        assert session._state.reply_context is None
-
-    def test_pending_not_set_when_id_missing(self) -> None:
-        """Verify that a missing id in the outer event data does not set pending state."""
-        renderer, buf = _captured_renderer()
-        session = _make_session(renderer=renderer)
-        data = {
-            "sender": {"name": "AgentX"},
-            "event": {
-                "__model__": "EventMessage",
-                "event": {
-                    "__model__": "HumanInputRequest",
-                    "prompt": "question?",
-                },
-            },
-        }
-        session._render_event(data)
-        assert session._state.input_mode == InputMode.CHAT
-        assert session._state.reply_context is None
 
 
 

--- a/tests/cli/test_cli_ws_client.py
+++ b/tests/cli/test_cli_ws_client.py
@@ -8,6 +8,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 import websockets.exceptions
 
+from akgentic.core.messages.message import Message
 from akgentic.infra.cli.ws_client import WsClient, WsConnectionError
 
 
@@ -144,23 +145,87 @@ class TestConnect:
 
 
 class TestReceiveEvent:
-    async def test_receive_json(self) -> None:
-        event = {"__model__": "SentMessage", "content": "hello"}
+    async def test_receive_json_returns_message(self) -> None:
+        """receive_event() deserializes JSON string into a typed Message."""
+        raw = {"__model__": "SomeModel", "data": "hello"}
         mock_ws = AsyncMock()
-        mock_ws.recv = AsyncMock(return_value=json.dumps(event))
+        mock_ws.recv = AsyncMock(return_value=json.dumps(raw))
+        mock_msg = MagicMock(spec=Message)
         client = WsClient("http://localhost:8000", "t1")
         client._ws = mock_ws
-        result = await client.receive_event()
-        assert result == event
+        with patch(
+            "akgentic.infra.cli.ws_client.deserialize_object",
+            return_value=mock_msg,
+        ) as mock_deser:
+            result = await client.receive_event()
+        assert result is mock_msg
+        mock_deser.assert_called_once_with(raw)
 
-    async def test_receive_bytes(self) -> None:
-        event = {"__model__": "SentMessage", "content": "hi"}
+    async def test_receive_bytes_returns_message(self) -> None:
+        """receive_event() handles bytes input and returns typed Message."""
+        raw = {"__model__": "SomeModel", "data": "hi"}
         mock_ws = AsyncMock()
-        mock_ws.recv = AsyncMock(return_value=json.dumps(event).encode("utf-8"))
+        mock_ws.recv = AsyncMock(return_value=json.dumps(raw).encode("utf-8"))
+        mock_msg = MagicMock(spec=Message)
         client = WsClient("http://localhost:8000", "t1")
         client._ws = mock_ws
-        result = await client.receive_event()
-        assert result == event
+        with patch(
+            "akgentic.infra.cli.ws_client.deserialize_object",
+            return_value=mock_msg,
+        ):
+            result = await client.receive_event()
+        assert result is mock_msg
+
+    async def test_v1_envelope_unwraps_event_key(self) -> None:
+        """V1 dual-format envelope: extracts 'event' dict before deserializing."""
+        inner = {"__model__": "FQN.SentMessage", "content": "hi"}
+        envelope = {"payload": {"type": "v1-stuff"}, "event": inner}
+        mock_ws = AsyncMock()
+        mock_ws.recv = AsyncMock(return_value=json.dumps(envelope))
+        mock_msg = MagicMock(spec=Message)
+        client = WsClient("http://localhost:8000", "t1")
+        client._ws = mock_ws
+        with patch(
+            "akgentic.infra.cli.ws_client.deserialize_object",
+            return_value=mock_msg,
+        ) as mock_deser:
+            result = await client.receive_event()
+        assert result is mock_msg
+        mock_deser.assert_called_once_with(inner)
+
+    async def test_deserialization_failure_skips_event(self) -> None:
+        """ValueError from deserialize_object skips event and retries."""
+        bad_raw = {"__model__": "Unknown"}
+        good_raw = {"__model__": "Good"}
+        mock_ws = AsyncMock()
+        mock_ws.recv = AsyncMock(
+            side_effect=[json.dumps(bad_raw), json.dumps(good_raw)]
+        )
+        mock_msg = MagicMock(spec=Message)
+        client = WsClient("http://localhost:8000", "t1")
+        client._ws = mock_ws
+        with patch(
+            "akgentic.infra.cli.ws_client.deserialize_object",
+            side_effect=[ValueError("unknown"), mock_msg],
+        ):
+            result = await client.receive_event()
+        assert result is mock_msg
+
+    async def test_non_message_result_skips_event(self) -> None:
+        """If deserialize_object returns a non-Message, event is skipped."""
+        mock_ws = AsyncMock()
+        mock_ws.recv = AsyncMock(
+            side_effect=[json.dumps({"a": 1}), json.dumps({"b": 2})]
+        )
+        mock_msg = MagicMock(spec=Message)
+        client = WsClient("http://localhost:8000", "t1")
+        client._ws = mock_ws
+        with patch(
+            "akgentic.infra.cli.ws_client.deserialize_object",
+            side_effect=["not-a-message", mock_msg],
+        ):
+            result = await client.receive_event()
+        assert result is mock_msg
 
     async def test_receive_not_connected_raises(self) -> None:
         client = WsClient("http://localhost:8000", "t1")

--- a/tests/cli/test_tui_commands.py
+++ b/tests/cli/test_tui_commands.py
@@ -472,17 +472,16 @@ async def test_history_no_events_mounts_message() -> None:
 @pytest.mark.asyncio
 async def test_history_with_events_mounts_widgets() -> None:
     """AC #2: /history with displayable events mounts widgets from EventRouter."""
+    from tests.fixtures.events import build_sent_message
+
     from akgentic.infra.cli.tui.widgets.agent_message import AgentMessage
 
     client = _mock_client()
+    typed_event = build_sent_message(content="hello from history")
     event = EventInfo(
         team_id="t-123",
         sequence=1,
-        event={
-            "__model__": "SentMessage",
-            "sender": {"name": "agent1", "role": "Agent"},
-            "message": {"content": "hello from history"},
-        },
+        event=typed_event,
         timestamp="2026-01-01",
     )
     client.get_events.return_value = [event]

--- a/tests/fixtures/events.py
+++ b/tests/fixtures/events.py
@@ -1,16 +1,21 @@
 """Shared fixture factories for core and LLM event types.
 
-Each factory creates a real model/dataclass instance, then returns
-``model.model_dump()`` (Pydantic) or ``dataclasses.asdict()`` (dataclass).
-This guarantees the dict shape always matches the real serialization contract.
+Each factory creates a real model/dataclass instance. The ``make_*``
+functions return ``model.model_dump()`` dicts (for legacy / API tests).
+The ``build_*`` functions return the real typed instances (for typed
+pipeline tests).
 
 Usage::
 
-    from tests.fixtures.events import make_sent_message
+    from tests.fixtures.events import make_sent_message, build_sent_message
 
-    def test_something():
+    def test_dict_shape():
         event = make_sent_message(content="custom")
         # event is a plain dict matching SentMessage.model_dump()
+
+    def test_typed():
+        event = build_sent_message(content="custom")
+        # event is a SentMessage instance
 """
 
 from __future__ import annotations
@@ -63,16 +68,12 @@ def _make_proxy(**overrides: Any) -> ActorAddressProxy:
 
 
 # ---------------------------------------------------------------------------
-# Core event factories
+# Core event factories (dict output -- legacy)
 # ---------------------------------------------------------------------------
 
 
 def make_sent_message(**overrides: Any) -> dict[str, Any]:
-    """Create a ``SentMessage`` fixture dict from a real model instance.
-
-    The inner ``message`` defaults to a ``UserMessage`` with ``content``
-    taken from *overrides* (default ``"Hello from test"``).
-    """
+    """Create a ``SentMessage`` fixture dict from a real model instance."""
     content = overrides.pop("content", "Hello from test")
     inner = overrides.pop("message", UserMessage(content=content))
     recipient = overrides.pop("recipient", _make_proxy(name="recipient"))
@@ -134,16 +135,12 @@ def make_processed_message(**overrides: Any) -> dict[str, Any]:
 
 
 # ---------------------------------------------------------------------------
-# LLM event factories (dataclasses → dataclasses.asdict)
+# LLM event factories (dataclasses -> dataclasses.asdict)
 # ---------------------------------------------------------------------------
 
 
 def make_tool_call_event(**overrides: Any) -> dict[str, Any]:
-    """Create a ``ToolCallEvent`` fixture dict from a real dataclass instance.
-
-    Adds ``__model__`` to match the real serialization contract
-    (``akgentic.core.utils.serializer.serialize`` adds it for dataclasses).
-    """
+    """Create a ``ToolCallEvent`` fixture dict from a real dataclass instance."""
     defaults: dict[str, Any] = {
         "run_id": "run-001",
         "tool_name": "test_tool",
@@ -157,10 +154,7 @@ def make_tool_call_event(**overrides: Any) -> dict[str, Any]:
 
 
 def make_tool_return_event(**overrides: Any) -> dict[str, Any]:
-    """Create a ``ToolReturnEvent`` fixture dict from a real dataclass instance.
-
-    Adds ``__model__`` to match the real serialization contract.
-    """
+    """Create a ``ToolReturnEvent`` fixture dict from a real dataclass instance."""
     defaults: dict[str, Any] = {
         "run_id": "run-001",
         "tool_name": "test_tool",
@@ -187,3 +181,76 @@ def make_llm_usage_event(**overrides: Any) -> dict[str, Any]:
     }
     defaults.update(overrides)
     return dataclasses.asdict(LlmUsageEvent(**defaults))
+
+
+# ---------------------------------------------------------------------------
+# Typed instance factories (for typed pipeline tests)
+# ---------------------------------------------------------------------------
+
+
+def build_sent_message(**overrides: Any) -> SentMessage:
+    """Create a ``SentMessage`` typed instance."""
+    content = overrides.pop("content", "Hello from test")
+    inner = overrides.pop("message", UserMessage(content=content))
+    recipient = overrides.pop("recipient", _make_proxy(name="recipient"))
+    sender = overrides.pop("sender", _make_proxy(name="sender"))
+    defaults: dict[str, Any] = {
+        "message": inner,
+        "recipient": recipient,
+        "sender": sender,
+    }
+    defaults.update(overrides)
+    return SentMessage(**defaults)
+
+
+def build_error_message(**overrides: Any) -> ErrorMessage:
+    """Create an ``ErrorMessage`` typed instance."""
+    defaults: dict[str, Any] = {
+        "exception_type": "ValueError",
+        "exception_value": "something went wrong",
+    }
+    defaults.update(overrides)
+    return ErrorMessage(**defaults)
+
+
+def build_event_message(**overrides: Any) -> EventMessage:
+    """Create an ``EventMessage`` typed instance."""
+    defaults: dict[str, Any] = {
+        "event": overrides.pop("event", {"type": "test-event", "data": "sample"}),
+    }
+    defaults.update(overrides)
+    return EventMessage(**defaults)
+
+
+def build_start_message(**overrides: Any) -> StartMessage:
+    """Create a ``StartMessage`` typed instance."""
+    config = overrides.pop("config", BaseConfig(name="test-agent", role="tester"))
+    defaults: dict[str, Any] = {
+        "config": config,
+    }
+    defaults.update(overrides)
+    return StartMessage(**defaults)
+
+
+def build_tool_call_event(**overrides: Any) -> ToolCallEvent:
+    """Create a ``ToolCallEvent`` typed instance."""
+    defaults: dict[str, Any] = {
+        "run_id": "run-001",
+        "tool_name": "test_tool",
+        "tool_call_id": "call-001",
+        "arguments": '{"key": "value"}',
+    }
+    defaults.update(overrides)
+    return ToolCallEvent(**defaults)
+
+
+def build_tool_return_event(**overrides: Any) -> ToolReturnEvent:
+    """Create a ``ToolReturnEvent`` typed instance."""
+    defaults: dict[str, Any] = {
+        "run_id": "run-001",
+        "tool_name": "test_tool",
+        "tool_call_id": "call-001",
+        "success": True,
+    }
+    defaults.update(overrides)
+    return ToolReturnEvent(**defaults)

--- a/tests/integration/test_repl_e2e.py
+++ b/tests/integration/test_repl_e2e.py
@@ -18,6 +18,7 @@ import time
 
 import pytest
 
+from akgentic.core.messages.message import Message
 from akgentic.infra.cli.client import ApiClient
 from akgentic.infra.cli.commands import (
     _create_handler,
@@ -111,7 +112,7 @@ def _cleanup_team(server_url: str, team_id: str) -> None:
 async def _wait_for_ws_event(
     conn: ConnectionManager | WsClient,
     timeout: float = POLL_TIMEOUT_S,
-) -> dict[str, object]:
+) -> object:
     """Wait for a single WebSocket event with timeout."""
     return await asyncio.wait_for(conn.receive_event(), timeout=timeout)
 
@@ -158,7 +159,7 @@ class TestStateTransitionWS:
                 session.client.send_message(team_id, "hello")
                 event = await _wait_for_ws_event(session.conn)
                 assert event is not None
-                assert isinstance(event, dict)
+                assert isinstance(event, Message)
         finally:
             _cleanup_team(smoke_server, team_id)
 

--- a/tests/integration/test_smoke.py
+++ b/tests/integration/test_smoke.py
@@ -15,6 +15,8 @@ import pytest
 from fastapi.testclient import TestClient
 from rich.console import Console
 
+from akgentic.core.messages.message import Message
+from akgentic.core.utils.deserializer import deserialize_object
 from akgentic.infra.cli.renderers import RichRenderer
 from akgentic.infra.cli.repl import _render_event_impl
 
@@ -144,7 +146,9 @@ def test_smoke_send_message_receive_response(smoke_client: TestClient) -> None:
         buf = _StringCapture()
         console = Console(file=buf, highlight=False, force_terminal=True)
         renderer = RichRenderer(console=console)
-        rendered = _render_event_impl(ev, renderer)
+        typed_event = deserialize_object(ev["event"])
+        assert isinstance(typed_event, Message), "Deserialized event must be a Message"
+        rendered = _render_event_impl(typed_event, renderer)
         assert rendered is True, "_render_event_impl should return True for SentMessage"
         rendered_text = buf.getvalue()
         assert "@Manager" in rendered_text, "Rendered output must contain @Manager"
@@ -213,10 +217,16 @@ def test_smoke_history_renders_messages(smoke_client: TestClient) -> None:
         # Render each event through _render_event_impl and capture output
         rendered_outputs: list[str] = []
         for ev in events:
+            try:
+                typed_event = deserialize_object(ev["event"])
+            except (ValueError, KeyError):
+                continue
+            if not isinstance(typed_event, Message):
+                continue
             buf = _StringCapture()
             console = Console(file=buf, highlight=False, force_terminal=True)
             renderer = RichRenderer(console=console)
-            was_rendered = _render_event_impl(ev, renderer)
+            was_rendered = _render_event_impl(typed_event, renderer)
             if was_rendered:
                 rendered_outputs.append(buf.getvalue())
 


### PR DESCRIPTION
## Summary

- Deserializes WebSocket events into typed `Message` models at the boundary (`WsClient.receive_event()`)
- Replaces all `dict[str, Any]` event handling and `__model__` string matching in the CLI pipeline with `isinstance()` dispatch and typed attribute access
- Updates `EventRouter`, `ConnectionManager`, `ApiClient.EventInfo`, `ChatApp`, and REPL to work with typed models end-to-end
- Marks V1 dual-format envelope unwrapping as `@deprecated` with `warnings.warn()`
- Code review fixes: removed dead `_is_displayable()` function, rewrote `_agents_handler` to use typed `StartMessage` dispatch, cleaned unused `Any` imports

Closes #171

## Test plan

- [x] All 1018 unit tests pass (89.20% coverage)
- [x] Ruff lint clean
- [x] Mypy strict mode clean
- [x] CI pipeline green