### PR TITLE
Simplify LocalTeamHandle to pure delegation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,12 +28,6 @@ jobs:
           git fetch origin ${{ github.head_ref || github.ref_name }}
           git checkout FETCH_HEAD
 
-      - name: Override akgentic-team submodule for process_human_input
-        working-directory: packages/akgentic-team
-        run: |
-          git fetch origin feat/85-add-teamruntime-process-human-input
-          git checkout FETCH_HEAD
-
       - name: Install uv
         uses: astral-sh/setup-uv@v4
         with:
@@ -92,12 +86,6 @@ jobs:
           git fetch origin ${{ github.head_ref || github.ref_name }}
           git checkout FETCH_HEAD
 
-      - name: Override akgentic-team submodule for process_human_input
-        working-directory: packages/akgentic-team
-        run: |
-          git fetch origin feat/85-add-teamruntime-process-human-input
-          git checkout FETCH_HEAD
-
       - name: Install uv
         uses: astral-sh/setup-uv@v4
         with:
@@ -151,12 +139,6 @@ jobs:
           git fetch origin ${{ github.head_ref || github.ref_name }}
           git checkout FETCH_HEAD
 
-      - name: Override akgentic-team submodule for process_human_input
-        working-directory: packages/akgentic-team
-        run: |
-          git fetch origin feat/85-add-teamruntime-process-human-input
-          git checkout FETCH_HEAD
-
       - name: Install uv
         uses: astral-sh/setup-uv@v4
         with:
@@ -205,13 +187,6 @@ jobs:
         run: |
           git fetch origin master
           git fetch origin ${{ github.head_ref || github.ref_name }}
-          git checkout FETCH_HEAD
-
-      - name: Override akgentic-team submodule for process_human_input
-        if: env.OPENAI_API_KEY != ''
-        working-directory: packages/akgentic-team
-        run: |
-          git fetch origin feat/85-add-teamruntime-process-human-input
           git checkout FETCH_HEAD
 
       - name: Install uv

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,12 @@ jobs:
           git fetch origin ${{ github.head_ref || github.ref_name }}
           git checkout FETCH_HEAD
 
+      - name: Override akgentic-team submodule for process_human_input
+        working-directory: packages/akgentic-team
+        run: |
+          git fetch origin feat/85-add-teamruntime-process-human-input
+          git checkout FETCH_HEAD
+
       - name: Install uv
         uses: astral-sh/setup-uv@v4
         with:
@@ -86,6 +92,12 @@ jobs:
           git fetch origin ${{ github.head_ref || github.ref_name }}
           git checkout FETCH_HEAD
 
+      - name: Override akgentic-team submodule for process_human_input
+        working-directory: packages/akgentic-team
+        run: |
+          git fetch origin feat/85-add-teamruntime-process-human-input
+          git checkout FETCH_HEAD
+
       - name: Install uv
         uses: astral-sh/setup-uv@v4
         with:
@@ -139,6 +151,12 @@ jobs:
           git fetch origin ${{ github.head_ref || github.ref_name }}
           git checkout FETCH_HEAD
 
+      - name: Override akgentic-team submodule for process_human_input
+        working-directory: packages/akgentic-team
+        run: |
+          git fetch origin feat/85-add-teamruntime-process-human-input
+          git checkout FETCH_HEAD
+
       - name: Install uv
         uses: astral-sh/setup-uv@v4
         with:
@@ -187,6 +205,13 @@ jobs:
         run: |
           git fetch origin master
           git fetch origin ${{ github.head_ref || github.ref_name }}
+          git checkout FETCH_HEAD
+
+      - name: Override akgentic-team submodule for process_human_input
+        if: env.OPENAI_API_KEY != ''
+        working-directory: packages/akgentic-team
+        run: |
+          git fetch origin feat/85-add-teamruntime-process-human-input
           git checkout FETCH_HEAD
 
       - name: Install uv

--- a/src/akgentic/infra/adapters/community/local_team_handle.py
+++ b/src/akgentic/infra/adapters/community/local_team_handle.py
@@ -5,8 +5,7 @@ from __future__ import annotations
 import uuid
 from typing import TYPE_CHECKING
 
-from akgentic.agent import HumanProxy
-from akgentic.core.orchestrator import EventSubscriber, Orchestrator
+from akgentic.core.orchestrator import EventSubscriber
 
 if TYPE_CHECKING:
     from akgentic.core.messages.message import Message
@@ -42,38 +41,13 @@ class LocalTeamHandle:
         self._runtime.send_from_to(sender_name, recipient_name, content)
 
     def process_human_input(self, content: str, message: Message) -> None:
-        """Route human input to the team's HumanProxy agent.
-
-        Walks the team's agent cards to find the HumanProxy, resolves its
-        address, obtains a typed proxy, and delegates the call.
-
-        Raises:
-            ValueError: If no HumanProxy found in the team.
-        """
-        for name, card in self._runtime.team.agent_cards.items():
-            if card.get_agent_class() is HumanProxy:
-                addr = self._runtime.addrs.get(name)
-                if addr is None:
-                    msg = f"HumanProxy '{name}' found but has no resolved address"
-                    raise ValueError(msg)
-                proxy = self._runtime.actor_system.proxy_ask(addr, HumanProxy)
-                proxy.process_human_input(content, message)
-                return
-        msg = "No HumanProxy found in team"
-        raise ValueError(msg)
+        """Route human input to the team's HumanProxy agent."""
+        self._runtime.process_human_input(content, message)
 
     def subscribe(self, subscriber: EventSubscriber) -> None:
         """Register an event subscriber with the team's orchestrator."""
-        orch_proxy = self._runtime.actor_system.proxy_ask(
-            self._runtime.orchestrator_addr,
-            Orchestrator,
-        )
-        orch_proxy.subscribe(subscriber)
+        self._runtime.orchestrator_proxy.subscribe(subscriber)
 
     def unsubscribe(self, subscriber: EventSubscriber) -> None:
         """Remove an event subscriber from the team's orchestrator."""
-        orch_proxy = self._runtime.actor_system.proxy_ask(
-            self._runtime.orchestrator_addr,
-            Orchestrator,
-        )
-        orch_proxy.unsubscribe(subscriber)
+        self._runtime.orchestrator_proxy.unsubscribe(subscriber)

--- a/tests/adapters/community/test_local_team_handle.py
+++ b/tests/adapters/community/test_local_team_handle.py
@@ -4,8 +4,6 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock
 
-import pytest
-
 from akgentic.infra.adapters.community.local_team_handle import LocalTeamHandle
 from akgentic.infra.protocols.team_handle import TeamHandle
 
@@ -61,133 +59,36 @@ class TestLocalTeamHandleSendFromTo:
 
 
 class TestLocalTeamHandleProcessHumanInput:
-    """AC1: process_human_input() encapsulates HumanProxy lookup + delegation."""
+    """AC1: process_human_input() delegates to TeamRuntime."""
 
-    def test_process_human_input_delegates(self) -> None:
-        """Finds HumanProxy in agent_cards, resolves addr, calls proxy."""
-        from akgentic.agent import HumanProxy
-
+    def test_process_human_input_delegates_to_runtime(self) -> None:
+        """process_human_input(content, message) calls runtime.process_human_input()."""
         runtime = MagicMock()
-        mock_card = MagicMock()
-        mock_card.get_agent_class.return_value = HumanProxy
-        runtime.team.agent_cards = {"human": mock_card}
-
-        mock_addr = MagicMock()
-        runtime.addrs = {"human": mock_addr}
-
-        mock_proxy = MagicMock()
-        runtime.actor_system.proxy_ask.return_value = mock_proxy
-
         message = MagicMock()
         handle = LocalTeamHandle(runtime)
         handle.process_human_input("user input", message)
-
-        runtime.actor_system.proxy_ask.assert_called_once_with(mock_addr, HumanProxy)
-        mock_proxy.process_human_input.assert_called_once_with("user input", message)
-
-    def test_process_human_input_raises_if_no_human_proxy(self) -> None:
-        """Raises ValueError when no HumanProxy agent exists in team."""
-        runtime = MagicMock()
-        mock_card = MagicMock()
-        mock_card.get_agent_class.return_value = type("OtherAgent", (), {})
-        runtime.team.agent_cards = {"other": mock_card}
-
-        handle = LocalTeamHandle(runtime)
-        message = MagicMock()
-        with pytest.raises(ValueError, match="No HumanProxy found in team"):
-            handle.process_human_input("input", message)
-
-    def test_process_human_input_raises_if_addr_missing(self) -> None:
-        """Raises ValueError when HumanProxy exists but has no resolved address."""
-        from akgentic.agent import HumanProxy
-
-        runtime = MagicMock()
-        mock_card = MagicMock()
-        mock_card.get_agent_class.return_value = HumanProxy
-        runtime.team.agent_cards = {"human": mock_card}
-        runtime.addrs = {}  # no addr for "human"
-
-        handle = LocalTeamHandle(runtime)
-        message = MagicMock()
-        with pytest.raises(
-            ValueError, match="HumanProxy 'human' found but has no resolved address"
-        ):
-            handle.process_human_input("input", message)
-
-    def test_process_human_input_raises_for_empty_agent_cards(self) -> None:
-        """Raises ValueError when agent_cards is empty."""
-        runtime = MagicMock()
-        runtime.team.agent_cards = {}
-
-        handle = LocalTeamHandle(runtime)
-        message = MagicMock()
-        with pytest.raises(ValueError, match="No HumanProxy found in team"):
-            handle.process_human_input("input", message)
-
-    def test_process_human_input_finds_human_proxy_among_multiple_cards(self) -> None:
-        """Finds HumanProxy when it is not the first card in the dict."""
-        from akgentic.agent import HumanProxy
-
-        runtime = MagicMock()
-        other_card = MagicMock()
-        other_card.get_agent_class.return_value = type("OtherAgent", (), {})
-        human_card = MagicMock()
-        human_card.get_agent_class.return_value = HumanProxy
-        runtime.team.agent_cards = {"analyst": other_card, "human": human_card}
-
-        mock_addr = MagicMock()
-        runtime.addrs = {"analyst": MagicMock(), "human": mock_addr}
-
-        mock_proxy = MagicMock()
-        runtime.actor_system.proxy_ask.return_value = mock_proxy
-
-        message = MagicMock()
-        handle = LocalTeamHandle(runtime)
-        handle.process_human_input("user input", message)
-
-        runtime.actor_system.proxy_ask.assert_called_once_with(mock_addr, HumanProxy)
-        mock_proxy.process_human_input.assert_called_once_with("user input", message)
+        runtime.process_human_input.assert_called_once_with("user input", message)
 
 
 class TestLocalTeamHandleSubscribe:
-    """AC1: subscribe() delegates via orchestrator proxy."""
+    """AC2: subscribe() delegates via runtime.orchestrator_proxy."""
 
-    def test_subscribe_delegates_to_orchestrator(self) -> None:
-        """Gets orchestrator proxy and calls subscribe(subscriber)."""
-        from akgentic.core.orchestrator import Orchestrator
-
+    def test_subscribe_delegates_via_orchestrator_proxy(self) -> None:
+        """subscribe(subscriber) calls runtime.orchestrator_proxy.subscribe()."""
         runtime = MagicMock()
-        mock_orch_proxy = MagicMock()
-        runtime.actor_system.proxy_ask.return_value = mock_orch_proxy
-
         subscriber = MagicMock()
         handle = LocalTeamHandle(runtime)
         handle.subscribe(subscriber)
-
-        runtime.actor_system.proxy_ask.assert_called_once_with(
-            runtime.orchestrator_addr,
-            Orchestrator,
-        )
-        mock_orch_proxy.subscribe.assert_called_once_with(subscriber)
+        runtime.orchestrator_proxy.subscribe.assert_called_once_with(subscriber)
 
 
 class TestLocalTeamHandleUnsubscribe:
-    """AC1: unsubscribe() delegates via orchestrator proxy."""
+    """AC3: unsubscribe() delegates via runtime.orchestrator_proxy."""
 
-    def test_unsubscribe_delegates_to_orchestrator(self) -> None:
-        """Gets orchestrator proxy and calls unsubscribe(subscriber)."""
-        from akgentic.core.orchestrator import Orchestrator
-
+    def test_unsubscribe_delegates_via_orchestrator_proxy(self) -> None:
+        """unsubscribe(subscriber) calls runtime.orchestrator_proxy.unsubscribe()."""
         runtime = MagicMock()
-        mock_orch_proxy = MagicMock()
-        runtime.actor_system.proxy_ask.return_value = mock_orch_proxy
-
         subscriber = MagicMock()
         handle = LocalTeamHandle(runtime)
         handle.unsubscribe(subscriber)
-
-        runtime.actor_system.proxy_ask.assert_called_once_with(
-            runtime.orchestrator_addr,
-            Orchestrator,
-        )
-        mock_orch_proxy.unsubscribe.assert_called_once_with(subscriber)
+        runtime.orchestrator_proxy.unsubscribe.assert_called_once_with(subscriber)


### PR DESCRIPTION
## Summary

- Replace `process_human_input()`, `subscribe()`, and `unsubscribe()` method bodies in `LocalTeamHandle` with one-line delegations to `TeamRuntime`
- Remove `HumanProxy` and `Orchestrator` imports from the infra adapter layer
- Replace 7 implementation-detail tests with 3 delegation-only tests
- Add temporary CI override to checkout akgentic-team's `feat/85-add-teamruntime-process-human-input` branch until PR #86 is merged in akgentic-team

After this change, all 6 methods in `LocalTeamHandle` follow the same one-line delegation pattern, making the adapter trivially auditable.

**Merge dependency:** akgentic-team PR #86 must merge first. Once merged, the CI override in `.github/workflows/ci.yml` should be removed.

Closes #206