### PR TITLE
Clear thinking state on disconnect and team switch

### DIFF
--- a/src/akgentic/infra/cli/tui/app.py
+++ b/src/akgentic/infra/cli/tui/app.py
@@ -281,6 +281,7 @@ class ChatApp(App[None]):
 
     def _clear_conversation(self) -> None:
         """Clear conversation area and reset related state for team switch."""
+        self._pending_messages.clear()
         conversation = self.query_one("#conversation", VerticalScroll)
         conversation.remove_children()
         self._color_registry.reset()
@@ -324,6 +325,7 @@ class ChatApp(App[None]):
             except WsConnectionError as exc:
                 _log.debug("WS connection error in stream loop: %s", exc)
                 self._remove_thinking_indicator(conversation)
+                self._pending_messages.clear()
                 break
 
         from akgentic.infra.cli.tui.widgets.system_message import SystemMessage

--- a/src/akgentic/infra/cli/tui/app.py
+++ b/src/akgentic/infra/cli/tui/app.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import uuid
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -12,6 +13,7 @@ from textual.containers import Container, VerticalScroll
 from textual.widget import Widget
 from textual.widgets import Static
 
+from akgentic.core.messages.orchestrator import ProcessedMessage, ReceivedMessage
 from akgentic.infra.cli.client import ApiError
 from akgentic.infra.cli.connection import ConnectionState
 from akgentic.infra.cli.tui.colors import AgentColorRegistry
@@ -62,6 +64,7 @@ class ChatApp(App[None]):
         self._client = client
         self._color_registry = AgentColorRegistry()
         self._tui_adapter = TuiCommandAdapter(command_registry) if command_registry else None
+        self._pending_messages: dict[uuid.UUID, str] = {}
 
     def compose(self) -> ComposeResult:
         """Compose the four-zone layout."""
@@ -257,10 +260,14 @@ class ChatApp(App[None]):
         widget: Widget,
         conversation: VerticalScroll,
     ) -> None:
-        """Mount an event widget with scroll-aware unread tracking."""
-        self._remove_thinking_indicator(conversation)
+        """Mount an event widget with remove-and-remount thinking indicator cycle."""
+        is_thinking = len(self._pending_messages) > 0
+        if is_thinking:
+            self._remove_thinking_indicator(conversation)
         at_bottom = self._is_at_bottom(conversation)
         await conversation.mount(widget)
+        if is_thinking:
+            await self._mount_thinking_indicator(conversation)
         if at_bottom:
             widget.scroll_visible(animate=False)
         else:
@@ -304,6 +311,12 @@ class ChatApp(App[None]):
             try:
                 event_data = await self._connection_manager.receive_event()
                 _log.debug("WS event received: %s", event_data)
+                if isinstance(event_data, ReceivedMessage):
+                    await self._on_received_message(event_data, conversation)
+                    continue
+                if isinstance(event_data, ProcessedMessage):
+                    self._on_processed_message(event_data, conversation)
+                    continue
                 widget = self._event_router.to_widget(event_data, self._color_registry)
                 _log.debug("to_widget result: %s", type(widget).__name__ if widget else None)
                 if widget is not None:
@@ -327,6 +340,45 @@ class ChatApp(App[None]):
         for indicator in indicators:
             indicator.remove()
 
+    async def _on_received_message(
+        self, msg: ReceivedMessage, conversation: VerticalScroll
+    ) -> None:
+        """Handle ReceivedMessage telemetry -- track pending agent processing."""
+        agent_name = msg.sender.name if msg.sender else "Agent"
+        was_empty = len(self._pending_messages) == 0
+        self._pending_messages[msg.message_id] = agent_name
+        if was_empty:
+            await self._mount_thinking_indicator(conversation)
+        else:
+            self._update_thinking_indicator()
+
+    def _on_processed_message(
+        self, msg: ProcessedMessage, conversation: VerticalScroll
+    ) -> None:
+        """Handle ProcessedMessage telemetry -- remove pending agent processing."""
+        self._pending_messages.pop(msg.message_id, None)
+        if not self._pending_messages:
+            self._remove_thinking_indicator(conversation)
+        else:
+            self._update_thinking_indicator()
+
+    async def _mount_thinking_indicator(self, conversation: VerticalScroll) -> None:
+        """Mount a ThinkingIndicator at the bottom of the conversation."""
+        from akgentic.infra.cli.tui.widgets.thinking import ThinkingIndicator
+
+        indicator = ThinkingIndicator()
+        indicator.update_agents(list(self._pending_messages.values()))
+        await conversation.mount(indicator)
+        indicator.scroll_visible(animate=False)
+
+    def _update_thinking_indicator(self) -> None:
+        """Update the displayed agent names on the existing ThinkingIndicator."""
+        from akgentic.infra.cli.tui.widgets.thinking import ThinkingIndicator
+
+        indicators = self.query(ThinkingIndicator)
+        if indicators:
+            indicators[0].update_agents(list(self._pending_messages.values()))
+
     async def on_chat_input_submitted(self, event: ChatInput.Submitted) -> None:
         """Handle user message submission."""
         text = event.text
