### PR TITLE
Complete Worker Route Protocol Parity

### DIFF
--- a/src/akgentic/infra/worker/routes/teams.py
+++ b/src/akgentic/infra/worker/routes/teams.py
@@ -1,4 +1,7 @@
-"""Worker team operation routes — create, message, stop, delete, resume."""
+"""Worker team operation routes.
+
+create, message, send_to, send_from_to, human-input, get, stop, delete, resume.
+"""
 
 from __future__ import annotations
 
@@ -9,9 +12,11 @@ from typing import NoReturn, cast
 from fastapi import APIRouter, Depends, HTTPException, Request
 from pydantic import BaseModel, Field
 
-from akgentic.infra.server.models import SendMessageRequest, TeamResponse
+from akgentic.core.messages.message import Message
+from akgentic.infra.server.models import HumanInputRequest, SendMessageRequest, TeamResponse
 from akgentic.infra.worker.deps import WorkerServices
 from akgentic.team.models import Process, TeamCard, TeamRuntime
+from akgentic.team.ports import EventStore
 
 logger = logging.getLogger(__name__)
 
@@ -44,6 +49,19 @@ def _process_to_response(process: Process) -> TeamResponse:
         created_at=process.created_at,
         updated_at=process.updated_at,
     )
+
+
+@router.get("/{team_id}", response_model=TeamResponse)
+def get_team(
+    team_id: uuid.UUID,
+    services: WorkerServices = Depends(get_services),
+) -> TeamResponse:
+    """Get team metadata by ID."""
+    logger.info("GET /teams/%s", team_id)
+    process = services.worker_handle.get_team(team_id)
+    if process is None:
+        raise HTTPException(status_code=404, detail="Team not found")
+    return _process_to_response(process)
 
 
 @router.post("/", status_code=201, response_model=TeamResponse)
