### PR TITLE
Shutdown settings on ServerSettings

### DIFF
--- a/src/akgentic/infra/server/settings.py
+++ b/src/akgentic/infra/server/settings.py
@@ -59,10 +59,12 @@ class ServerSettings(BaseSettings):
     )
     shutdown_drain_timeout: int = Field(
         default=30,
+        ge=0,
         description="Max seconds for stop_all() to complete during graceful shutdown",
     )
     shutdown_pre_drain_delay: int = Field(
         default=0,
+        ge=0,
         description=(
             "Seconds to wait after marking draining before starting teardown "
             "(0 for standalone, 5-10 for LB deployments)"

--- a/tests/server/models/test_server_settings.py
+++ b/tests/server/models/test_server_settings.py
@@ -277,11 +277,13 @@ class TestCommunitySettingsDefaults:
         assert settings.catalog_path == Path("data/catalog")
 
     def test_inherits_base_fields(self) -> None:
-        """CommunitySettings inherits host, port, cors_origins from ServerSettings."""
+        """CommunitySettings inherits host, port, cors_origins, shutdown fields."""
         settings = CommunitySettings()
         assert settings.host == "0.0.0.0"
         assert settings.port == 8000
         assert settings.cors_origins == ["*"]
+        assert settings.shutdown_drain_timeout == 30
+        assert settings.shutdown_pre_drain_delay == 0
 
     def test_event_store_path_from_env(self) -> None:
         """AKGENTIC_EVENT_STORE_PATH overrides event_store_path field."""
@@ -366,3 +368,17 @@ class TestShutdownSettings:
         fields = ServerSettings.model_fields
         assert fields["shutdown_drain_timeout"].description is not None
         assert fields["shutdown_pre_drain_delay"].description is not None
+
+    def test_shutdown_drain_timeout_rejects_negative(self) -> None:
+        """shutdown_drain_timeout rejects negative values (ge=0 constraint)."""
+        from pydantic import ValidationError
+
+        with pytest.raises(ValidationError, match="shutdown_drain_timeout"):
+            ServerSettings(shutdown_drain_timeout=-1)
+
+    def test_shutdown_pre_drain_delay_rejects_negative(self) -> None:
+        """shutdown_pre_drain_delay rejects negative values (ge=0 constraint)."""
+        from pydantic import ValidationError
+
+        with pytest.raises(ValidationError, match="shutdown_pre_drain_delay"):
+            ServerSettings(shutdown_pre_drain_delay=-1)


### PR DESCRIPTION
## Summary

- Add `shutdown_drain_timeout: int = 30` and `shutdown_pre_drain_delay: int = 0` fields to `ServerSettings` with `ge=0` validation constraints
- Both fields loadable from environment variables via `AKGENTIC_` prefix pattern
- Updated field-set assertion test; added 7 new tests covering defaults, env overrides, descriptions, and negative value rejection

## Review Fixes Applied

- Added `ge=0` constraint on both shutdown fields to reject negative values
- Added tests for negative value rejection
- Extended CommunitySettings inheritance test to verify shutdown fields are inherited

Closes #186