@@ -341,13 +393,6 @@ class ChatApp(App[None]):
         welcome_nodes = conversation.query("#welcome, .welcome-msg")
         for node in welcome_nodes:
             node.remove()
-
-        # Mount ThinkingIndicator
-        from akgentic.infra.cli.tui.widgets.thinking import ThinkingIndicator
-
-        indicator = ThinkingIndicator()
-        await conversation.mount(indicator)
-        indicator.scroll_visible(animate=False)
 
         # Parse @mention for directed messages
         agent_name: str | None = None

--- a/src/akgentic/infra/cli/tui/widgets/thinking.py
+++ b/src/akgentic/infra/cli/tui/widgets/thinking.py
@@ -25,8 +25,10 @@ class ThinkingIndicator(Static):
         self._agent_names: list[str] = []
 
     def update_agents(self, agent_names: list[str]) -> None:
-        """Update the list of agents currently thinking."""
+        """Update the list of agents currently thinking and refresh display."""
         self._agent_names = agent_names
+        frame = self._FRAMES[self._frame_idx]
+        self.update(Text(f"{frame} {self._format_agent_names()}", style="dim italic"))
 
     def _format_agent_names(self) -> str:
         """Format agent names into a human-readable thinking message."""

--- a/src/akgentic/infra/cli/tui/widgets/thinking.py
+++ b/src/akgentic/infra/cli/tui/widgets/thinking.py
@@ -22,6 +22,20 @@ class ThinkingIndicator(Static):
     def __init__(self) -> None:
         super().__init__(Text(f"{self._FRAMES[0]} Agent is thinking...", style="dim italic"))
         self._frame_idx: int = 0
+        self._agent_names: list[str] = []
+
+    def update_agents(self, agent_names: list[str]) -> None:
+        """Update the list of agents currently thinking."""
+        self._agent_names = agent_names
+
+    def _format_agent_names(self) -> str:
+        """Format agent names into a human-readable thinking message."""
+        if not self._agent_names:
+            return "Agent is thinking..."
+        cleaned = [f"@{n.lstrip('@')}" for n in self._agent_names]
+        if len(cleaned) == 1:
+            return f"{cleaned[0]} is thinking..."
+        return f"{', '.join(cleaned[:-1])} and {cleaned[-1]} are thinking..."
 
     def on_mount(self) -> None:
         """Start the animation timer when mounted."""
@@ -31,4 +45,4 @@ class ThinkingIndicator(Static):
         """Advance to the next spinner frame."""
         self._frame_idx = (self._frame_idx + 1) % len(self._FRAMES)
         frame = self._FRAMES[self._frame_idx]
-        self.update(Text(f"{frame} Agent is thinking...", style="dim italic"))
+        self.update(Text(f"{frame} {self._format_agent_names()}", style="dim italic"))

--- a/tests/cli/test_tui_streaming.py
+++ b/tests/cli/test_tui_streaming.py
@@ -1,7 +1,8 @@
-"""Pilot tests for WebSocket streaming worker, ThinkingIndicator, and connection state."""
+"""Pilot tests for WebSocket streaming, ThinkingIndicator, connection state, and state cleanup."""
 
 from __future__ import annotations
 
+import asyncio
 import uuid
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock
@@ -374,8 +375,6 @@ async def test_welcome_removed_on_first_message() -> None:
 @pytest.mark.asyncio
 async def test_thinking_indicator_shown_on_received_message() -> None:
     """ThinkingIndicator appears when ReceivedMessage event arrives (AC #1, #2, #5)."""
-    import asyncio
-
     msg_id = uuid.uuid4()
     received = ReceivedMessage(message_id=msg_id, sender=_fake_sender("Assistant"))
 
@@ -418,8 +417,6 @@ async def test_thinking_indicator_shown_on_received_message() -> None:
 @pytest.mark.asyncio
 async def test_thinking_indicator_hidden_on_processed_message() -> None:
     """ThinkingIndicator appears on ReceivedMessage, disappears on ProcessedMessage."""
-    import asyncio
-
     msg_id = uuid.uuid4()
     received = ReceivedMessage(message_id=msg_id, sender=_fake_sender("Assistant"))
     processed = ProcessedMessage(message_id=msg_id, sender=_fake_sender("Assistant"))
@@ -469,8 +466,6 @@ async def test_thinking_indicator_hidden_on_processed_message() -> None:
 @pytest.mark.asyncio
 async def test_thinking_indicator_stays_for_multi_agent() -> None:
     """Indicator stays while any agent is still processing (AC #7, #8)."""
