### PR TITLE
WorkerLifecycle service for startup registration and graceful shutdown

### DIFF
--- a/src/akgentic/infra/worker/__init__.py
+++ b/src/akgentic/infra/worker/__init__.py
@@ -2,6 +2,7 @@
 
 from akgentic.infra.worker.app import create_worker_app
 from akgentic.infra.worker.deps import WorkerServices
+from akgentic.infra.worker.services.lifecycle import WorkerLifecycle
 from akgentic.infra.worker.settings import WorkerSettings
 
-__all__ = ["WorkerSettings", "WorkerServices", "create_worker_app"]
+__all__ = ["WorkerLifecycle", "WorkerSettings", "WorkerServices", "create_worker_app"]

--- a/src/akgentic/infra/worker/app.py
+++ b/src/akgentic/infra/worker/app.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import uuid
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 
@@ -13,6 +14,7 @@ from akgentic.infra.server.logging_config import configure_logging
 from akgentic.infra.worker.deps import WorkerServices
 from akgentic.infra.worker.routes.readiness import router as readiness_router
 from akgentic.infra.worker.routes.teams import router as teams_router
+from akgentic.infra.worker.services.lifecycle import WorkerLifecycle
 from akgentic.infra.worker.settings import WorkerSettings
 
 logger = logging.getLogger(__name__)
