### PR TITLE
Generalize TierServices.event_store to EventStore protocol

### DIFF
--- a/src/akgentic/infra/server/deps.py
+++ b/src/akgentic/infra/server/deps.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, SkipValidation
 
 from akgentic.catalog.services import (
     AgentCatalog,
@@ -19,8 +19,7 @@ from akgentic.infra.protocols.placement import PlacementStrategy
 from akgentic.infra.protocols.runtime_cache import RuntimeCache
 from akgentic.infra.protocols.worker_handle import WorkerHandle
 from akgentic.team.manager import TeamManager
-from akgentic.team.ports import ServiceRegistry
-from akgentic.team.repositories.yaml import YamlEventStore
+from akgentic.team.ports import EventStore, ServiceRegistry
 
 
 class TierServices(BaseModel):
@@ -28,10 +27,6 @@ class TierServices(BaseModel):
 
     This is a runtime DI container, NOT a serialization model — arbitrary_types_allowed
     is intentional (Golden Rule #1b exemption).
-
-    Note: ``event_store`` uses the concrete ``YamlEventStore`` type because
-    ``EventStore`` (from akgentic-team) is not ``@runtime_checkable`` and cannot
-    be modified from this submodule.
     """
 
     model_config = ConfigDict(arbitrary_types_allowed=True)
@@ -39,7 +34,9 @@ class TierServices(BaseModel):
     placement: PlacementStrategy = Field(description="Strategy for placing teams on workers")
     worker_handle: WorkerHandle = Field(description="Worker-level team lifecycle operations")
     auth: AuthStrategy = Field(description="Authentication strategy for incoming requests")
-    event_store: YamlEventStore = Field(description="Persistence backend for team event sourcing")
+    event_store: SkipValidation[EventStore] = Field(
+        description="Persistence backend for team event sourcing"
+    )
     runtime_cache: RuntimeCache = Field(
         description="Cache mapping team IDs to live TeamHandle instances"
     )

--- a/src/akgentic/infra/wiring.py
+++ b/src/akgentic/infra/wiring.py
@@ -32,7 +32,7 @@ from akgentic.infra.protocols.event_stream import EventStream
 from akgentic.infra.server.deps import CommunityServices
 from akgentic.infra.server.settings import CommunitySettings
 from akgentic.team.manager import TeamManager
-from akgentic.team.ports import NullServiceRegistry, ServiceRegistry
+from akgentic.team.ports import EventStore, NullServiceRegistry, ServiceRegistry
 from akgentic.team.repositories.yaml import YamlEventStore
 
 logger = logging.getLogger(__name__)
@@ -93,7 +93,7 @@ def wire_community(settings: CommunitySettings) -> CommunityServices:
 
 
 def _build_actor_layer(
-    event_store: YamlEventStore,
+    event_store: EventStore,
     service_registry: ServiceRegistry,
     event_stream: EventStream,
 ) -> tuple[ActorSystem, TeamManager]:

--- a/tests/test_deps.py
+++ b/tests/test_deps.py
@@ -1,0 +1,93 @@
+"""Tests for TierServices dependency injection container."""
+
+from __future__ import annotations
+
+import uuid
+from unittest.mock import MagicMock
+
+from akgentic.catalog.services import (
+    AgentCatalog,
+    TeamCatalog,
+    TemplateCatalog,
+    ToolCatalog,
+)
+from akgentic.team.models import AgentStateSnapshot, PersistedEvent, Process
+
+from akgentic.infra.protocols.auth import AuthStrategy
+from akgentic.infra.protocols.channels import ChannelRegistry, InteractionChannelIngestion
+from akgentic.infra.protocols.event_stream import EventStream
+from akgentic.infra.protocols.placement import PlacementStrategy
+from akgentic.infra.protocols.runtime_cache import RuntimeCache
+from akgentic.infra.protocols.worker_handle import WorkerHandle
+from akgentic.infra.server.deps import TierServices
+
+
+class FakeEventStore:
+    """Minimal EventStore-shaped class satisfying the protocol via structural subtyping.
+
+    Does NOT inherit from EventStore -- validates that Pydantic accepts
+    protocol-typed fields through structural subtyping when
+    arbitrary_types_allowed=True and SkipValidation is used.
+    """
+
+    def save_event(self, event: PersistedEvent) -> None:
+        """No-op stub."""
+
+    def load_events(self, team_id: uuid.UUID) -> list[PersistedEvent]:
+        """Return empty list."""
+        return []
+
+    def save_team(self, process: Process) -> None:
+        """No-op stub."""
+
+    def load_team(self, team_id: uuid.UUID) -> Process | None:
+        """Return None."""
+        return None
+
+    def delete_team(self, team_id: uuid.UUID) -> None:
+        """No-op stub."""
+
+    def save_agent_state(self, snapshot: AgentStateSnapshot) -> None:
+        """No-op stub."""
+
+    def list_teams(self) -> list[Process]:
+        """Return empty list."""
+        return []
+
+    def get_max_sequence(self, team_id: uuid.UUID) -> int:
+        """Return 0."""
+        return 0
+
+    def load_agent_states(self, team_id: uuid.UUID) -> list[AgentStateSnapshot]:
+        """Return empty list."""
+        return []
+
+
+class TestTierServicesEventStoreProtocol:
+    """AC6: TierServices accepts a MongoEventStore-shaped object via structural subtyping."""
+
+    def test_tierservices_accepts_mongo_shaped_event_store(self) -> None:
+        """TierServices construction succeeds with a fake EventStore implementation.
+
+        The fake class does NOT inherit from EventStore -- it satisfies the
+        protocol purely through structural subtyping, the same pattern used
+        by MongoEventStore and YamlEventStore.
+        """
+        fake_store = FakeEventStore()
+
+        services = TierServices(
+            placement=MagicMock(spec=PlacementStrategy),
+            worker_handle=MagicMock(spec=WorkerHandle),
+            auth=MagicMock(spec=AuthStrategy),
+            event_store=fake_store,
+            runtime_cache=MagicMock(spec=RuntimeCache),
+            event_stream=MagicMock(spec=EventStream),
+            ingestion=MagicMock(spec=InteractionChannelIngestion),
+            channel_registry=MagicMock(spec=ChannelRegistry),
+            team_catalog=MagicMock(spec=TeamCatalog),
+            agent_catalog=MagicMock(spec=AgentCatalog),
+            tool_catalog=MagicMock(spec=ToolCatalog),
+            template_catalog=MagicMock(spec=TemplateCatalog),
+        )
+
+        assert services.event_store is fake_store


### PR DESCRIPTION
## Summary

- Changed `TierServices.event_store` field type from concrete `YamlEventStore` to `SkipValidation[EventStore]` protocol, enabling enterprise tiers to inject any `EventStore` implementation
- Updated `_build_actor_layer()` parameter type from `YamlEventStore` to `EventStore`
- Removed stale docstring about `@runtime_checkable` limitation
- Added structural subtyping test confirming `TierServices` accepts non-inheriting `EventStore` implementations

Closes #208