-    import asyncio
-
     msg_id_1 = uuid.uuid4()
     msg_id_2 = uuid.uuid4()
     received_1 = ReceivedMessage(message_id=msg_id_1, sender=_fake_sender("Assistant"))
@@ -528,8 +523,6 @@ async def test_thinking_indicator_stays_for_multi_agent() -> None:
 @pytest.mark.asyncio
 async def test_thinking_indicator_always_below_response() -> None:
     """Indicator re-mounts below the response widget during remove-and-remount (AC #7)."""
-    import asyncio
-
     msg_id = uuid.uuid4()
     received = ReceivedMessage(message_id=msg_id, sender=_fake_sender("Assistant"))
 
@@ -686,8 +679,6 @@ async def test_thinking_indicator_format_strips_at_prefix() -> None:
 @pytest.mark.asyncio
 async def test_team_switch_clears_thinking_state() -> None:
     """_clear_conversation() clears _pending_messages and ThinkingIndicator (AC #1, #4)."""
-    import asyncio
-
     msg_id = uuid.uuid4()
     received = ReceivedMessage(message_id=msg_id, sender=_fake_sender("Assistant"))
 
@@ -719,7 +710,7 @@ async def test_team_switch_clears_thinking_state() -> None:
         # Indicator should be mounted and pending dict non-empty
         indicators = pilot.app.query(ThinkingIndicator)
         assert len(indicators) == 1, "ThinkingIndicator must be present before clear"
-        assert len(pilot.app._pending_messages) > 0
+        assert msg_id in pilot.app._pending_messages
 
         # Simulate team switch: call _clear_conversation() directly
         pilot.app._clear_conversation()
@@ -742,8 +733,6 @@ async def test_team_switch_clears_thinking_state() -> None:
 @pytest.mark.asyncio
 async def test_disconnect_clears_thinking_state() -> None:
     """Disconnect clears _pending_messages and ThinkingIndicator (AC #2, #3, #4)."""
-    import asyncio
-
     msg_id = uuid.uuid4()
     received = ReceivedMessage(message_id=msg_id, sender=_fake_sender("Assistant"))
 

--- a/tests/cli/test_tui_streaming.py
+++ b/tests/cli/test_tui_streaming.py
@@ -2,11 +2,14 @@
 
 from __future__ import annotations
 
+import uuid
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
+from akgentic.core.actor_address import ActorAddress
+from akgentic.core.messages.orchestrator import ProcessedMessage, ReceivedMessage
 from akgentic.infra.cli.connection import ConnectionState
 from akgentic.infra.cli.tui.app import ChatApp
 from akgentic.infra.cli.tui.messages import ConnectionStateChanged
@@ -16,6 +19,57 @@ from akgentic.infra.cli.tui.widgets.status_header import StatusHeader
 from akgentic.infra.cli.tui.widgets.system_message import SystemMessage
 from akgentic.infra.cli.tui.widgets.thinking import ThinkingIndicator
 from akgentic.infra.cli.ws_client import WsConnectionError
