### PR TITLE
WorkerSettings base model for worker configuration

### DIFF
--- a/src/akgentic/infra/server/deps.py
+++ b/src/akgentic/infra/server/deps.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, SkipValidation
 
 from akgentic.catalog.services import (
     AgentCatalog,
@@ -19,8 +19,7 @@ from akgentic.infra.protocols.placement import PlacementStrategy
 from akgentic.infra.protocols.runtime_cache import RuntimeCache
 from akgentic.infra.protocols.worker_handle import WorkerHandle
 from akgentic.team.manager import TeamManager
-from akgentic.team.ports import ServiceRegistry
-from akgentic.team.repositories.yaml import YamlEventStore
+from akgentic.team.ports import EventStore, ServiceRegistry
 
 
 class TierServices(BaseModel):
@@ -28,10 +27,6 @@ class TierServices(BaseModel):
 
     This is a runtime DI container, NOT a serialization model — arbitrary_types_allowed
     is intentional (Golden Rule #1b exemption).
-
-    Note: ``event_store`` uses the concrete ``YamlEventStore`` type because
-    ``EventStore`` (from akgentic-team) is not ``@runtime_checkable`` and cannot
-    be modified from this submodule.
     """
 
     model_config = ConfigDict(arbitrary_types_allowed=True)
@@ -39,7 +34,9 @@ class TierServices(BaseModel):
     placement: PlacementStrategy = Field(description="Strategy for placing teams on workers")
     worker_handle: WorkerHandle = Field(description="Worker-level team lifecycle operations")
     auth: AuthStrategy = Field(description="Authentication strategy for incoming requests")
-    event_store: YamlEventStore = Field(description="Persistence backend for team event sourcing")
+    event_store: SkipValidation[EventStore] = Field(
+        description="Persistence backend for team event sourcing"
+    )
     runtime_cache: RuntimeCache = Field(
         description="Cache mapping team IDs to live TeamHandle instances"
     )

--- a/src/akgentic/infra/wiring.py
+++ b/src/akgentic/infra/wiring.py
@@ -32,7 +32,7 @@ from akgentic.infra.protocols.event_stream import EventStream
 from akgentic.infra.server.deps import CommunityServices
 from akgentic.infra.server.settings import CommunitySettings
 from akgentic.team.manager import TeamManager
-from akgentic.team.ports import NullServiceRegistry, ServiceRegistry
+from akgentic.team.ports import EventStore, NullServiceRegistry, ServiceRegistry
 from akgentic.team.repositories.yaml import YamlEventStore
 
 logger = logging.getLogger(__name__)
@@ -93,7 +93,7 @@ def wire_community(settings: CommunitySettings) -> CommunityServices:
 
 
 def _build_actor_layer(
-    event_store: YamlEventStore,
+    event_store: EventStore,
     service_registry: ServiceRegistry,
     event_stream: EventStream,
 ) -> tuple[ActorSystem, TeamManager]:

--- a/src/akgentic/infra/worker/__init__.py
+++ b/src/akgentic/infra/worker/__init__.py
@@ -1,1 +1,5 @@
-"""Worker module — implemented in future stories."""
+"""Worker module — typed configuration and lifecycle for akgentic-infra workers."""
+
+from akgentic.infra.worker.settings import WorkerSettings
+
+__all__ = ["WorkerSettings"]

--- a/src/akgentic/infra/worker/settings.py
+++ b/src/akgentic/infra/worker/settings.py
@@ -1,0 +1,69 @@
+"""WorkerSettings -- typed configuration for the akgentic-infra worker."""
+
+from __future__ import annotations
+
+import warnings
+from pathlib import Path
+
+from pydantic import Field, field_validator
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+_VALID_LOG_LEVELS = frozenset({"DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"})
+
+
+class WorkerSettings(BaseSettings):
+    """Tier-agnostic worker configuration loaded from environment variables.
+
+    Contains only settings common to all deployment tiers.
+    All fields can be overridden via environment variables prefixed with ``AKGENTIC_WORKER_``.
+    """
+
+    model_config = SettingsConfigDict(env_prefix="AKGENTIC_WORKER_")
+
+    host: str = Field(
+        default="0.0.0.0",
+        description="Bind address for the worker HTTP server",
+    )
+    port: int = Field(
+        default=8001,
+        description="Port number for the worker HTTP server",
+    )
+    log_level: str = Field(
+        default="INFO",
+        description="Application log level (DEBUG, INFO, WARNING, ERROR, CRITICAL)",
+    )
+    workspaces_root: Path = Field(
+        default=Path("/data/workspaces"),
+        description="Root directory for team workspace storage",
+    )
+    shutdown_drain_timeout: int = Field(
+        default=30,
+        ge=0,
+        description="Max seconds for stop_all() during graceful shutdown",
+    )
+    shutdown_pre_drain_delay: int = Field(
+        default=0,
+        ge=0,
+        description=(
+            "Seconds to wait after marking draining before teardown "
+            "(0 for standalone, 5-10 for LB deployments)"
+        ),
+    )
+    worker_labels: dict[str, str] = Field(
+        default_factory=dict,
+        description="Labels for placement strategy matching (e.g. gpu=true, region=eu)",
+    )
+
+    @field_validator("log_level", mode="before")
+    @classmethod
+    def _normalize_log_level(cls, v: str) -> str:
+        """Normalize to uppercase and fall back to INFO for invalid values."""
+        upper = str(v).upper()
+        if upper not in _VALID_LOG_LEVELS:
+            warnings.warn(
+                f"Invalid AKGENTIC_WORKER_LOG_LEVEL '{v}', falling back to INFO",
+                UserWarning,
+                stacklevel=1,
+            )
+            return "INFO"
+        return upper

--- a/tests/test_deps.py
+++ b/tests/test_deps.py
@@ -1,0 +1,93 @@
+"""Tests for TierServices dependency injection container."""
+
+from __future__ import annotations
+
+import uuid
+from unittest.mock import MagicMock
+
+from akgentic.catalog.services import (
+    AgentCatalog,
+    TeamCatalog,
+    TemplateCatalog,
+    ToolCatalog,
+)
+from akgentic.team.models import AgentStateSnapshot, PersistedEvent, Process
+
+from akgentic.infra.protocols.auth import AuthStrategy
+from akgentic.infra.protocols.channels import ChannelRegistry, InteractionChannelIngestion
+from akgentic.infra.protocols.event_stream import EventStream
+from akgentic.infra.protocols.placement import PlacementStrategy
+from akgentic.infra.protocols.runtime_cache import RuntimeCache
+from akgentic.infra.protocols.worker_handle import WorkerHandle
+from akgentic.infra.server.deps import TierServices
+
+
+class FakeEventStore:
+    """Minimal EventStore-shaped class satisfying the protocol via structural subtyping.
+
+    Does NOT inherit from EventStore -- validates that Pydantic accepts
+    protocol-typed fields through structural subtyping when
+    arbitrary_types_allowed=True and SkipValidation is used.
+    """
+
+    def save_event(self, event: PersistedEvent) -> None:
+        """No-op stub."""
+
+    def load_events(self, team_id: uuid.UUID) -> list[PersistedEvent]:
+        """Return empty list."""
+        return []
+
+    def save_team(self, process: Process) -> None:
+        """No-op stub."""
+
+    def load_team(self, team_id: uuid.UUID) -> Process | None:
+        """Return None."""
+        return None
+
+    def delete_team(self, team_id: uuid.UUID) -> None:
+        """No-op stub."""
+
+    def save_agent_state(self, snapshot: AgentStateSnapshot) -> None:
+        """No-op stub."""
+
+    def list_teams(self) -> list[Process]:
+        """Return empty list."""
+        return []
+
+    def get_max_sequence(self, team_id: uuid.UUID) -> int:
+        """Return 0."""
+        return 0
+
+    def load_agent_states(self, team_id: uuid.UUID) -> list[AgentStateSnapshot]:
+        """Return empty list."""
+        return []
+
+
+class TestTierServicesEventStoreProtocol:
+    """AC6: TierServices accepts a MongoEventStore-shaped object via structural subtyping."""
+
+    def test_tierservices_accepts_mongo_shaped_event_store(self) -> None:
+        """TierServices construction succeeds with a fake EventStore implementation.
+
+        The fake class does NOT inherit from EventStore -- it satisfies the
+        protocol purely through structural subtyping, the same pattern used
+        by MongoEventStore and YamlEventStore.
+        """
+        fake_store = FakeEventStore()
+
+        services = TierServices(
+            placement=MagicMock(spec=PlacementStrategy),
+            worker_handle=MagicMock(spec=WorkerHandle),
+            auth=MagicMock(spec=AuthStrategy),
+            event_store=fake_store,
+            runtime_cache=MagicMock(spec=RuntimeCache),
+            event_stream=MagicMock(spec=EventStream),
+            ingestion=MagicMock(spec=InteractionChannelIngestion),
+            channel_registry=MagicMock(spec=ChannelRegistry),
+            team_catalog=MagicMock(spec=TeamCatalog),
+            agent_catalog=MagicMock(spec=AgentCatalog),
+            tool_catalog=MagicMock(spec=ToolCatalog),
+            template_catalog=MagicMock(spec=TemplateCatalog),
+        )
+
+        assert services.event_store is fake_store

--- a/tests/worker/test_worker_settings.py
+++ b/tests/worker/test_worker_settings.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from pathlib import Path
 
 import pytest
+from pydantic import ValidationError
 
 from akgentic.infra.worker.settings import WorkerSettings
 
@@ -12,7 +13,14 @@ from akgentic.infra.worker.settings import WorkerSettings
 class TestDefaultValues:
     """WorkerSettings must have sensible defaults matching ADR-017 Decision 2."""
 
-    def test_default_values(self) -> None:
+    def test_default_values(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("AKGENTIC_WORKER_HOST", raising=False)
+        monkeypatch.delenv("AKGENTIC_WORKER_PORT", raising=False)
+        monkeypatch.delenv("AKGENTIC_WORKER_LOG_LEVEL", raising=False)
+        monkeypatch.delenv("AKGENTIC_WORKER_WORKSPACES_ROOT", raising=False)
+        monkeypatch.delenv("AKGENTIC_WORKER_SHUTDOWN_DRAIN_TIMEOUT", raising=False)
+        monkeypatch.delenv("AKGENTIC_WORKER_SHUTDOWN_PRE_DRAIN_DELAY", raising=False)
+        monkeypatch.delenv("AKGENTIC_WORKER_WORKER_LABELS", raising=False)
         settings = WorkerSettings()
         assert settings.host == "0.0.0.0"
         assert settings.port == 8001
@@ -64,3 +72,43 @@ class TestLogLevelNormalization:
         with pytest.warns(UserWarning, match="Invalid AKGENTIC_WORKER_LOG_LEVEL"):
             settings = WorkerSettings()
         assert settings.log_level == "INFO"
+
+
+class TestConstraintValidation:
+    """Constrained fields must reject invalid values."""
+
+    def test_shutdown_drain_timeout_rejects_negative(self) -> None:
+        with pytest.raises(ValidationError, match="shutdown_drain_timeout"):
+            WorkerSettings(shutdown_drain_timeout=-1)
+
+    def test_shutdown_pre_drain_delay_rejects_negative(self) -> None:
+        with pytest.raises(ValidationError, match="shutdown_pre_drain_delay"):
+            WorkerSettings(shutdown_pre_drain_delay=-1)
+
+
+class TestModelStructure:
+    """WorkerSettings model metadata and structure."""
+
+    def test_is_base_settings_subclass(self) -> None:
+        from pydantic_settings import BaseSettings
+
+        assert issubclass(WorkerSettings, BaseSettings)
+
+    def test_field_descriptions_present(self) -> None:
+        for name, field_info in WorkerSettings.model_fields.items():
+            assert field_info.description is not None, f"Field {name} missing description"
+
+    def test_has_only_tier_agnostic_fields(self) -> None:
+        fields = set(WorkerSettings.model_fields.keys())
+        expected = {
+            "host",
+            "port",
+            "log_level",
+            "workspaces_root",
+            "shutdown_drain_timeout",
+            "shutdown_pre_drain_delay",
+            "worker_labels",
+        }
+        assert fields == expected, (
+            f"WorkerSettings fields mismatch: got {fields}, expected {expected}"
+        )

--- a/tests/worker/test_worker_settings.py
+++ b/tests/worker/test_worker_settings.py
@@ -1,0 +1,66 @@
+"""Tests for WorkerSettings configuration model."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from akgentic.infra.worker.settings import WorkerSettings
+
+
+class TestDefaultValues:
+    """WorkerSettings must have sensible defaults matching ADR-017 Decision 2."""
+
+    def test_default_values(self) -> None:
+        settings = WorkerSettings()
+        assert settings.host == "0.0.0.0"
+        assert settings.port == 8001
+        assert settings.log_level == "INFO"
+        assert settings.workspaces_root == Path("/data/workspaces")
+        assert settings.shutdown_drain_timeout == 30
+        assert settings.shutdown_pre_drain_delay == 0
+        assert settings.worker_labels == {}
+
+
+class TestEnvVarOverride:
+    """WorkerSettings must load overrides from AKGENTIC_WORKER_ prefixed env vars."""
+
+    def test_env_var_override(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("AKGENTIC_WORKER_HOST", "127.0.0.1")
+        monkeypatch.setenv("AKGENTIC_WORKER_PORT", "9999")
+        monkeypatch.setenv("AKGENTIC_WORKER_LOG_LEVEL", "DEBUG")
+        monkeypatch.setenv("AKGENTIC_WORKER_WORKSPACES_ROOT", "/tmp/ws")
+        monkeypatch.setenv("AKGENTIC_WORKER_SHUTDOWN_DRAIN_TIMEOUT", "60")
+        monkeypatch.setenv("AKGENTIC_WORKER_SHUTDOWN_PRE_DRAIN_DELAY", "5")
+        monkeypatch.setenv(
+            "AKGENTIC_WORKER_WORKER_LABELS", '{"gpu": "true", "region": "eu"}'
+        )
+
+        settings = WorkerSettings()
+        assert settings.host == "127.0.0.1"
+        assert settings.port == 9999
+        assert settings.log_level == "DEBUG"
+        assert settings.workspaces_root == Path("/tmp/ws")
+        assert settings.shutdown_drain_timeout == 60
+        assert settings.shutdown_pre_drain_delay == 5
+        assert settings.worker_labels == {"gpu": "true", "region": "eu"}
+
+
+class TestLogLevelNormalization:
+    """Log level validator must normalize case and reject invalid values."""
+
+    def test_log_level_normalizes_to_uppercase(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("AKGENTIC_WORKER_LOG_LEVEL", "debug")
+        settings = WorkerSettings()
+        assert settings.log_level == "DEBUG"
+
+    def test_log_level_invalid_falls_back_to_info(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("AKGENTIC_WORKER_LOG_LEVEL", "bogus")
+        with pytest.warns(UserWarning, match="Invalid AKGENTIC_WORKER_LOG_LEVEL"):
+            settings = WorkerSettings()
+        assert settings.log_level == "INFO"


### PR DESCRIPTION
## Summary

- Add `WorkerSettings(BaseSettings)` with 7 tier-agnostic fields (host, port, log_level, workspaces_root, shutdown_drain_timeout, shutdown_pre_drain_delay, worker_labels) matching ADR-017 Decision 2
- Export `WorkerSettings` from `worker/__init__.py`
- 9 unit tests covering defaults, env overrides, log level normalization, constraint validation, and model structure
- Code review fixes: env var isolation, negative constraint tests, model structure tests

Closes #210