### PR TITLE
feat: enrich TelemetrySubscriber spans with sender and team_id

### DIFF
--- a/src/akgentic/infra/adapters/shared/telemetry_subscriber.py
+++ b/src/akgentic/infra/adapters/shared/telemetry_subscriber.py
@@ -37,10 +37,15 @@ class TelemetrySubscriber:
         """
         if self._restoring:
             return
-        msg_type = type(msg).__name__
+        
+        sender = msg.sender.name if msg.sender else "unknown"
+        msg_type = msg.__class__.__name__
+        team_id = msg.team_id
         logfire.info(
-            "orchestrator event: {msg_type}",
+            "{sender} event: {msg_type} - {team_id}",
+            sender=sender,
             msg_type=msg_type,
+            team_id=team_id,
         )
         logger.debug("Telemetry event: %s", msg_type)
 


### PR DESCRIPTION
## Summary

- Enriches `TelemetrySubscriber.on_message` logfire span with `sender` name and `team_id` for better observability filtering in multi-agent, multi-team scenarios
- Span template changes from `"orchestrator event: {msg_type}"` to `"{sender} event: {msg_type} - {team_id}"`
- No behavioral changes — restore-awareness and thread-safety unchanged

Closes #200