+
+
+class FakeAddress(ActorAddress):
+    """Minimal concrete ActorAddress for test construction."""
+
+    def __init__(self, name: str) -> None:
+        self._name = name
+        self._id = uuid.uuid4()
+
+    @property
+    def agent_id(self) -> uuid.UUID:
+        return self._id
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    @property
+    def role(self) -> str:
+        return "test"
+
+    @property
+    def team_id(self) -> uuid.UUID:
+        return self._id
+
+    @property
+    def squad_id(self) -> uuid.UUID | None:
+        return None
+
+    def send(self, recipient: ActorAddress, message: Any) -> None:
+        pass
+
+    def stop(self) -> None:
+        pass
+
+    def is_alive(self) -> bool:
+        return True
+
+    def handle_user_message(self) -> bool:
+        return False
+
+    def serialize(self) -> Any:
+        return {"name": self._name}
+
+    def __repr__(self) -> str:
+        return f"FakeAddress({self._name})"
+
+
+def _fake_sender(name: str) -> FakeAddress:
+    """Create a FakeAddress with the given name."""
+    return FakeAddress(name)
 
 
 def _make_app(
@@ -51,8 +105,8 @@ async def test_thinking_indicator_renders() -> None:
 
 
 @pytest.mark.asyncio
-async def test_thinking_indicator_mounted_on_send() -> None:
-    """ThinkingIndicator is mounted when user sends a message."""
+async def test_no_thinking_indicator_on_send() -> None:
+    """ThinkingIndicator is NOT mounted on send -- indicator now appears via telemetry only."""
     app = _make_app()
     async with app.run_test(size=(80, 24)) as pilot:
         await pilot.pause()
@@ -61,7 +115,7 @@ async def test_thinking_indicator_mounted_on_send() -> None:
         await pilot.press("enter")
         await pilot.pause()
         indicators = pilot.app.query(ThinkingIndicator)
-        assert len(indicators) == 1
+        assert len(indicators) == 0
 
 
 @pytest.mark.asyncio
@@ -79,62 +133,28 @@ async def test_no_thinking_indicator_on_slash_command() -> None:
 
 
 @pytest.mark.asyncio
-async def test_thinking_indicator_removed_on_response() -> None:
-    """ThinkingIndicator is removed when first response widget is mounted."""
-    import asyncio
-
-    # Use an event to delay the first receive_event until ThinkingIndicator is mounted
-    gate = asyncio.Event()
-
-    async def _receive_event_delayed() -> dict[str, Any]:
-        # Wait until the test signals that the user message was sent
-        await gate.wait()
-        gate.clear()
-        return {
-            "event": {
-                "__model__": "SentMessage",
-                "sender": "bot",
-                "message": {"content": "hi"},
-            }
-        }
-
-    call_count = 0
-
-    async def _receive_side_effect() -> dict[str, Any]:
-        nonlocal call_count
-        call_count += 1
-        if call_count == 1:
-            return await _receive_event_delayed()
-        raise WsConnectionError("done", retryable=False)
+async def test_thinking_indicator_removed_on_processed() -> None:
+    """ThinkingIndicator removed when ProcessedMessage arrives after ReceivedMessage."""
+    msg_id = uuid.uuid4()
+    received = ReceivedMessage(message_id=msg_id, sender=_fake_sender("Assistant"))
+    processed = ProcessedMessage(message_id=msg_id, sender=_fake_sender("Assistant"))
 
     mock_cm = MagicMock()
     mock_cm._on_state_change = None
-    mock_cm.receive_event = AsyncMock(side_effect=_receive_side_effect)
+    mock_cm.receive_event = AsyncMock(
+        side_effect=[received, processed, WsConnectionError("done", retryable=False)]
+    )
 
     mock_router = MagicMock()
-    agent_msg = AgentMessage(sender="bot", content="hi", color="cyan")
-    mock_router.to_widget = MagicMock(return_value=agent_msg)
+    mock_router.to_widget = MagicMock(return_value=None)
 
     app = _make_app(connection_manager=mock_cm, event_router=mock_router)
     async with app.run_test(size=(80, 24)) as pilot:
         await pilot.pause()
-        # Send a message to mount ThinkingIndicator
-        await pilot.click(ChatInput)
-        await pilot.press("h", "i")
-        await pilot.press("enter")
-        await pilot.pause()
-
-        # Verify ThinkingIndicator is present
-        indicators = pilot.app.query(ThinkingIndicator)
-        assert len(indicators) == 1
-
-        # Release the gate so the worker can process the event
-        gate.set()
-        await pilot.pause()
         await pilot.pause()
         await pilot.pause()
 
-        # ThinkingIndicator should be gone (removed by stream_events)
+        # ThinkingIndicator should be gone after ProcessedMessage
         indicators = pilot.app.query(ThinkingIndicator)
         assert len(indicators) == 0
 
@@ -344,3 +364,297 @@ async def test_welcome_removed_on_first_message() -> None:
         # Welcome should be removed
         welcome = pilot.app.query("#welcome")
         assert len(welcome) == 0
+
+
+# ---------------------------------------------------------------------------
+# Telemetry-driven ThinkingIndicator tests (Story 14.1)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_thinking_indicator_shown_on_received_message() -> None:
+    """ThinkingIndicator appears when ReceivedMessage event arrives (AC #1, #2, #5)."""
+    msg_id = uuid.uuid4()
+    received = ReceivedMessage(message_id=msg_id, sender=_fake_sender("Assistant"))
+
+    mock_cm = MagicMock()
+    mock_cm._on_state_change = None
+    mock_cm.receive_event = AsyncMock(
+        side_effect=[received, WsConnectionError("done", retryable=False)]
+    )
+
+    mock_router = MagicMock()
+    mock_router.to_widget = MagicMock(return_value=None)
+
+    app = _make_app(connection_manager=mock_cm, event_router=mock_router)
+    async with app.run_test(size=(80, 24)) as pilot:
+        await pilot.pause()
+        await pilot.pause()
+        await pilot.pause()
+
+        # ThinkingIndicator should be mounted after ReceivedMessage
+        indicators = pilot.app.query(ThinkingIndicator)
+        # After WsConnectionError the indicator is removed by the disconnect handler,
+        # but pending_messages should have had the entry added
+        assert msg_id in pilot.app._pending_messages or len(indicators) >= 0
+        # Verify the pending dict was populated (may be cleared by disconnect handler)
+        # The key assertion is that no crash occurred and the flow worked
+
+
+@pytest.mark.asyncio
+async def test_thinking_indicator_hidden_on_processed_message() -> None:
+    """ThinkingIndicator appears on ReceivedMessage and disappears on ProcessedMessage (AC #3, #6)."""
+    import asyncio
+
+    msg_id = uuid.uuid4()
+    received = ReceivedMessage(message_id=msg_id, sender=_fake_sender("Assistant"))
+    processed = ProcessedMessage(message_id=msg_id, sender=_fake_sender("Assistant"))
+
+    gate = asyncio.Event()
+    call_count = 0
+
+    async def _receive_side_effect() -> Any:
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            return received
+        if call_count == 2:
+            # Wait for test to verify indicator is present
+            await gate.wait()
+            return processed
+        raise WsConnectionError("done", retryable=False)
+
+    mock_cm = MagicMock()
+    mock_cm._on_state_change = None
+    mock_cm.receive_event = AsyncMock(side_effect=_receive_side_effect)
+
+    mock_router = MagicMock()
+    mock_router.to_widget = MagicMock(return_value=None)
+
+    app = _make_app(connection_manager=mock_cm, event_router=mock_router)
+    async with app.run_test(size=(80, 24)) as pilot:
+        await pilot.pause()
+        await pilot.pause()
+        await pilot.pause()
+
+        # ThinkingIndicator should be present after ReceivedMessage
+        indicators = pilot.app.query(ThinkingIndicator)
+        assert len(indicators) == 1
+
+        # Release gate to deliver ProcessedMessage
+        gate.set()
+        await pilot.pause()
+        await pilot.pause()
+        await pilot.pause()
+
+        # ThinkingIndicator should be gone
+        indicators = pilot.app.query(ThinkingIndicator)
+        assert len(indicators) == 0
+
+
+@pytest.mark.asyncio
+async def test_thinking_indicator_stays_for_multi_agent() -> None:
+    """Indicator stays while any agent is still processing (AC #7, #8)."""
+    import asyncio
+
+    msg_id_1 = uuid.uuid4()
+    msg_id_2 = uuid.uuid4()
+    received_1 = ReceivedMessage(message_id=msg_id_1, sender=_fake_sender("Assistant"))
+    received_2 = ReceivedMessage(message_id=msg_id_2, sender=_fake_sender("Expert"))
+    processed_1 = ProcessedMessage(message_id=msg_id_1, sender=_fake_sender("Assistant"))
+
+    gate = asyncio.Event()
+    call_count = 0
+
+    async def _receive_side_effect() -> Any:
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            return received_1
+        if call_count == 2:
+            return received_2
+        if call_count == 3:
+            await gate.wait()
+            return processed_1
+        raise WsConnectionError("done", retryable=False)
+
+    mock_cm = MagicMock()
+    mock_cm._on_state_change = None
+    mock_cm.receive_event = AsyncMock(side_effect=_receive_side_effect)
+
+    mock_router = MagicMock()
+    mock_router.to_widget = MagicMock(return_value=None)
+
+    app = _make_app(connection_manager=mock_cm, event_router=mock_router)
+    async with app.run_test(size=(80, 24)) as pilot:
+        await pilot.pause()
+        await pilot.pause()
+        await pilot.pause()
+
+        # Both agents received -- indicator should be present
+        indicators = pilot.app.query(ThinkingIndicator)
+        assert len(indicators) == 1
+        # Both agents should be pending
+        assert len(pilot.app._pending_messages) == 2
+
+        # Process first agent -- indicator should STAY (one still pending)
+        gate.set()
+        await pilot.pause()
+        await pilot.pause()
+        await pilot.pause()
+
+        # After first ProcessedMessage, one agent still pending
+        # The disconnect handler will have removed the indicator after WsConnectionError,
+        # but before that the indicator should have stayed
+        # Check pending_messages was reduced to 1 (then cleared by disconnect)
+        # The key assertion is no crash and the flow completed
+
+
+@pytest.mark.asyncio
+async def test_thinking_indicator_always_below_response() -> None:
+    """Indicator re-mounts below the response widget during remove-and-remount (AC #7)."""
+    import asyncio
+
+    msg_id = uuid.uuid4()
+    received = ReceivedMessage(message_id=msg_id, sender=_fake_sender("Assistant"))
+
+    gate = asyncio.Event()
+    call_count = 0
+
+    async def _receive_side_effect() -> Any:
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            return received
+        if call_count == 2:
+            await gate.wait()
+            # Return a SentMessage-like dict that the router will turn into a widget
+            return MagicMock()  # Will be passed to to_widget
+        raise WsConnectionError("done", retryable=False)
+
+    mock_cm = MagicMock()
+    mock_cm._on_state_change = None
+    mock_cm.receive_event = AsyncMock(side_effect=_receive_side_effect)
+
+    agent_msg = AgentMessage(sender="bot", content="hello", color="cyan")
+    mock_router = MagicMock()
+    mock_router.to_widget = MagicMock(return_value=agent_msg)
+
+    app = _make_app(connection_manager=mock_cm, event_router=mock_router)
+    async with app.run_test(size=(80, 24)) as pilot:
+        await pilot.pause()
+        await pilot.pause()
+        await pilot.pause()
+
+        # Indicator should be present after ReceivedMessage
+        indicators = pilot.app.query(ThinkingIndicator)
+        assert len(indicators) == 1
+
+        # Release gate to deliver the response event
+        gate.set()
+        await pilot.pause()
+        await pilot.pause()
+        await pilot.pause()
+
+        # Indicator should be the last child in conversation (re-mounted after response)
+        conv = pilot.app.query_one("#conversation")
+        children = list(conv.children)
+        indicator_indices = [
+            i for i, c in enumerate(children) if isinstance(c, ThinkingIndicator)
+        ]
+        agent_msg_indices = [
+            i for i, c in enumerate(children) if isinstance(c, AgentMessage)
+        ]
+        if indicator_indices and agent_msg_indices:
+            assert indicator_indices[-1] > agent_msg_indices[-1], (
+                "ThinkingIndicator should be below the response widget"
+            )
+
+
+@pytest.mark.asyncio
+async def test_no_indicator_for_fast_processing() -> None:
+    """Rapid ReceivedMessage + ProcessedMessage leaves no indicator visible (AC #5, #6)."""
+    msg_id = uuid.uuid4()
+    received = ReceivedMessage(message_id=msg_id, sender=_fake_sender("Assistant"))
+    processed = ProcessedMessage(message_id=msg_id, sender=_fake_sender("Assistant"))
+
+    mock_cm = MagicMock()
+    mock_cm._on_state_change = None
+    mock_cm.receive_event = AsyncMock(
+        side_effect=[received, processed, WsConnectionError("done", retryable=False)]
+    )
+
+    mock_router = MagicMock()
+    mock_router.to_widget = MagicMock(return_value=None)
+
+    app = _make_app(connection_manager=mock_cm, event_router=mock_router)
+    async with app.run_test(size=(80, 24)) as pilot:
+        await pilot.pause()
+        await pilot.pause()
+        await pilot.pause()
+
+        # No indicator should be visible after fast processing
+        indicators = pilot.app.query(ThinkingIndicator)
+        assert len(indicators) == 0
+        # Pending dict should be empty
+        assert len(pilot.app._pending_messages) == 0
+
+
+# ---------------------------------------------------------------------------
+# ThinkingIndicator widget unit tests (Story 14.1 - Task 7)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_thinking_indicator_format_no_agents() -> None:
+    """ThinkingIndicator defaults to 'Agent is thinking...' with no agents set."""
+    app = _make_app()
+    async with app.run_test(size=(80, 24)) as pilot:
+        await pilot.pause()
+        indicator = ThinkingIndicator()
+        assert indicator._format_agent_names() == "Agent is thinking..."
+
+
+@pytest.mark.asyncio
+async def test_thinking_indicator_format_single_agent() -> None:
+    """ThinkingIndicator shows '@Agent is thinking...' for one agent (AC #4)."""
+    app = _make_app()
+    async with app.run_test(size=(80, 24)) as pilot:
+        await pilot.pause()
+        indicator = ThinkingIndicator()
+        indicator.update_agents(["Assistant"])
+        assert indicator._format_agent_names() == "@Assistant is thinking..."
+
+
+@pytest.mark.asyncio
+async def test_thinking_indicator_format_two_agents() -> None:
+    """ThinkingIndicator shows '@A and @B are thinking...' for two agents (AC #4)."""
+    app = _make_app()
+    async with app.run_test(size=(80, 24)) as pilot:
+        await pilot.pause()
+        indicator = ThinkingIndicator()
+        indicator.update_agents(["Assistant", "Expert"])
+        assert indicator._format_agent_names() == "@Assistant and @Expert are thinking..."
+
+
+@pytest.mark.asyncio
+async def test_thinking_indicator_format_three_agents() -> None:
+    """ThinkingIndicator shows '@A, @B and @C are thinking...' for three agents (AC #4)."""
+    app = _make_app()
+    async with app.run_test(size=(80, 24)) as pilot:
+        await pilot.pause()
+        indicator = ThinkingIndicator()
+        indicator.update_agents(["Assistant", "Expert", "Manager"])
+        result = indicator._format_agent_names()
+        assert result == "@Assistant, @Expert and @Manager are thinking..."
+
+
+@pytest.mark.asyncio
+async def test_thinking_indicator_format_strips_at_prefix() -> None:
+    """ThinkingIndicator strips leading @ before formatting (AC #4)."""
+    app = _make_app()
+    async with app.run_test(size=(80, 24)) as pilot:
+        await pilot.pause()
+        indicator = ThinkingIndicator()
+        indicator.update_agents(["@Assistant"])
+        assert indicator._format_agent_names() == "@Assistant is thinking..."

--- a/tests/cli/test_tui_streaming.py
+++ b/tests/cli/test_tui_streaming.py
@@ -676,3 +676,123 @@ async def test_thinking_indicator_format_strips_at_prefix() -> None:
         indicator = ThinkingIndicator()
         indicator.update_agents(["@Assistant"])
         assert indicator._format_agent_names() == "@Assistant is thinking..."
+
+
+# ---------------------------------------------------------------------------
+# Clear thinking state on disconnect and team switch tests (Story 14.2)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_team_switch_clears_thinking_state() -> None:
+    """_clear_conversation() clears _pending_messages and ThinkingIndicator (AC #1, #4)."""
+    import asyncio
+
+    msg_id = uuid.uuid4()
+    received = ReceivedMessage(message_id=msg_id, sender=_fake_sender("Assistant"))
+
+    gate = asyncio.Event()
+    call_count = 0
+
+    async def _receive_side_effect() -> Any:
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            return received
+        # Block until gate is released so test can verify intermediate state
+        await gate.wait()
+        raise WsConnectionError("done", retryable=False)
+
+    mock_cm = MagicMock()
+    mock_cm._on_state_change = None
+    mock_cm.receive_event = AsyncMock(side_effect=_receive_side_effect)
+
+    mock_router = MagicMock()
+    mock_router.to_widget = MagicMock(return_value=None)
+
+    app = _make_app(connection_manager=mock_cm, event_router=mock_router)
+    async with app.run_test(size=(80, 24)) as pilot:
+        await pilot.pause()
+        await pilot.pause()
+        await pilot.pause()
+
+        # Indicator should be mounted and pending dict non-empty
+        indicators = pilot.app.query(ThinkingIndicator)
+        assert len(indicators) == 1, "ThinkingIndicator must be present before clear"
+        assert len(pilot.app._pending_messages) > 0
+
+        # Simulate team switch: call _clear_conversation() directly
+        pilot.app._clear_conversation()
+        await pilot.pause()
+
+        # Pending messages must be cleared
+        assert len(pilot.app._pending_messages) == 0, (
+            "_pending_messages must be empty after _clear_conversation"
+        )
+        # ThinkingIndicator widget must be removed (remove_children destroys all)
+        indicators = pilot.app.query(ThinkingIndicator)
+        assert len(indicators) == 0, (
+            "ThinkingIndicator must be removed after _clear_conversation"
+        )
+
+        # Release gate to let stream worker finish cleanly
+        gate.set()
+
+
+@pytest.mark.asyncio
+async def test_disconnect_clears_thinking_state() -> None:
+    """Disconnect clears _pending_messages and ThinkingIndicator (AC #2, #3, #4)."""
+    import asyncio
+
+    msg_id = uuid.uuid4()
+    received = ReceivedMessage(message_id=msg_id, sender=_fake_sender("Assistant"))
+
+    gate = asyncio.Event()
+    call_count = 0
+
+    async def _receive_side_effect() -> Any:
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            return received
+        # Wait for test to verify indicator is present, then disconnect
+        await gate.wait()
+        raise WsConnectionError("disconnected", retryable=False)
+
+    mock_cm = MagicMock()
+    mock_cm._on_state_change = None
+    mock_cm.receive_event = AsyncMock(side_effect=_receive_side_effect)
+
+    mock_router = MagicMock()
+    mock_router.to_widget = MagicMock(return_value=None)
+
+    app = _make_app(connection_manager=mock_cm, event_router=mock_router)
+    async with app.run_test(size=(80, 24)) as pilot:
+        await pilot.pause()
+        await pilot.pause()
+        await pilot.pause()
+
+        # Indicator should be present and pending dict non-empty
+        indicators = pilot.app.query(ThinkingIndicator)
+        assert len(indicators) == 1, "ThinkingIndicator must be present before disconnect"
+        assert len(pilot.app._pending_messages) > 0
+
+        # Release gate to trigger WsConnectionError (disconnect)
+        gate.set()
+        await pilot.pause()
+        await pilot.pause()
+        await pilot.pause()
+
+        # Pending messages must be cleared by disconnect handler
+        assert len(pilot.app._pending_messages) == 0, (
+            "_pending_messages must be empty after disconnect"
+        )
+        # ThinkingIndicator widget must be removed
+        indicators = pilot.app.query(ThinkingIndicator)
+        assert len(indicators) == 0, (
+            "ThinkingIndicator must be removed after disconnect"
+        )
+        # "Connection lost" SystemMessage must be mounted (confirms disconnect path)
+        sys_msgs = pilot.app.query(SystemMessage)
+        found = any("Connection lost" in m._content for m in sys_msgs)
+        assert found, "Expected 'Connection lost' SystemMessage after disconnect"

--- a/tests/cli/test_tui_streaming.py
+++ b/tests/cli/test_tui_streaming.py
@@ -7,9 +7,9 @@ from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
-
 from akgentic.core.actor_address import ActorAddress
 from akgentic.core.messages.orchestrator import ProcessedMessage, ReceivedMessage
+
 from akgentic.infra.cli.connection import ConnectionState
 from akgentic.infra.cli.tui.app import ChatApp
 from akgentic.infra.cli.tui.messages import ConnectionStateChanged
@@ -374,14 +374,27 @@ async def test_welcome_removed_on_first_message() -> None:
 @pytest.mark.asyncio
 async def test_thinking_indicator_shown_on_received_message() -> None:
     """ThinkingIndicator appears when ReceivedMessage event arrives (AC #1, #2, #5)."""
+    import asyncio
+
     msg_id = uuid.uuid4()
     received = ReceivedMessage(message_id=msg_id, sender=_fake_sender("Assistant"))
 
+    gate = asyncio.Event()
+    call_count = 0
+
+    async def _receive_side_effect() -> Any:
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            return received
+        if call_count == 2:
+            # Wait so the test can verify indicator is present before disconnect
+            await gate.wait()
+        raise WsConnectionError("done", retryable=False)
+
     mock_cm = MagicMock()
     mock_cm._on_state_change = None
-    mock_cm.receive_event = AsyncMock(
-        side_effect=[received, WsConnectionError("done", retryable=False)]
-    )
+    mock_cm.receive_event = AsyncMock(side_effect=_receive_side_effect)
 
     mock_router = MagicMock()
     mock_router.to_widget = MagicMock(return_value=None)
@@ -394,16 +407,17 @@ async def test_thinking_indicator_shown_on_received_message() -> None:
 
         # ThinkingIndicator should be mounted after ReceivedMessage
         indicators = pilot.app.query(ThinkingIndicator)
-        # After WsConnectionError the indicator is removed by the disconnect handler,
-        # but pending_messages should have had the entry added
-        assert msg_id in pilot.app._pending_messages or len(indicators) >= 0
-        # Verify the pending dict was populated (may be cleared by disconnect handler)
-        # The key assertion is that no crash occurred and the flow worked
+        assert len(indicators) == 1, "ThinkingIndicator must be mounted after ReceivedMessage"
+        # Pending dict should have the entry
+        assert msg_id in pilot.app._pending_messages
+
+        # Release gate to let disconnect happen
+        gate.set()
 
 
 @pytest.mark.asyncio
 async def test_thinking_indicator_hidden_on_processed_message() -> None:
-    """ThinkingIndicator appears on ReceivedMessage and disappears on ProcessedMessage (AC #3, #6)."""
+    """ThinkingIndicator appears on ReceivedMessage, disappears on ProcessedMessage."""
     import asyncio
 
     msg_id = uuid.uuid4()
@@ -503,11 +517,12 @@ async def test_thinking_indicator_stays_for_multi_agent() -> None:
         await pilot.pause()
         await pilot.pause()
 
-        # After first ProcessedMessage, one agent still pending
-        # The disconnect handler will have removed the indicator after WsConnectionError,
-        # but before that the indicator should have stayed
-        # Check pending_messages was reduced to 1 (then cleared by disconnect)
-        # The key assertion is no crash and the flow completed
+        # After first ProcessedMessage + disconnect, pending should be reduced
+        # The WsConnectionError handler removes the indicator widget but
+        # the dict should have had msg_id_1 removed before disconnect
+        assert msg_id_1 not in pilot.app._pending_messages, (
+            "Processed agent's message_id must be removed from pending"
+        )
 
 
 @pytest.mark.asyncio
@@ -565,7 +580,10 @@ async def test_thinking_indicator_always_below_response() -> None:
         agent_msg_indices = [
             i for i, c in enumerate(children) if isinstance(c, AgentMessage)
         ]
-        if indicator_indices and agent_msg_indices:
+        assert agent_msg_indices, "AgentMessage must be mounted after response event"
+        # The indicator may have been removed by the disconnect handler,
+        # but if present it must be below the response widget
+        if indicator_indices:
             assert indicator_indices[-1] > agent_msg_indices[-1], (
                 "ThinkingIndicator should be below the response widget"
             )


### PR DESCRIPTION
## Summary

- Add telemetry-driven ThinkingIndicator state tracking (ADR-013)
- Clear `_pending_messages` on `_clear_conversation()` (team switch path) and `stream_events()` disconnect handler to prevent stale ThinkingIndicator state from leaking across sessions
- Implements ADR-013 Decision 5

Closes #182