### PR TITLE
Fix human-input route to unwrap SentMessage before delegation

### DIFF
--- a/src/akgentic/infra/server/services/team_service.py
+++ b/src/akgentic/infra/server/services/team_service.py
@@ -7,6 +7,7 @@ import uuid
 
 from akgentic.catalog.models.errors import EntryNotFoundError
 from akgentic.core.messages.message import Message
+from akgentic.core.messages.orchestrator import SentMessage
 from akgentic.infra.protocols.event_stream import EventStream
 from akgentic.infra.protocols.runtime_cache import RuntimeCache
 from akgentic.infra.protocols.team_handle import TeamHandle
@@ -132,8 +133,12 @@ class TeamService:
             ValueError: If team not found, not running, or message not found.
         """
         handle = self._get_running_handle(team_id)
-        original_message = self._find_message(team_id, message_id)
-        handle.process_human_input(content, original_message)
+        event = self._find_message(team_id, message_id)
+        if not isinstance(event, SentMessage):
+            msg = f"Message {message_id} is a {type(event).__name__}, expected SentMessage"
+            raise ValueError(msg)
+        inner = event.message
+        handle.process_human_input(content, inner)
         logger.debug("Human input routed to team %s, message_id=%s", team_id, message_id)
 
     def stop_team(self, team_id: uuid.UUID) -> None:

--- a/src/akgentic/infra/worker/routes/teams.py
+++ b/src/akgentic/infra/worker/routes/teams.py
@@ -13,6 +13,7 @@ from fastapi import APIRouter, Depends, HTTPException, Request
 from pydantic import BaseModel, Field
 
 from akgentic.core.messages.message import Message
+from akgentic.core.messages.orchestrator import SentMessage
 from akgentic.infra.server.models import HumanInputRequest, SendMessageRequest, TeamResponse
 from akgentic.infra.worker.deps import WorkerServices
 from akgentic.team.models import Process, TeamCard, TeamRuntime
@@ -173,8 +174,12 @@ def human_input(
     if handle is None:
         raise HTTPException(status_code=404, detail="Team not found in worker cache")
     try:
-        original_message = _find_message(services.event_store, team_id, body.message_id)
-        handle.process_human_input(body.content, original_message)
+        event = _find_message(services.event_store, team_id, body.message_id)
+        if not isinstance(event, SentMessage):
+            msg = f"Message {body.message_id} is a {type(event).__name__}, expected SentMessage"
+            raise ValueError(msg)
+        inner = event.message
+        handle.process_human_input(body.content, inner)
     except ValueError as exc:
         _raise_action_error(exc)
 

--- a/tests/worker/test_worker_app.py
+++ b/tests/worker/test_worker_app.py
@@ -421,6 +421,29 @@ class TestHumanInput:
             )
         assert resp.status_code == 409
 
+    @pytest.mark.asyncio
+    async def test_human_input_returns_409_when_event_not_sentmessage(
+        self, worker_app: FastAPI, mock_services: WorkerServices
+    ) -> None:
+        team_id = uuid.uuid4()
+        message_id = uuid.uuid4()
+        mock_handle = MagicMock()
+        mock_services.runtime_cache.get.return_value = mock_handle  # type: ignore[attr-defined]
+
+        # Event found but is NOT a SentMessage — isinstance guard should reject it
+        mock_event = MagicMock()
+        mock_event.event.id = message_id
+        mock_services.event_store.load_events.return_value = [mock_event]  # type: ignore[attr-defined]
+
+        transport = ASGITransport(app=worker_app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            resp = await client.post(
+                f"/teams/{team_id}/human-input",
+                json={"content": "reply", "message_id": str(message_id)},
+            )
+        assert resp.status_code == 409
+        assert "expected SentMessage" in resp.json()["detail"]
+
 
 class TestStopTeam:
     """POST /teams/{team_id}/stop route tests (AC #4)."""

--- a/tests/worker/test_worker_app.py
+++ b/tests/worker/test_worker_app.py
@@ -18,6 +18,7 @@ from akgentic.infra.protocols.worker_handle import WorkerHandle
 from akgentic.infra.worker.app import _lifespan, create_worker_app
 from akgentic.infra.worker.deps import WorkerServices
 from akgentic.infra.worker.settings import WorkerSettings
+from tests.fixtures.events import build_sent_message
 
 
 def _make_mock_process(team_id: uuid.UUID | None = None) -> MagicMock:
@@ -340,11 +341,14 @@ class TestHumanInput:
         mock_handle = MagicMock()
         mock_services.runtime_cache.get.return_value = mock_handle  # type: ignore[attr-defined]
 
+        # Build a real SentMessage so isinstance() check passes after unwrapping
+        sent_msg = build_sent_message(id=message_id)
+
         # Two events: first doesn't match, second does — exercises loop iteration branch
         non_matching_event = MagicMock()
         non_matching_event.event.id = uuid.uuid4()
         matching_event = MagicMock()
-        matching_event.event.id = message_id
+        matching_event.event = sent_msg
         mock_services.event_store.load_events.return_value = [  # type: ignore[attr-defined]
             non_matching_event,
             matching_event,
@@ -359,7 +363,7 @@ class TestHumanInput:
         assert resp.status_code == 204
         mock_services.event_store.load_events.assert_called_once_with(team_id)  # type: ignore[attr-defined]
         mock_handle.process_human_input.assert_called_once_with(
-            "user reply", matching_event.event
+            "user reply", sent_msg.message
         )
 
     @pytest.mark.asyncio
@@ -404,8 +408,9 @@ class TestHumanInput:
         mock_handle.process_human_input.side_effect = ValueError("team is stopped")
         mock_services.runtime_cache.get.return_value = mock_handle  # type: ignore[attr-defined]
 
+        sent_msg = build_sent_message(id=message_id)
         mock_event = MagicMock()
-        mock_event.event.id = message_id
+        mock_event.event = sent_msg
         mock_services.event_store.load_events.return_value = [mock_event]  # type: ignore[attr-defined]
 
         transport = ASGITransport(app=worker_app)


### PR DESCRIPTION
## Summary

- Validates found event is a `SentMessage` and extracts `.message` before passing to `handle.process_human_input()` in both `TeamService.human_input()` and worker `human_input()` route
- Raises `ValueError` with descriptive message if event is not a `SentMessage`, caught by existing error handling
- Updates worker tests to use real `SentMessage` instances via `build_sent_message()` fixture factory
- Adds test for `isinstance` guard rejection path (code review fix)

Closes #219