### PR TITLE
WorkerServices DI container and worker app factory

### DIFF
--- a/src/akgentic/infra/worker/__init__.py
+++ b/src/akgentic/infra/worker/__init__.py
@@ -1,5 +1,7 @@
-"""Worker module — typed configuration and lifecycle for akgentic-infra workers."""
+"""Worker module — typed configuration, DI container, and app factory for akgentic-infra workers."""
 
+from akgentic.infra.worker.app import create_worker_app
+from akgentic.infra.worker.deps import WorkerServices
 from akgentic.infra.worker.settings import WorkerSettings
 
-__all__ = ["WorkerSettings"]
+__all__ = ["WorkerSettings", "WorkerServices", "create_worker_app"]

--- a/src/akgentic/infra/worker/app.py
+++ b/src/akgentic/infra/worker/app.py
@@ -1,0 +1,81 @@
+"""FastAPI application factory for the akgentic-infra worker."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+
+from fastapi import FastAPI
+
+from akgentic.infra.server.logging_config import configure_logging
+from akgentic.infra.worker.deps import WorkerServices
+from akgentic.infra.worker.routes.readiness import router as readiness_router
+from akgentic.infra.worker.routes.teams import router as teams_router
+from akgentic.infra.worker.settings import WorkerSettings
+
+logger = logging.getLogger(__name__)
+
+
+def create_worker_app(
+    services: WorkerServices,
+    settings: WorkerSettings | None = None,
+) -> FastAPI:
+    """Create and configure the worker FastAPI application.
+
+    Args:
+        services: Pre-wired worker services container.
+        settings: Worker settings. Defaults to ``WorkerSettings()``.
+
+    Returns:
+        Configured FastAPI application instance.
+    """
+    settings = settings or WorkerSettings()
+    configure_logging(settings.log_level)
+    logger.info("Logging configured: level=%s", settings.log_level)
+
+    app = FastAPI(title="Akgentic Worker", lifespan=_lifespan)
+    app.state.services = services
+    app.state.settings = settings
+    app.include_router(readiness_router)
+    app.include_router(teams_router)
+
+    logger.info("Worker app built: routes mounted")
+    return app
+
+
+@asynccontextmanager
+async def _lifespan(app: FastAPI) -> AsyncIterator[None]:
+    """FastAPI lifespan handler for worker graceful shutdown.
+
+    Startup: sets ``app.state.draining = False``.
+    Shutdown: sets draining flag, waits pre-drain delay, then stops all
+    teams via ``worker_handle.stop_all()``.
+    """
+    app.state.draining = False
+    logger.info("Worker lifespan startup: draining=False")
+    yield
+    # --- Shutdown sequence ---
+    app.state.draining = True
+    logger.info("Worker lifespan shutdown: draining=True")
+
+    settings: WorkerSettings = app.state.settings
+    delay = settings.shutdown_pre_drain_delay
+    if delay > 0:
+        logger.info("Pre-drain delay: sleeping %ds", delay)
+        await asyncio.sleep(delay)
+
+    timeout = settings.shutdown_drain_timeout
+    logger.info("Stopping all teams (timeout=%ds)", timeout)
+    try:
+        await asyncio.wait_for(
+            asyncio.to_thread(app.state.services.worker_handle.stop_all),
+            timeout=timeout,
+        )
+        logger.info("stop_all() completed successfully")
+    except TimeoutError:
+        logger.warning(
+            "stop_all() exceeded shutdown_drain_timeout=%ds, proceeding with exit",
+            timeout,
+        )

--- a/src/akgentic/infra/worker/deps.py
+++ b/src/akgentic/infra/worker/deps.py
@@ -1,0 +1,36 @@
+"""Dependency injection container for worker processes."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field, SkipValidation
+
+from akgentic.core import ActorSystem
+from akgentic.infra.protocols.runtime_cache import RuntimeCache
+from akgentic.infra.protocols.worker_handle import WorkerHandle
+from akgentic.team.manager import TeamManager
+from akgentic.team.ports import EventStore, ServiceRegistry
+
+
+class WorkerServices(BaseModel):
+    """Runtime DI container for worker processes.
+
+    Holds worker-side dependencies: team lifecycle management, actor system,
+    event sourcing, service discovery, and runtime caching. Enterprise and
+    department tiers extend this with tier-specific adapters (Dapr, Redis).
+
+    This is a runtime DI container, NOT a serialization model —
+    arbitrary_types_allowed is intentional (Golden Rule #1b exemption).
+    """
+
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+    team_manager: TeamManager = Field(description="Team lifecycle manager")
+    actor_system: ActorSystem = Field(description="Actor system for agent lifecycle")
+    event_store: SkipValidation[EventStore] = Field(
+        description="Persistence backend for team event sourcing"
+    )
+    service_registry: ServiceRegistry = Field(description="Service discovery registry")
+    runtime_cache: RuntimeCache = Field(
+        description="Cache mapping team IDs to live TeamHandle instances"
+    )
+    worker_handle: WorkerHandle = Field(description="Local worker handle for this process")