@@ -81,6 +99,82 @@ def send_message(
         raise HTTPException(status_code=404, detail="Team not found in worker cache")
     try:
         handle.send(body.content)
+    except ValueError as exc:
+        _raise_action_error(exc)
+
+
+@router.post("/{team_id}/message/{agent_name}", status_code=204)
+def send_message_to_agent(
+    team_id: uuid.UUID,
+    agent_name: str,
+    body: SendMessageRequest,
+    services: WorkerServices = Depends(get_services),
+) -> None:
+    """Send a message to a specific agent within a running team."""
+    logger.info("POST /teams/%s/message/%s", team_id, agent_name)
+    handle = services.runtime_cache.get(team_id)
+    if handle is None:
+        raise HTTPException(status_code=404, detail="Team not found in worker cache")
+    try:
+        handle.send_to(agent_name, body.content)
+    except ValueError as exc:
+        _raise_action_error(exc)
+
+
+@router.post(
+    "/{team_id}/message/from/{sender_name}/to/{recipient_name}",
+    status_code=204,
+)
+def send_message_from_to(
+    team_id: uuid.UUID,
+    sender_name: str,
+    recipient_name: str,
+    body: SendMessageRequest,
+    services: WorkerServices = Depends(get_services),
+) -> None:
+    """Send a message from a specific agent to another agent."""
+    logger.info(
+        "POST /teams/%s/message/from/%s/to/%s", team_id, sender_name, recipient_name
+    )
+    handle = services.runtime_cache.get(team_id)
+    if handle is None:
+        raise HTTPException(status_code=404, detail="Team not found in worker cache")
+    try:
+        handle.send_from_to(sender_name, recipient_name, body.content)
+    except ValueError as exc:
+        _raise_action_error(exc)
+
+
+def _find_message(
+    event_store: EventStore, team_id: uuid.UUID, message_id: str
+) -> Message:
+    """Find a message by ID in persisted events.
+
+    Raises:
+        ValueError: If message not found.
+    """
+    events = event_store.load_events(team_id)
+    for ev in events:
+        if str(ev.event.id) == message_id:
+            return ev.event
+    msg = f"Message {message_id} not found"
+    raise ValueError(msg)
+
+
+@router.post("/{team_id}/human-input", status_code=204)
+def human_input(
+    team_id: uuid.UUID,
+    body: HumanInputRequest,
+    services: WorkerServices = Depends(get_services),
+) -> None:
+    """Process human input for a running team."""
+    logger.info("POST /teams/%s/human-input", team_id)
+    handle = services.runtime_cache.get(team_id)
+    if handle is None:
+        raise HTTPException(status_code=404, detail="Team not found in worker cache")
+    try:
+        original_message = _find_message(services.event_store, team_id, body.message_id)
+        handle.process_human_input(body.content, original_message)
     except ValueError as exc:
         _raise_action_error(exc)
 

--- a/tests/worker/test_worker_app.py
+++ b/tests/worker/test_worker_app.py
@@ -155,6 +155,227 @@ class TestSendMessage:
         assert resp.status_code == 404
 
 
+class TestGetTeam:
+    """GET /teams/{team_id} route tests (AC #1)."""
+
+    @pytest.mark.asyncio
+    async def test_get_team_returns_team_response(
+        self, worker_app: FastAPI, mock_services: WorkerServices
+    ) -> None:
+        team_id = uuid.uuid4()
+        process = _make_mock_process(team_id)
+        mock_services.worker_handle.get_team.return_value = process  # type: ignore[attr-defined]
+
+        transport = ASGITransport(app=worker_app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            resp = await client.get(f"/teams/{team_id}")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["team_id"] == str(team_id)
+        assert data["name"] == "Test Team"
+        assert data["status"] == "running"
+
+    @pytest.mark.asyncio
+    async def test_get_team_returns_404_when_not_found(
+        self, worker_app: FastAPI, mock_services: WorkerServices
+    ) -> None:
+        team_id = uuid.uuid4()
+        mock_services.worker_handle.get_team.return_value = None  # type: ignore[attr-defined]
+
+        transport = ASGITransport(app=worker_app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            resp = await client.get(f"/teams/{team_id}")
+        assert resp.status_code == 404
+
+
+class TestSendMessageToAgent:
+    """POST /teams/{team_id}/message/{agent_name} route tests (AC #2)."""
+
+    @pytest.mark.asyncio
+    async def test_send_to_agent_returns_204(
+        self, worker_app: FastAPI, mock_services: WorkerServices
+    ) -> None:
+        team_id = uuid.uuid4()
+        mock_handle = MagicMock()
+        mock_services.runtime_cache.get.return_value = mock_handle  # type: ignore[attr-defined]
+
+        transport = ASGITransport(app=worker_app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            resp = await client.post(
+                f"/teams/{team_id}/message/TestAgent",
+                json={"content": "hello agent"},
+            )
+        assert resp.status_code == 204
+        mock_handle.send_to.assert_called_once_with("TestAgent", "hello agent")
+
+    @pytest.mark.asyncio
+    async def test_send_to_agent_returns_404_when_not_in_cache(
+        self, worker_app: FastAPI, mock_services: WorkerServices
+    ) -> None:
+        team_id = uuid.uuid4()
+        mock_services.runtime_cache.get.return_value = None  # type: ignore[attr-defined]
+
+        transport = ASGITransport(app=worker_app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            resp = await client.post(
+                f"/teams/{team_id}/message/TestAgent",
+                json={"content": "hello"},
+            )
+        assert resp.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_send_to_agent_returns_409_on_state_conflict(
+        self, worker_app: FastAPI, mock_services: WorkerServices
+    ) -> None:
+        team_id = uuid.uuid4()
+        mock_handle = MagicMock()
+        mock_handle.send_to.side_effect = ValueError("team is stopped")
+        mock_services.runtime_cache.get.return_value = mock_handle  # type: ignore[attr-defined]
+
+        transport = ASGITransport(app=worker_app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            resp = await client.post(
+                f"/teams/{team_id}/message/TestAgent",
+                json={"content": "hello"},
+            )
+        assert resp.status_code == 409
+
+
+class TestSendMessageFromTo:
+    """POST /teams/{team_id}/message/from/{sender}/to/{recipient} route tests (AC #3)."""
+
+    @pytest.mark.asyncio
+    async def test_send_from_to_returns_204(
+        self, worker_app: FastAPI, mock_services: WorkerServices
+    ) -> None:
+        team_id = uuid.uuid4()
+        mock_handle = MagicMock()
+        mock_services.runtime_cache.get.return_value = mock_handle  # type: ignore[attr-defined]
+
+        transport = ASGITransport(app=worker_app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            resp = await client.post(
+                f"/teams/{team_id}/message/from/Alice/to/Bob",
+                json={"content": "hello bob"},
+            )
+        assert resp.status_code == 204
+        mock_handle.send_from_to.assert_called_once_with("Alice", "Bob", "hello bob")
+
+    @pytest.mark.asyncio
+    async def test_send_from_to_returns_404_when_not_in_cache(
+        self, worker_app: FastAPI, mock_services: WorkerServices
+    ) -> None:
+        team_id = uuid.uuid4()
+        mock_services.runtime_cache.get.return_value = None  # type: ignore[attr-defined]
+
+        transport = ASGITransport(app=worker_app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            resp = await client.post(
+                f"/teams/{team_id}/message/from/Alice/to/Bob",
+                json={"content": "hello"},
+            )
+        assert resp.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_send_from_to_returns_409_on_state_conflict(
+        self, worker_app: FastAPI, mock_services: WorkerServices
+    ) -> None:
+        team_id = uuid.uuid4()
+        mock_handle = MagicMock()
+        mock_handle.send_from_to.side_effect = ValueError("team is stopped")
+        mock_services.runtime_cache.get.return_value = mock_handle  # type: ignore[attr-defined]
+
+        transport = ASGITransport(app=worker_app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            resp = await client.post(
+                f"/teams/{team_id}/message/from/Alice/to/Bob",
+                json={"content": "hello"},
+            )
+        assert resp.status_code == 409
+
+
+class TestHumanInput:
+    """POST /teams/{team_id}/human-input route tests (AC #4)."""
+
+    @pytest.mark.asyncio
+    async def test_human_input_returns_204(
+        self, worker_app: FastAPI, mock_services: WorkerServices
+    ) -> None:
+        team_id = uuid.uuid4()
+        message_id = uuid.uuid4()
+        mock_handle = MagicMock()
+        mock_services.runtime_cache.get.return_value = mock_handle  # type: ignore[attr-defined]
+
+        mock_event = MagicMock()
+        mock_event.event.id = message_id
+        mock_services.event_store.load_events.return_value = [mock_event]  # type: ignore[attr-defined]
+
+        transport = ASGITransport(app=worker_app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            resp = await client.post(
+                f"/teams/{team_id}/human-input",
+                json={"content": "user reply", "message_id": str(message_id)},
+            )
+        assert resp.status_code == 204
+        mock_handle.process_human_input.assert_called_once_with(
+            "user reply", mock_event.event
+        )
+
+    @pytest.mark.asyncio
+    async def test_human_input_returns_404_when_not_in_cache(
+        self, worker_app: FastAPI, mock_services: WorkerServices
+    ) -> None:
+        team_id = uuid.uuid4()
+        mock_services.runtime_cache.get.return_value = None  # type: ignore[attr-defined]
+
+        transport = ASGITransport(app=worker_app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            resp = await client.post(
+                f"/teams/{team_id}/human-input",
+                json={"content": "reply", "message_id": str(uuid.uuid4())},
+            )
+        assert resp.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_human_input_returns_404_when_message_not_found(
+        self, worker_app: FastAPI, mock_services: WorkerServices
+    ) -> None:
+        team_id = uuid.uuid4()
+        mock_handle = MagicMock()
+        mock_services.runtime_cache.get.return_value = mock_handle  # type: ignore[attr-defined]
+        mock_services.event_store.load_events.return_value = []  # type: ignore[attr-defined]
+
+        transport = ASGITransport(app=worker_app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            resp = await client.post(
+                f"/teams/{team_id}/human-input",
+                json={"content": "reply", "message_id": str(uuid.uuid4())},
+            )
+        assert resp.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_human_input_returns_409_on_state_conflict(
+        self, worker_app: FastAPI, mock_services: WorkerServices
+    ) -> None:
+        team_id = uuid.uuid4()
+        message_id = uuid.uuid4()
+        mock_handle = MagicMock()
+        mock_handle.process_human_input.side_effect = ValueError("team is stopped")
+        mock_services.runtime_cache.get.return_value = mock_handle  # type: ignore[attr-defined]
+
+        mock_event = MagicMock()
+        mock_event.event.id = message_id
+        mock_services.event_store.load_events.return_value = [mock_event]  # type: ignore[attr-defined]
+
+        transport = ASGITransport(app=worker_app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            resp = await client.post(
+                f"/teams/{team_id}/human-input",
+                json={"content": "reply", "message_id": str(message_id)},
+            )
+        assert resp.status_code == 409
+
+
 class TestStopTeam:
     """POST /teams/{team_id}/stop route tests (AC #4)."""
 

--- a/tests/worker/test_worker_app.py
+++ b/tests/worker/test_worker_app.py
@@ -240,6 +240,23 @@ class TestSendMessageToAgent:
             )
         assert resp.status_code == 409
 
+    @pytest.mark.asyncio
+    async def test_send_to_agent_returns_404_on_not_found(
+        self, worker_app: FastAPI, mock_services: WorkerServices
+    ) -> None:
+        team_id = uuid.uuid4()
+        mock_handle = MagicMock()
+        mock_handle.send_to.side_effect = ValueError("agent not found")
+        mock_services.runtime_cache.get.return_value = mock_handle  # type: ignore[attr-defined]
+
+        transport = ASGITransport(app=worker_app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            resp = await client.post(
+                f"/teams/{team_id}/message/TestAgent",
+                json={"content": "hello"},
+            )
+        assert resp.status_code == 404
+
 
 class TestSendMessageFromTo:
     """POST /teams/{team_id}/message/from/{sender}/to/{recipient} route tests (AC #3)."""
@@ -293,6 +310,23 @@ class TestSendMessageFromTo:
             )
         assert resp.status_code == 409
 
+    @pytest.mark.asyncio
+    async def test_send_from_to_returns_404_on_not_found(
+        self, worker_app: FastAPI, mock_services: WorkerServices
+    ) -> None:
+        team_id = uuid.uuid4()
+        mock_handle = MagicMock()
+        mock_handle.send_from_to.side_effect = ValueError("recipient not found")
+        mock_services.runtime_cache.get.return_value = mock_handle  # type: ignore[attr-defined]
+
+        transport = ASGITransport(app=worker_app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            resp = await client.post(
+                f"/teams/{team_id}/message/from/Alice/to/Bob",
+                json={"content": "hello"},
+            )
+        assert resp.status_code == 404
+
 
 class TestHumanInput:
     """POST /teams/{team_id}/human-input route tests (AC #4)."""
@@ -306,9 +340,15 @@ class TestHumanInput:
         mock_handle = MagicMock()
         mock_services.runtime_cache.get.return_value = mock_handle  # type: ignore[attr-defined]
 
-        mock_event = MagicMock()
-        mock_event.event.id = message_id
-        mock_services.event_store.load_events.return_value = [mock_event]  # type: ignore[attr-defined]
+        # Two events: first doesn't match, second does — exercises loop iteration branch
+        non_matching_event = MagicMock()
+        non_matching_event.event.id = uuid.uuid4()
+        matching_event = MagicMock()
+        matching_event.event.id = message_id
+        mock_services.event_store.load_events.return_value = [  # type: ignore[attr-defined]
+            non_matching_event,
+            matching_event,
+        ]
 
         transport = ASGITransport(app=worker_app)
         async with AsyncClient(transport=transport, base_url="http://test") as client:
@@ -317,8 +357,9 @@ class TestHumanInput:
                 json={"content": "user reply", "message_id": str(message_id)},
             )
         assert resp.status_code == 204
+        mock_services.event_store.load_events.assert_called_once_with(team_id)  # type: ignore[attr-defined]
         mock_handle.process_human_input.assert_called_once_with(
-            "user reply", mock_event.event
+            "user reply", matching_event.event
         )
 
     @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- Add 4 new worker routes: `GET /teams/{team_id}`, `POST send_to`, `POST send_from_to`, `POST human-input`
- Add `_find_message` helper for message resolution from event_store (mirrors server pattern)
- Route ordering preserves FastAPI path matching: send_message before send_to before send_from_to
- 15 new tests added (2 get_team, 4 send_to, 4 send_from_to, 4 human_input, 1 load_events assertion)
- Worker routes at 100% branch coverage
- Ruff clean, mypy clean, zero imports from Dapr/Redis/tier-specific deps

Closes #217