@@ -38,6 +40,11 @@ def create_worker_app(
     app = FastAPI(title="Akgentic Worker", lifespan=_lifespan)
     app.state.services = services
     app.state.settings = settings
+    app.state.lifecycle = WorkerLifecycle(
+        worker_handle=services.worker_handle,
+        service_registry=services.service_registry,
+        instance_id=uuid.uuid4(),
+    )
     app.include_router(readiness_router)
     app.include_router(teams_router)
 
@@ -49,12 +56,13 @@ def create_worker_app(
 async def _lifespan(app: FastAPI) -> AsyncIterator[None]:
     """FastAPI lifespan handler for worker graceful shutdown.
 
-    Startup: sets ``app.state.draining = False``.
-    Shutdown: sets draining flag, waits pre-drain delay, then stops all
-    teams via ``worker_handle.stop_all()``.
+    Startup: sets ``app.state.draining = False`` and registers with service registry.
+    Shutdown: sets draining flag, waits pre-drain delay, then delegates to
+    ``WorkerLifecycle.shutdown()`` for deregistration and team teardown.
     """
     app.state.draining = False
     logger.info("Worker lifespan startup: draining=False")
+    await app.state.lifecycle.startup()
     yield
     # --- Shutdown sequence ---
     app.state.draining = True
@@ -66,16 +74,4 @@ async def _lifespan(app: FastAPI) -> AsyncIterator[None]:
         logger.info("Pre-drain delay: sleeping %ds", delay)
         await asyncio.sleep(delay)
 
-    timeout = settings.shutdown_drain_timeout
-    logger.info("Stopping all teams (timeout=%ds)", timeout)
-    try:
-        await asyncio.wait_for(
-            asyncio.to_thread(app.state.services.worker_handle.stop_all),
-            timeout=timeout,
-        )
-        logger.info("stop_all() completed successfully")
-    except TimeoutError:
-        logger.warning(
-            "stop_all() exceeded shutdown_drain_timeout=%ds, proceeding with exit",
-            timeout,
-        )
+    await app.state.lifecycle.shutdown(drain_timeout=settings.shutdown_drain_timeout)

--- a/src/akgentic/infra/worker/services/__init__.py
+++ b/src/akgentic/infra/worker/services/__init__.py
@@ -1,0 +1,5 @@
+"""Worker services — lifecycle management and related service abstractions."""
+
+from akgentic.infra.worker.services.lifecycle import WorkerLifecycle
+
+__all__ = ["WorkerLifecycle"]

--- a/src/akgentic/infra/worker/services/lifecycle.py
+++ b/src/akgentic/infra/worker/services/lifecycle.py
@@ -1,0 +1,65 @@
+"""Worker lifecycle management — startup registration and graceful shutdown."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import uuid
+
+from akgentic.infra.protocols.worker_handle import WorkerHandle
+from akgentic.team.ports import ServiceRegistry
+
+logger = logging.getLogger(__name__)
+
+
+class WorkerLifecycle:
+    """Manages worker startup registration and graceful shutdown.
+
+    Startup registers the worker instance with the ``ServiceRegistry``.
+    Shutdown deregisters the instance, then stops all running teams via
+    ``WorkerHandle.stop_all()`` with a configurable drain timeout.
+
+    Enterprise tiers extend this class for Dapr-specific registration
+    and TTL-based heartbeats. Community tier uses ``NullServiceRegistry``
+    (all methods are no-ops).
+    """
+
+    def __init__(
+        self,
+        worker_handle: WorkerHandle,
+        service_registry: ServiceRegistry,
+        instance_id: uuid.UUID,
+    ) -> None:
+        self._worker_handle = worker_handle
+        self._service_registry = service_registry
+        self._instance_id = instance_id
+
+    async def startup(self) -> None:
+        """Register this worker instance with the service registry."""
+        logger.info("WorkerLifecycle startup: registering instance %s", self._instance_id)
+        await asyncio.to_thread(self._service_registry.register_instance, self._instance_id)
+        logger.info("WorkerLifecycle startup: registered instance %s", self._instance_id)
+
+    async def shutdown(self, drain_timeout: int) -> None:
+        """Deregister this worker instance and stop all running teams.
+
+        Args:
+            drain_timeout: Maximum seconds to wait for ``stop_all()`` to complete.
+        """
+        logger.info("WorkerLifecycle shutdown: deregistering instance %s", self._instance_id)
+        await asyncio.to_thread(self._service_registry.deregister_instance, self._instance_id)
+        logger.info("WorkerLifecycle shutdown: deregistered instance %s", self._instance_id)
+
+        logger.info("WorkerLifecycle shutdown: stopping all teams (timeout=%ds)", drain_timeout)
+        try:
+            await asyncio.wait_for(
+                asyncio.to_thread(self._worker_handle.stop_all),
+                timeout=drain_timeout,
+            )
+            logger.info("WorkerLifecycle shutdown: stop_all() completed successfully")
+        except TimeoutError:
+            logger.warning(
+                "WorkerLifecycle shutdown: stop_all() exceeded drain_timeout=%ds, "
+                "proceeding with exit",
+                drain_timeout,
+            )

--- a/src/akgentic/infra/worker/services/lifecycle.py
+++ b/src/akgentic/infra/worker/services/lifecycle.py
@@ -47,8 +47,15 @@ class WorkerLifecycle:
             drain_timeout: Maximum seconds to wait for ``stop_all()`` to complete.
         """
         logger.info("WorkerLifecycle shutdown: deregistering instance %s", self._instance_id)
-        await asyncio.to_thread(self._service_registry.deregister_instance, self._instance_id)
-        logger.info("WorkerLifecycle shutdown: deregistered instance %s", self._instance_id)
+        try:
+            await asyncio.to_thread(self._service_registry.deregister_instance, self._instance_id)
+            logger.info("WorkerLifecycle shutdown: deregistered instance %s", self._instance_id)
+        except Exception:
+            logger.exception(
+                "WorkerLifecycle shutdown: deregister_instance failed for %s, "
+                "proceeding with stop_all",
+                self._instance_id,
+            )
 
         logger.info("WorkerLifecycle shutdown: stopping all teams (timeout=%ds)", drain_timeout)
         try:

--- a/tests/worker/test_worker_app.py
+++ b/tests/worker/test_worker_app.py
@@ -355,16 +355,13 @@ class TestLifespan:
 
     @pytest.mark.asyncio
     async def test_lifespan_handles_timeout(self, worker_app: FastAPI) -> None:
-        import asyncio
-
-        never_done: asyncio.Future[None] = asyncio.get_event_loop().create_future()
-
         with patch(
-            "akgentic.infra.worker.app.asyncio.to_thread", return_value=never_done
+            "akgentic.infra.worker.services.lifecycle.asyncio.wait_for",
+            side_effect=TimeoutError,
         ):
             worker_app.state.settings = WorkerSettings(
                 shutdown_drain_timeout=0, shutdown_pre_drain_delay=0
             )
             async with _lifespan(worker_app):
                 pass
-        # Should not raise — timeout is handled gracefully
+        # Should not raise — timeout is handled gracefully in WorkerLifecycle

--- a/tests/worker/test_worker_lifecycle.py
+++ b/tests/worker/test_worker_lifecycle.py
@@ -1,0 +1,171 @@
+"""Tests for WorkerLifecycle service."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import uuid
+from unittest.mock import MagicMock, patch
+
+import pytest
+from akgentic.team.ports import NullServiceRegistry, ServiceRegistry
+
+from akgentic.infra.protocols.worker_handle import WorkerHandle
+from akgentic.infra.worker.services.lifecycle import WorkerLifecycle
+
+
+@pytest.fixture()
+def instance_id() -> uuid.UUID:
+    return uuid.uuid4()
+
+
+@pytest.fixture()
+def mock_worker_handle() -> MagicMock:
+    return MagicMock(spec=WorkerHandle)
+
+
+@pytest.fixture()
+def mock_service_registry() -> MagicMock:
+    return MagicMock(spec=ServiceRegistry)
+
+
+@pytest.fixture()
+def lifecycle(
+    mock_worker_handle: MagicMock,
+    mock_service_registry: MagicMock,
+    instance_id: uuid.UUID,
+) -> WorkerLifecycle:
+    return WorkerLifecycle(
+        worker_handle=mock_worker_handle,
+        service_registry=mock_service_registry,
+        instance_id=instance_id,
+    )
+
+
+class TestStartup:
+    """WorkerLifecycle.startup() tests (AC #2)."""
+
+    @pytest.mark.asyncio
+    async def test_startup_registers_instance(
+        self,
+        lifecycle: WorkerLifecycle,
+        mock_service_registry: MagicMock,
+        instance_id: uuid.UUID,
+    ) -> None:
+        await lifecycle.startup()
+        mock_service_registry.register_instance.assert_called_once_with(instance_id)
+
+
+class TestShutdown:
+    """WorkerLifecycle.shutdown() tests (AC #3, #6)."""
+
+    @pytest.mark.asyncio
+    async def test_shutdown_deregisters_and_stops(
+        self,
+        lifecycle: WorkerLifecycle,
+        mock_service_registry: MagicMock,
+        mock_worker_handle: MagicMock,
+        instance_id: uuid.UUID,
+    ) -> None:
+        await lifecycle.shutdown(drain_timeout=30)
+        mock_service_registry.deregister_instance.assert_called_once_with(instance_id)
+        mock_worker_handle.stop_all.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_shutdown_deregisters_before_stop_all(
+        self,
+        lifecycle: WorkerLifecycle,
+        mock_service_registry: MagicMock,
+        mock_worker_handle: MagicMock,
+    ) -> None:
+        """Deregister must happen before stop_all (no new teams routed while stopping)."""
+        call_order: list[str] = []
+        mock_service_registry.deregister_instance.side_effect = (
+            lambda _: call_order.append("deregister")
+        )
+        mock_worker_handle.stop_all.side_effect = lambda: call_order.append("stop_all")
+
+        await lifecycle.shutdown(drain_timeout=30)
+        assert call_order == ["deregister", "stop_all"]
+
+    @pytest.mark.asyncio
+    async def test_shutdown_timeout_logged_not_raised(
+        self,
+        lifecycle: WorkerLifecycle,
+        mock_worker_handle: MagicMock,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """TimeoutError from stop_all() is caught and logged, not raised."""
+
+        def hang() -> None:
+            raise TimeoutError
+
+        with patch(
+            "akgentic.infra.worker.services.lifecycle.asyncio.wait_for",
+            side_effect=TimeoutError,
+        ):
+            with caplog.at_level(logging.WARNING):
+                await lifecycle.shutdown(drain_timeout=1)
+
+        assert any("exceeded drain_timeout" in rec.message for rec in caplog.records)
+
+
+class TestNullServiceRegistry:
+    """WorkerLifecycle with NullServiceRegistry (AC #4)."""
+
+    @pytest.mark.asyncio
+    async def test_works_with_null_service_registry(
+        self,
+        mock_worker_handle: MagicMock,
+    ) -> None:
+        """Community tier path — NullServiceRegistry no-ops, no errors."""
+        null_registry = NullServiceRegistry()
+        lc = WorkerLifecycle(
+            worker_handle=mock_worker_handle,
+            service_registry=null_registry,
+            instance_id=uuid.uuid4(),
+        )
+        await lc.startup()
+        await lc.shutdown(drain_timeout=5)
+        mock_worker_handle.stop_all.assert_called_once()
+
+
+class TestLifespanDelegation:
+    """Lifespan handler delegates to WorkerLifecycle (AC #5)."""
+
+    @pytest.mark.asyncio
+    async def test_lifespan_delegates_to_lifecycle(self) -> None:
+        """Create a worker app, invoke _lifespan directly, verify lifecycle methods called."""
+        from unittest.mock import AsyncMock
+
+        from akgentic.core import ActorSystem
+        from akgentic.team.manager import TeamManager
+        from akgentic.team.ports import EventStore
+
+        from akgentic.infra.protocols.runtime_cache import RuntimeCache
+        from akgentic.infra.worker.app import _lifespan, create_worker_app
+        from akgentic.infra.worker.deps import WorkerServices
+        from akgentic.infra.worker.settings import WorkerSettings
+
+        services = WorkerServices(
+            team_manager=MagicMock(spec=TeamManager),
+            actor_system=MagicMock(spec=ActorSystem),
+            event_store=MagicMock(spec=EventStore),
+            service_registry=NullServiceRegistry(),
+            runtime_cache=MagicMock(spec=RuntimeCache),
+            worker_handle=MagicMock(spec=WorkerHandle),
+        )
+        settings = WorkerSettings(shutdown_drain_timeout=1, shutdown_pre_drain_delay=0)
+        app = create_worker_app(services, settings)
+
+        # Replace lifecycle with a mock to verify delegation
+        mock_lifecycle = MagicMock()
+        mock_lifecycle.startup = AsyncMock()
+        mock_lifecycle.shutdown = AsyncMock()
+        app.state.lifecycle = mock_lifecycle
+
+        async with _lifespan(app):
+            assert app.state.draining is False
+            mock_lifecycle.startup.assert_called_once()
+
+        mock_lifecycle.shutdown.assert_called_once_with(drain_timeout=1)

--- a/tests/worker/test_worker_lifecycle.py
+++ b/tests/worker/test_worker_lifecycle.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import asyncio
 import logging
 import uuid
 from unittest.mock import MagicMock, patch
@@ -96,10 +95,6 @@ class TestShutdown:
         caplog: pytest.LogCaptureFixture,
     ) -> None:
         """TimeoutError from stop_all() is caught and logged, not raised."""
-
-        def hang() -> None:
-            raise TimeoutError
-
         with patch(
             "akgentic.infra.worker.services.lifecycle.asyncio.wait_for",
             side_effect=TimeoutError,
@@ -108,6 +103,28 @@ class TestShutdown:
                 await lifecycle.shutdown(drain_timeout=1)
 
         assert any("exceeded drain_timeout" in rec.message for rec in caplog.records)
+
+
+    @pytest.mark.asyncio
+    async def test_shutdown_stop_all_runs_even_if_deregister_fails(
+        self,
+        mock_worker_handle: MagicMock,
+        mock_service_registry: MagicMock,
+        instance_id: uuid.UUID,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """stop_all() must execute even if deregister_instance() raises."""
+        mock_service_registry.deregister_instance.side_effect = RuntimeError("registry down")
+        lc = WorkerLifecycle(
+            worker_handle=mock_worker_handle,
+            service_registry=mock_service_registry,
+            instance_id=instance_id,
+        )
+        with caplog.at_level(logging.ERROR):
+            await lc.shutdown(drain_timeout=30)
+
+        mock_worker_handle.stop_all.assert_called_once()
+        assert any("deregister_instance failed" in rec.message for rec in caplog.records)
 
 
 class TestNullServiceRegistry:


### PR DESCRIPTION
## Summary

- Add `WorkerLifecycle` class with `startup()` and `shutdown()` async methods for worker registration/deregistration with `ServiceRegistry`
- Refactor `_lifespan` in `worker/app.py` to delegate to `WorkerLifecycle` instead of inline shutdown logic
- `shutdown()` deregisters before `stop_all()`, respects drain timeout, catches `TimeoutError`
- Community tier uses `NullServiceRegistry` (no-ops); enterprise extends for Dapr registration

## Code Review Fixes

- Fixed stale mock patch in `test_lifespan_handles_timeout` — now targets lifecycle module
- Removed dead `hang()` function from test
- Protected `stop_all()` from `deregister_instance()` failure — deregister wrapped in try/except
- Added test for deregister failure path (41 worker tests total, all passing)

Closes #214