--- a/src/akgentic/infra/worker/routes/readiness.py
+++ b/src/akgentic/infra/worker/routes/readiness.py
@@ -1,0 +1,40 @@
+"""Readiness probe endpoint for worker load-balancer drain support."""
+
+from __future__ import annotations
+
+import logging
+from typing import Literal
+
+from fastapi import APIRouter, Request
+from fastapi.responses import JSONResponse
+from pydantic import BaseModel
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(tags=["readiness"])
+
+
+class ReadinessResponse(BaseModel):
+    """Response model for the readiness probe endpoint."""
+
+    status: Literal["ready", "draining"]
+
+
+@router.get("/readiness", response_model=ReadinessResponse)
+async def readiness(request: Request) -> ReadinessResponse | JSONResponse:
+    """Worker-level readiness probe for load-balancer traffic management.
+
+    Returns 200 when the worker is ready to accept traffic, or 503 when
+    the worker is draining (shutdown in progress).
+
+    Args:
+        request: The incoming HTTP request.
+
+    Returns:
+        ReadinessResponse with status "ready" (200) or "draining" (503).
+    """
+    draining: bool = getattr(request.app.state, "draining", False)
+    if draining:
+        logger.info("Readiness probe: draining")
+        return JSONResponse(content={"status": "draining"}, status_code=503)
+    return ReadinessResponse(status="ready")

--- a/src/akgentic/infra/worker/routes/teams.py
+++ b/src/akgentic/infra/worker/routes/teams.py
@@ -1,0 +1,141 @@
+"""Worker team operation routes — create, message, stop, delete, resume."""
+
+from __future__ import annotations
+
+import logging
+import uuid
+from typing import NoReturn, cast
+
+from fastapi import APIRouter, Depends, HTTPException, Request
+from pydantic import BaseModel, Field
+
+from akgentic.infra.server.models import SendMessageRequest, TeamResponse
+from akgentic.infra.worker.deps import WorkerServices
+from akgentic.team.models import Process, TeamCard, TeamRuntime
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/teams", tags=["teams"])
+
+
+class WorkerCreateTeamRequest(BaseModel):
+    """Request body for POST /teams on the worker.
+
+    The worker receives the already-resolved TeamCard and user_id from the
+    server — catalog resolution happens server-side.
+    """
+
+    team_card: TeamCard = Field(description="Pre-resolved TeamCard for team creation")
+    user_id: str = Field(description="Authenticated user identifier (from server)")
+
+
+def get_services(request: Request) -> WorkerServices:
+    """FastAPI dependency: extract WorkerServices from app.state."""
+    return cast(WorkerServices, request.app.state.services)
+
+
+def _process_to_response(process: Process) -> TeamResponse:
+    """Convert a Process model to a TeamResponse."""
+    return TeamResponse(
+        team_id=process.team_id,
+        name=process.team_card.name,
+        status=process.status.value,
+        user_id=process.user_id,
+        created_at=process.created_at,
+        updated_at=process.updated_at,
+    )
+
+
+@router.post("/", status_code=201, response_model=TeamResponse)
+def create_team(
+    body: WorkerCreateTeamRequest,
+    services: WorkerServices = Depends(get_services),
+) -> TeamResponse:
+    """Create a new team from a pre-resolved TeamCard.
+
+    The server resolves catalog_entry_id to a TeamCard and forwards it
+    to the worker. The worker calls team_manager.create_team() directly.
+    """
+    logger.info("POST /teams — user_id=%s", body.user_id)
+    runtime: TeamRuntime = services.team_manager.create_team(
+        team_card=body.team_card,
+        user_id=body.user_id,
+    )
+    process = services.worker_handle.get_team(runtime.id)
+    if process is None:  # pragma: no cover
+        msg = f"Team {runtime.id} was created but not found in event store"
+        raise RuntimeError(msg)
+    return _process_to_response(process)
+
+
+@router.post("/{team_id}/message", status_code=204)
+def send_message(
+    team_id: uuid.UUID,
+    body: SendMessageRequest,
+    services: WorkerServices = Depends(get_services),
+) -> None:
+    """Send a message to a running team on this worker."""
+    logger.info("POST /teams/%s/message", team_id)
+    handle = services.runtime_cache.get(team_id)
+    if handle is None:
+        raise HTTPException(status_code=404, detail="Team not found in worker cache")
+    try:
+        handle.send(body.content)
+    except ValueError as exc:
+        _raise_action_error(exc)
+
+
+@router.post("/{team_id}/stop", status_code=204)
+def stop_team(
+    team_id: uuid.UUID,
+    services: WorkerServices = Depends(get_services),
+) -> None:
+    """Stop a running team without deleting persisted data."""
+    logger.info("POST /teams/%s/stop", team_id)
+    try:
+        services.worker_handle.stop_team(team_id)
+    except ValueError as exc:
+        _raise_action_error(exc)
+
+
+@router.delete("/{team_id}", status_code=204)
+def delete_team(
+    team_id: uuid.UUID,
+    services: WorkerServices = Depends(get_services),
+) -> None:
+    """Delete a team and its resources."""
+    logger.info("DELETE /teams/%s", team_id)
+    try:
+        services.worker_handle.delete_team(team_id)
+    except ValueError as exc:
+        _raise_action_error(exc)
+
+
+@router.post("/{team_id}/resume", status_code=200, response_model=TeamResponse)
+def resume_team(
+    team_id: uuid.UUID,
+    services: WorkerServices = Depends(get_services),
+) -> TeamResponse:
+    """Resume a stopped team and return its metadata."""
+    logger.info("POST /teams/%s/resume", team_id)
+    try:
+        handle = services.worker_handle.resume_team(team_id)
+    except ValueError as exc:
+        _raise_action_error(exc)
+    services.runtime_cache.store(team_id, handle)
+    process = services.worker_handle.get_team(team_id)
+    if process is None:
+        raise HTTPException(status_code=404, detail="Team not found after resume")
+    return _process_to_response(process)
+
+
+def _raise_action_error(exc: ValueError) -> NoReturn:
+    """Map ValueError messages to appropriate HTTP status codes.
+
+    Raises:
+        HTTPException: 404 for not-found/deleted errors, 409 for state conflicts.
+    """
+    detail = str(exc)
+    if "not found" in detail or "deleted" in detail:
+        raise HTTPException(status_code=404, detail=detail) from None
+    raise HTTPException(status_code=409, detail=detail) from None

--- a/tests/worker/test_worker_app.py
+++ b/tests/worker/test_worker_app.py
@@ -3,26 +3,26 @@
 from __future__ import annotations
 
 import uuid
-from datetime import datetime, timezone
-from unittest.mock import MagicMock
+from datetime import UTC, datetime
+from unittest.mock import MagicMock, patch
 
 import pytest
+from akgentic.core import ActorSystem
+from akgentic.team.manager import TeamManager
+from akgentic.team.ports import EventStore, NullServiceRegistry
 from fastapi import FastAPI
 from httpx import ASGITransport, AsyncClient
 
-from akgentic.core import ActorSystem
 from akgentic.infra.protocols.runtime_cache import RuntimeCache
 from akgentic.infra.protocols.worker_handle import WorkerHandle
-from akgentic.infra.worker.app import create_worker_app
+from akgentic.infra.worker.app import _lifespan, create_worker_app
 from akgentic.infra.worker.deps import WorkerServices
 from akgentic.infra.worker.settings import WorkerSettings
-from akgentic.team.manager import TeamManager
-from akgentic.team.ports import EventStore, NullServiceRegistry
 
 
 def _make_mock_process(team_id: uuid.UUID | None = None) -> MagicMock:
     """Create a mock Process with the attributes routes need."""
-    now = datetime.now(tz=timezone.utc)
+    now = datetime.now(tz=UTC)
     process = MagicMock()
     process.team_id = team_id or uuid.uuid4()
     process.team_card.name = "Test Team"
@@ -219,3 +219,152 @@ class TestResumeTeam:
         data = resp.json()
         assert data["team_id"] == str(team_id)
         mock_services.runtime_cache.store.assert_called_once_with(team_id, mock_handle)  # type: ignore[attr-defined]
+
+    @pytest.mark.asyncio
+    async def test_resume_team_returns_404_when_not_found(
+        self, worker_app: FastAPI, mock_services: WorkerServices
+    ) -> None:
+        team_id = uuid.uuid4()
+        mock_services.worker_handle.resume_team.side_effect = ValueError(  # type: ignore[attr-defined]
+            "Team not found"
+        )
+        transport = ASGITransport(app=worker_app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            resp = await client.post(f"/teams/{team_id}/resume")
+        assert resp.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_resume_team_returns_409_on_conflict(
+        self, worker_app: FastAPI, mock_services: WorkerServices
+    ) -> None:
+        team_id = uuid.uuid4()
+        mock_services.worker_handle.resume_team.side_effect = ValueError(  # type: ignore[attr-defined]
+            "Team is already running"
+        )
+        transport = ASGITransport(app=worker_app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            resp = await client.post(f"/teams/{team_id}/resume")
+        assert resp.status_code == 409
+
+    @pytest.mark.asyncio
+    async def test_resume_team_returns_404_when_get_team_none(
+        self, worker_app: FastAPI, mock_services: WorkerServices
+    ) -> None:
+        team_id = uuid.uuid4()
+        mock_handle = MagicMock()
+        mock_services.worker_handle.resume_team.return_value = mock_handle  # type: ignore[attr-defined]
+        mock_services.worker_handle.get_team.return_value = None  # type: ignore[attr-defined]
+
+        transport = ASGITransport(app=worker_app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            resp = await client.post(f"/teams/{team_id}/resume")
+        assert resp.status_code == 404
+
+
+class TestSendMessageErrors:
+    """Error path tests for POST /teams/{team_id}/message."""
+
+    @pytest.mark.asyncio
+    async def test_send_message_returns_409_on_value_error(
+        self, worker_app: FastAPI, mock_services: WorkerServices
+    ) -> None:
+        team_id = uuid.uuid4()
+        mock_handle = MagicMock()
+        mock_handle.send.side_effect = ValueError("Team is already stopped")
+        mock_services.runtime_cache.get.return_value = mock_handle  # type: ignore[attr-defined]
+
+        transport = ASGITransport(app=worker_app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            resp = await client.post(
+                f"/teams/{team_id}/message",
+                json={"content": "hello"},
+            )
+        assert resp.status_code == 409
+
+
+class TestDeleteTeamErrors:
+    """Error path tests for DELETE /teams/{team_id}."""
+
+    @pytest.mark.asyncio
+    async def test_delete_team_returns_404_when_not_found(
+        self, worker_app: FastAPI, mock_services: WorkerServices
+    ) -> None:
+        team_id = uuid.uuid4()
+        mock_services.worker_handle.delete_team.side_effect = ValueError(  # type: ignore[attr-defined]
+            "Team not found"
+        )
+        transport = ASGITransport(app=worker_app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            resp = await client.delete(f"/teams/{team_id}")
+        assert resp.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_delete_team_returns_404_when_deleted(
+        self, worker_app: FastAPI, mock_services: WorkerServices
+    ) -> None:
+        team_id = uuid.uuid4()
+        mock_services.worker_handle.delete_team.side_effect = ValueError(  # type: ignore[attr-defined]
+            "Team already deleted"
+        )
+        transport = ASGITransport(app=worker_app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            resp = await client.delete(f"/teams/{team_id}")
+        assert resp.status_code == 404
+
+
+class TestStopTeamErrors:
+    """Additional error path tests for POST /teams/{team_id}/stop."""
+
+    @pytest.mark.asyncio
+    async def test_stop_team_returns_404_when_not_found(
+        self, worker_app: FastAPI, mock_services: WorkerServices
+    ) -> None:
+        team_id = uuid.uuid4()
+        mock_services.worker_handle.stop_team.side_effect = ValueError(  # type: ignore[attr-defined]
+            "Team not found"
+        )
+        transport = ASGITransport(app=worker_app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            resp = await client.post(f"/teams/{team_id}/stop")
+        assert resp.status_code == 404
+
+
+class TestLifespan:
+    """Worker lifespan handler tests."""
+
+    @pytest.mark.asyncio
+    async def test_lifespan_sets_draining_false_on_startup(
+        self, worker_app: FastAPI
+    ) -> None:
+        async with _lifespan(worker_app):
+            assert worker_app.state.draining is False
+
+    @pytest.mark.asyncio
+    async def test_lifespan_sets_draining_true_on_shutdown(
+        self, worker_app: FastAPI
+    ) -> None:
+        async with _lifespan(worker_app):
+            pass
+        assert worker_app.state.draining is True
+
+    @pytest.mark.asyncio
+    async def test_lifespan_calls_stop_all(self, worker_app: FastAPI) -> None:
+        async with _lifespan(worker_app):
+            pass
+        worker_app.state.services.worker_handle.stop_all.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_lifespan_handles_timeout(self, worker_app: FastAPI) -> None:
+        import asyncio
+
+        never_done: asyncio.Future[None] = asyncio.get_event_loop().create_future()
+
+        with patch(
+            "akgentic.infra.worker.app.asyncio.to_thread", return_value=never_done
+        ):
+            worker_app.state.settings = WorkerSettings(
+                shutdown_drain_timeout=0, shutdown_pre_drain_delay=0
+            )
+            async with _lifespan(worker_app):
+                pass
+        # Should not raise — timeout is handled gracefully

--- a/tests/worker/test_worker_app.py
+++ b/tests/worker/test_worker_app.py
@@ -1,0 +1,221 @@
+"""Tests for worker app factory and routes."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+from akgentic.core import ActorSystem
+from akgentic.infra.protocols.runtime_cache import RuntimeCache
+from akgentic.infra.protocols.worker_handle import WorkerHandle
+from akgentic.infra.worker.app import create_worker_app
+from akgentic.infra.worker.deps import WorkerServices
+from akgentic.infra.worker.settings import WorkerSettings
+from akgentic.team.manager import TeamManager
+from akgentic.team.ports import EventStore, NullServiceRegistry
+
+
+def _make_mock_process(team_id: uuid.UUID | None = None) -> MagicMock:
+    """Create a mock Process with the attributes routes need."""
+    now = datetime.now(tz=timezone.utc)
+    process = MagicMock()
+    process.team_id = team_id or uuid.uuid4()
+    process.team_card.name = "Test Team"
+    process.status.value = "running"
+    process.user_id = "test-user"
+    process.created_at = now
+    process.updated_at = now
+    return process
+
+
+@pytest.fixture()
+def mock_services() -> WorkerServices:
+    """Create WorkerServices with all-mocked dependencies."""
+    return WorkerServices(
+        team_manager=MagicMock(spec=TeamManager),
+        actor_system=MagicMock(spec=ActorSystem),
+        event_store=MagicMock(spec=EventStore),
+        service_registry=NullServiceRegistry(),
+        runtime_cache=MagicMock(spec=RuntimeCache),
+        worker_handle=MagicMock(spec=WorkerHandle),
+    )
+
+
+@pytest.fixture()
+def worker_app(mock_services: WorkerServices) -> FastAPI:
+    """Create a worker app with mocked services."""
+    settings = WorkerSettings()
+    return create_worker_app(mock_services, settings)
+
+
+class TestReadiness:
+    """Worker readiness endpoint tests (AC #4)."""
+
+    @pytest.mark.asyncio
+    async def test_readiness_returns_200(self, worker_app: FastAPI) -> None:
+        transport = ASGITransport(app=worker_app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            resp = await client.get("/readiness")
+        assert resp.status_code == 200
+        assert resp.json() == {"status": "ready"}
+
+    @pytest.mark.asyncio
+    async def test_readiness_returns_503_when_draining(self, worker_app: FastAPI) -> None:
+        worker_app.state.draining = True
+        transport = ASGITransport(app=worker_app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            resp = await client.get("/readiness")
+        assert resp.status_code == 503
+        assert resp.json() == {"status": "draining"}
+
+
+class TestCreateTeam:
+    """POST /teams route tests (AC #4)."""
+
+    @pytest.mark.asyncio
+    async def test_create_team_returns_201(
+        self, worker_app: FastAPI, mock_services: WorkerServices
+    ) -> None:
+        process = _make_mock_process()
+        mock_runtime = MagicMock()
+        mock_runtime.id = process.team_id
+        mock_services.team_manager.create_team.return_value = mock_runtime  # type: ignore[attr-defined]
+        mock_services.worker_handle.get_team.return_value = process  # type: ignore[attr-defined]
+
+        # Build a minimal valid TeamCard JSON payload
+        team_card_json = {
+            "name": "Test Team",
+            "description": "A test team",
+            "entry_point": {
+                "card": {
+                    "role": "Human",
+                    "description": "Human user",
+                    "skills": [],
+                    "agent_class": "akgentic.agent.HumanProxy",
+                    "config": {"name": "@Human", "role": "Human"},
+                },
+            },
+            "members": [],
+        }
+        transport = ASGITransport(app=worker_app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            resp = await client.post(
+                "/teams/",
+                json={
+                    "team_card": team_card_json,
+                    "user_id": "test-user",
+                },
+            )
+        assert resp.status_code == 201
+        data = resp.json()
+        assert data["team_id"] == str(process.team_id)
+        assert data["name"] == "Test Team"
+        assert data["status"] == "running"
+        assert data["user_id"] == "test-user"
+
+
+class TestSendMessage:
+    """POST /teams/{team_id}/message route tests (AC #4)."""
+
+    @pytest.mark.asyncio
+    async def test_send_message_returns_204(
+        self, worker_app: FastAPI, mock_services: WorkerServices
+    ) -> None:
+        team_id = uuid.uuid4()
+        mock_handle = MagicMock()
+        mock_services.runtime_cache.get.return_value = mock_handle  # type: ignore[attr-defined]
+
+        transport = ASGITransport(app=worker_app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            resp = await client.post(
+                f"/teams/{team_id}/message",
+                json={"content": "hello"},
+            )
+        assert resp.status_code == 204
+        mock_handle.send.assert_called_once_with("hello")
+
+    @pytest.mark.asyncio
+    async def test_send_message_returns_404_when_not_cached(
+        self, worker_app: FastAPI, mock_services: WorkerServices
+    ) -> None:
+        team_id = uuid.uuid4()
+        mock_services.runtime_cache.get.return_value = None  # type: ignore[attr-defined]
+
+        transport = ASGITransport(app=worker_app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            resp = await client.post(
+                f"/teams/{team_id}/message",
+                json={"content": "hello"},
+            )
+        assert resp.status_code == 404
+
+
+class TestStopTeam:
+    """POST /teams/{team_id}/stop route tests (AC #4)."""
+
+    @pytest.mark.asyncio
+    async def test_stop_team_returns_204(
+        self, worker_app: FastAPI, mock_services: WorkerServices
+    ) -> None:
+        team_id = uuid.uuid4()
+        transport = ASGITransport(app=worker_app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            resp = await client.post(f"/teams/{team_id}/stop")
+        assert resp.status_code == 204
+        mock_services.worker_handle.stop_team.assert_called_once_with(team_id)  # type: ignore[attr-defined]
+
+    @pytest.mark.asyncio
+    async def test_stop_team_returns_409_on_conflict(
+        self, worker_app: FastAPI, mock_services: WorkerServices
+    ) -> None:
+        team_id = uuid.uuid4()
+        mock_services.worker_handle.stop_team.side_effect = ValueError(  # type: ignore[attr-defined]
+            "Team is already stopped"
+        )
+
+        transport = ASGITransport(app=worker_app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            resp = await client.post(f"/teams/{team_id}/stop")
+        assert resp.status_code == 409
+
+
+class TestDeleteTeam:
+    """DELETE /teams/{team_id} route tests (AC #4)."""
+
+    @pytest.mark.asyncio
+    async def test_delete_team_returns_204(
+        self, worker_app: FastAPI, mock_services: WorkerServices
+    ) -> None:
+        team_id = uuid.uuid4()
+        transport = ASGITransport(app=worker_app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            resp = await client.delete(f"/teams/{team_id}")
+        assert resp.status_code == 204
+        mock_services.worker_handle.delete_team.assert_called_once_with(team_id)  # type: ignore[attr-defined]
+
+
+class TestResumeTeam:
+    """POST /teams/{team_id}/resume route tests (AC #4)."""
+
+    @pytest.mark.asyncio
+    async def test_resume_team_returns_200(
+        self, worker_app: FastAPI, mock_services: WorkerServices
+    ) -> None:
+        team_id = uuid.uuid4()
+        process = _make_mock_process(team_id)
+        mock_handle = MagicMock()
+        mock_services.worker_handle.resume_team.return_value = mock_handle  # type: ignore[attr-defined]
+        mock_services.worker_handle.get_team.return_value = process  # type: ignore[attr-defined]
+
+        transport = ASGITransport(app=worker_app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            resp = await client.post(f"/teams/{team_id}/resume")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["team_id"] == str(team_id)
+        mock_services.runtime_cache.store.assert_called_once_with(team_id, mock_handle)  # type: ignore[attr-defined]

--- a/tests/worker/test_worker_deps.py
+++ b/tests/worker/test_worker_deps.py
@@ -1,0 +1,67 @@
+"""Tests for WorkerServices DI container."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from akgentic.core import ActorSystem
+from akgentic.infra.protocols.runtime_cache import RuntimeCache
+from akgentic.infra.protocols.worker_handle import WorkerHandle
+from akgentic.infra.worker.deps import WorkerServices
+from akgentic.team.manager import TeamManager
+from akgentic.team.ports import EventStore, NullServiceRegistry, ServiceRegistry
+
+
+class TestWorkerServicesConstruction:
+    """WorkerServices must accept community-tier concrete types (AC #2)."""
+
+    def test_worker_services_accepts_community_adapters(self) -> None:
+        """Construct WorkerServices with the same types used by wire_community()."""
+        team_manager = MagicMock(spec=TeamManager)
+        actor_system = MagicMock(spec=ActorSystem)
+        event_store = MagicMock(spec=EventStore)
+        service_registry = NullServiceRegistry()
+        runtime_cache = MagicMock(spec=RuntimeCache)
+        worker_handle = MagicMock(spec=WorkerHandle)
+
+        services = WorkerServices(
+            team_manager=team_manager,
+            actor_system=actor_system,
+            event_store=event_store,
+            service_registry=service_registry,
+            runtime_cache=runtime_cache,
+            worker_handle=worker_handle,
+        )
+
+        assert services.team_manager is team_manager
+        assert services.actor_system is actor_system
+        assert services.event_store is event_store
+        assert services.service_registry is service_registry
+        assert services.runtime_cache is runtime_cache
+        assert services.worker_handle is worker_handle
+
+
+class TestWorkerServicesModel:
+    """WorkerServices model structure and metadata (AC #1)."""
+
+    def test_has_required_fields(self) -> None:
+        expected_fields = {
+            "team_manager",
+            "actor_system",
+            "event_store",
+            "service_registry",
+            "runtime_cache",
+            "worker_handle",
+        }
+        assert set(WorkerServices.model_fields.keys()) == expected_fields
+
+    def test_field_descriptions_present(self) -> None:
+        for name, field_info in WorkerServices.model_fields.items():
+            assert field_info.description is not None, f"Field {name} missing description"
+
+    def test_arbitrary_types_allowed(self) -> None:
+        assert WorkerServices.model_config.get("arbitrary_types_allowed") is True
+
+    def test_service_registry_is_runtime_checkable(self) -> None:
+        registry = NullServiceRegistry()
+        assert isinstance(registry, ServiceRegistry)


### PR DESCRIPTION
## Summary
- Add `WorkerServices(BaseModel)` DI container at `worker/deps.py` with 6 protocol-typed fields mirroring TierServices pattern
- Implement worker team routes (create/message/stop/delete/resume) at `worker/routes/teams.py` with correct status codes
- Add `create_worker_app()` factory with lifespan handler for graceful shutdown
- Readiness endpoint at `worker/routes/readiness.py`
- Export `WorkerServices` and `create_worker_app` from `worker/__init__.py`
- 20 tests covering happy paths, error paths, and lifespan behavior
- Zero imports from Dapr, Redis, or tier-specific dependencies

Closes #212