### PR TITLE
Rewrite LocalEventStream with per-reader Event signaling

### DIFF
--- a/src/akgentic/infra/adapters/community/local_event_stream.py
+++ b/src/akgentic/infra/adapters/community/local_event_stream.py
@@ -1,14 +1,19 @@
-"""LocalEventStream — community-tier in-memory EventStream with replay and fan-out.
+"""LocalEventStream — community-tier in-memory EventStream with per-reader signaling.
 
 Provides a thread-safe, in-process event stream backed by a plain dict.
 Designed for single-process community deployments where no external
 infrastructure (Redis, Kafka) is available.
 
-Threading model:
-- One ``threading.Lock`` on the stream protects the ``_streams`` dict and all
-  per-team state during ``append()``, ``read_from()``, ``subscribe()``, ``remove()``.
-- One ``threading.Condition`` per team for reader notification (``read_next()``
-  blocks on the condition until events are available or timeout expires).
+Threading model (CPython GIL assumption):
+- One ``threading.Lock`` (``_lock``) on the ``LocalEventStream`` protects
+  the ``_streams`` dict during ``append()``, ``subscribe()``, ``remove()``.
+- One ``threading.Lock`` per ``_TeamStream`` protects its ``signals`` set
+  and ``closed`` flag.
+- ``read_next()`` is lock-free during replay: CPython's GIL guarantees
+  atomic ``list.append()`` and ``len()``, so a reader whose cursor is
+  behind the write frontier can safely index into ``events`` without
+  holding any lock. The reader only blocks on its own ``threading.Event``
+  when fully caught up.
 - Safe for concurrent use from FastAPI thread-pool executors.
 """
 
@@ -16,7 +21,6 @@ from __future__ import annotations
 
 import logging
 import threading
-import time
 import uuid
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
@@ -31,40 +35,40 @@ logger = logging.getLogger(__name__)
 
 @dataclass
 class _TeamStream:
-    """Per-team stream state grouping events, condition, readers, and bookkeeping."""
+    """Per-team stream state: events, per-reader signals, lock, and closed flag."""
 
     events: list[Message] = field(default_factory=list)
-    condition: threading.Condition = field(default_factory=threading.Condition)
-    readers: list[LocalStreamReader] = field(default_factory=list)
+    signals: set[threading.Event] = field(default_factory=set)
+    lock: threading.Lock = field(default_factory=threading.Lock)
     closed: bool = False
-    base_offset: int = 0
 
 
 class LocalStreamReader:
     """Cursor-based blocking reader for a single team's event stream.
 
-    Holds an absolute cursor position and a reference to the parent
-    ``_TeamStream``. Blocks on the team's ``Condition`` when no new
-    events are available.
+    Each reader holds its own ``threading.Event`` for wake-up signaling
+    and an absolute cursor into the parent ``_TeamStream.events`` list.
 
-    Thread-safety: all mutable state is accessed under the parent
-    team's ``Condition`` lock.
+    The replay path (``cursor < len(events)``) is lock-free under CPython's
+    GIL. The reader only blocks on ``_signal.wait()`` when fully caught up.
     """
 
     def __init__(
         self,
         team_stream: _TeamStream,
+        signal: threading.Event,
         cursor: int,
     ) -> None:
         self._team_stream = team_stream
+        self._signal = signal
         self._cursor = cursor
         self._closed = False
 
     def read_next(self, timeout: float = 0.5) -> Message | None:
         """Read the next event from the cursor position.
 
-        Blocks up to *timeout* seconds waiting for a new event. Returns
-        ``None`` if the timeout elapses with no event available.
+        Lock-free when replaying (``cursor < len(events)``). Blocks on
+        the reader's own ``threading.Event`` when caught up.
 
         Args:
             timeout: Maximum seconds to block.
@@ -75,34 +79,45 @@ class LocalStreamReader:
         Raises:
             StreamClosed: If the stream has been removed.
         """
-        with self._team_stream.condition:
-            deadline = time.monotonic() + timeout
-            while True:
-                if self._closed or self._team_stream.closed:
-                    raise StreamClosed()
-                base = self._team_stream.base_offset
-                end = base + len(self._team_stream.events)
-                if self._cursor < base:
-                    self._cursor = base
-                if self._cursor < end:
-                    event = self._team_stream.events[self._cursor - base]
-                    self._cursor += 1
-                    return event
-                remaining = deadline - time.monotonic()
-                if remaining <= 0:
-                    return None
-                self._team_stream.condition.wait(timeout=remaining)
+        if self._closed or self._team_stream.closed:
+            raise StreamClosed()
+
+        # Lock-free replay path
+        if self._cursor < len(self._team_stream.events):
+            event = self._team_stream.events[self._cursor]
+            self._cursor += 1
+            return event
+
+        # Caught up — wait for signal
+        self._signal.clear()
+
+        # Re-check after clear to avoid lost-wakeup race
+        if self._closed or self._team_stream.closed:
+            raise StreamClosed()
+        if self._cursor < len(self._team_stream.events):
+            event = self._team_stream.events[self._cursor]
+            self._cursor += 1
+            return event
+
+        self._signal.wait(timeout=timeout)
+
+        # Post-wait checks
+        if self._closed or self._team_stream.closed:
+            raise StreamClosed()
+        if self._cursor < len(self._team_stream.events):
+            event = self._team_stream.events[self._cursor]
+            self._cursor += 1
+            return event
+
+        return None
 
     def close(self) -> None:
         """Release resources held by this reader. Idempotent."""
         if self._closed:
             return
         self._closed = True
-        with self._team_stream.condition:
-            try:
-                self._team_stream.readers.remove(self)
-            except ValueError:
-                pass
+        with self._team_stream.lock:
+            self._team_stream.signals.discard(self._signal)
 
 
 class LocalEventStream:
@@ -110,17 +125,11 @@ class LocalEventStream:
 
     Satisfies the ``EventStream`` protocol (runtime-checkable). Backed by
     ``dict[UUID, _TeamStream]`` with a ``threading.Lock`` for thread safety.
-
-    Args:
-        maxlen: Optional maximum number of events per team stream.
-            When exceeded, oldest events are evicted (FIFO) and reader
-            cursors are adjusted.
     """
 
-    def __init__(self, maxlen: int | None = None) -> None:
+    def __init__(self) -> None:
         self._streams: dict[uuid.UUID, _TeamStream] = {}
         self._lock = threading.Lock()
-        self._maxlen = maxlen
 
     def append(self, team_id: uuid.UUID, event: Message) -> int:
         """Append an event to the team's stream.
@@ -133,7 +142,7 @@ class LocalEventStream:
             event: The message to append.
 
         Returns:
-            Monotonically increasing sequence number.
+            Monotonically increasing sequence number, or -1 if stream is closed.
         """
         with self._lock:
             ts = self._streams.get(team_id)
@@ -141,22 +150,14 @@ class LocalEventStream:
                 ts = _TeamStream()
                 self._streams[team_id] = ts
 
-        with ts.condition:
+        with ts.lock:
             if ts.closed:
                 logger.warning("append() on removed stream team_id=%s — discarding", team_id)
                 return -1
             ts.events.append(event)
-            seq = ts.base_offset + len(ts.events)
-
-            if self._maxlen is not None and len(ts.events) > self._maxlen:
-                evict_count = len(ts.events) - self._maxlen
-                ts.events = ts.events[evict_count:]
-                ts.base_offset += evict_count
-                for reader in ts.readers:
-                    if reader._cursor < ts.base_offset:
-                        reader._cursor = ts.base_offset
-
-            ts.condition.notify_all()
+            seq = len(ts.events)
+            for sig in ts.signals:
+                sig.set()
             return seq
 
     def read_from(
@@ -176,14 +177,9 @@ class LocalEventStream:
             if ts is None:
                 return []
 
-        with ts.condition:
-            if ts.closed:
-                return []
-            base = ts.base_offset
-            if cursor < base:
-                cursor = base
-            start_idx = cursor - base
-            return list(ts.events[start_idx:])
+        if ts.closed:
+            return []
+        return list(ts.events[cursor:])
 
     def subscribe(
         self, team_id: uuid.UUID, cursor: int = 0
@@ -205,18 +201,18 @@ class LocalEventStream:
                 ts = _TeamStream()
                 self._streams[team_id] = ts
 
-        with ts.condition:
+        signal = threading.Event()
+        with ts.lock:
             if ts.closed:
                 raise StreamClosed()
-            reader = LocalStreamReader(ts, cursor)
-            ts.readers.append(reader)
-            return reader
+            ts.signals.add(signal)
+        return LocalStreamReader(ts, signal, cursor)
 
     def remove(self, team_id: uuid.UUID) -> None:
         """Remove the stream for a team.
 
-        Sets the closed flag on all active readers and notifies them,
-        then deletes the stream data from the backing store.
+        Sets the closed flag and signals all active readers, then
+        deletes the stream data from the backing store.
 
         Args:
             team_id: ID of the team whose stream to remove.
@@ -226,6 +222,7 @@ class LocalEventStream:
             if ts is None:
                 return
 
-        with ts.condition:
+        with ts.lock:
             ts.closed = True
-            ts.condition.notify_all()
+            for sig in ts.signals:
+                sig.set()

--- a/src/akgentic/infra/adapters/community/local_event_stream.py
+++ b/src/akgentic/infra/adapters/community/local_event_stream.py
@@ -64,6 +64,19 @@ class LocalStreamReader:
         self._cursor = cursor
         self._closed = False
 
+    def _advance(self) -> Message | None:
+        """Advance the cursor and return the next event, or ``None`` if caught up."""
+        if self._cursor < len(self._team_stream.events):
+            event = self._team_stream.events[self._cursor]
+            self._cursor += 1
+            return event
+        return None
+
+    def _check_closed(self) -> None:
+        """Raise ``StreamClosed`` if the reader or stream has been closed."""
+        if self._closed or self._team_stream.closed:
+            raise StreamClosed()
+
     def read_next(self, timeout: float = 0.5) -> Message | None:
         """Read the next event from the cursor position.
 
@@ -79,37 +92,27 @@ class LocalStreamReader:
         Raises:
             StreamClosed: If the stream has been removed.
         """
-        if self._closed or self._team_stream.closed:
-            raise StreamClosed()
+        self._check_closed()
 
         # Lock-free replay path
-        if self._cursor < len(self._team_stream.events):
-            event = self._team_stream.events[self._cursor]
-            self._cursor += 1
+        event = self._advance()
+        if event is not None:
             return event
 
         # Caught up — wait for signal
         self._signal.clear()
 
         # Re-check after clear to avoid lost-wakeup race
-        if self._closed or self._team_stream.closed:
-            raise StreamClosed()
-        if self._cursor < len(self._team_stream.events):
-            event = self._team_stream.events[self._cursor]
-            self._cursor += 1
+        self._check_closed()
+        event = self._advance()
+        if event is not None:
             return event
 
         self._signal.wait(timeout=timeout)
 
         # Post-wait checks
-        if self._closed or self._team_stream.closed:
-            raise StreamClosed()
-        if self._cursor < len(self._team_stream.events):
-            event = self._team_stream.events[self._cursor]
-            self._cursor += 1
-            return event
-
-        return None
+        self._check_closed()
+        return self._advance()
 
     def close(self) -> None:
         """Release resources held by this reader. Idempotent."""

--- a/tests/test_local_event_stream.py
+++ b/tests/test_local_event_stream.py
@@ -255,8 +255,8 @@ def test_read_from_cursor_beyond_end_returns_empty() -> None:
     assert events == []
 
 
-def test_subscribe_on_closed_stream_raises() -> None:
-    """subscribe() on a removed stream creates a new stream (removed was popped)."""
+def test_subscribe_after_remove_creates_new_stream() -> None:
+    """subscribe() after remove() creates a fresh stream (remove pops the old one)."""
     stream = LocalEventStream()
     stream.append(_TEAM_ID, _make_event(1))
     stream.remove(_TEAM_ID)
@@ -284,3 +284,33 @@ def test_append_on_removed_stream_returns_negative() -> None:
 
     result = stream.append(_TEAM_ID, _make_event(2))
     assert result == -1
+
+
+def test_subscribe_on_concurrently_closed_stream_raises() -> None:
+    """subscribe() raises StreamClosed when stream is closed between lookup and lock."""
+    stream = LocalEventStream()
+    stream.append(_TEAM_ID, _make_event(1))
+
+    # Simulate the race: get a reference to the _TeamStream, close it manually,
+    # but leave it in _streams so subscribe() finds it and hits the closed guard
+    with stream._lock:
+        ts = stream._streams[_TEAM_ID]
+    with ts.lock:
+        ts.closed = True
+
+    with pytest.raises(StreamClosed):
+        stream.subscribe(_TEAM_ID, cursor=0)
+
+
+def test_read_from_on_closed_stream_returns_empty() -> None:
+    """read_from() returns empty list when stream is closed but still in _streams."""
+    stream = LocalEventStream()
+    stream.append(_TEAM_ID, _make_event(1))
+
+    # Close the stream without removing it from _streams
+    with stream._lock:
+        ts = stream._streams[_TEAM_ID]
+    with ts.lock:
+        ts.closed = True
+
+    assert stream.read_from(_TEAM_ID) == []

--- a/tests/test_local_event_stream.py
+++ b/tests/test_local_event_stream.py
@@ -1,4 +1,4 @@
-"""Tests for LocalEventStream and LocalStreamReader (Story 13.2, updated 13.7)."""
+"""Tests for LocalEventStream and LocalStreamReader (Story 21.1 — per-reader Event design)."""
 
 from __future__ import annotations
 
@@ -22,7 +22,7 @@ def _make_event(seq: int = 1, team_id: uuid.UUID = _TEAM_ID) -> Message:
     return UserMessage(content=f"msg-{seq}", team_id=team_id)
 
 
-# --- Task 9: Protocol conformance (AC1) ---
+# --- Protocol conformance ---
 
 
 def test_localeventstream_satisfies_protocol() -> None:
@@ -30,11 +30,11 @@ def test_localeventstream_satisfies_protocol() -> None:
     assert isinstance(LocalEventStream(), EventStream)
 
 
-# --- Task 5: Basic operations (AC3, AC4, AC8) ---
+# --- Basic operations ---
 
 
 def test_append_returns_monotonic_sequence() -> None:
-    """append() returns monotonically increasing sequence numbers (AC3)."""
+    """append() returns monotonically increasing sequence numbers."""
     stream = LocalEventStream()
     seq1 = stream.append(_TEAM_ID, _make_event(1))
     seq2 = stream.append(_TEAM_ID, _make_event(2))
@@ -43,7 +43,7 @@ def test_append_returns_monotonic_sequence() -> None:
 
 
 def test_append_implicitly_creates_stream() -> None:
-    """append() implicitly creates stream for new team_id (AC3)."""
+    """append() implicitly creates stream for new team_id."""
     stream = LocalEventStream()
     new_team = uuid.uuid4()
     seq = stream.append(new_team, _make_event(1, team_id=new_team))
@@ -53,7 +53,7 @@ def test_append_implicitly_creates_stream() -> None:
 
 
 def test_read_from_cursor_zero_returns_all() -> None:
-    """read_from(cursor=0) returns all events (AC4)."""
+    """read_from(cursor=0) returns all events."""
     stream = LocalEventStream()
     for i in range(5):
         stream.append(_TEAM_ID, _make_event(i))
@@ -63,7 +63,7 @@ def test_read_from_cursor_zero_returns_all() -> None:
 
 @pytest.mark.parametrize("cursor", [1, 2, 3, 4])
 def test_read_from_cursor_n_returns_from_n(cursor: int) -> None:
-    """read_from(cursor=K) returns events from position K onward (AC4)."""
+    """read_from(cursor=K) returns events from position K onward."""
     stream = LocalEventStream()
     for i in range(5):
         stream.append(_TEAM_ID, _make_event(i))
@@ -72,13 +72,13 @@ def test_read_from_cursor_n_returns_from_n(cursor: int) -> None:
 
 
 def test_read_from_nonexistent_team_returns_empty() -> None:
-    """read_from() on nonexistent team returns empty list (AC4)."""
+    """read_from() on nonexistent team returns empty list."""
     stream = LocalEventStream()
     assert stream.read_from(uuid.uuid4()) == []
 
 
 def test_read_next_timeout_returns_none() -> None:
-    """read_next(timeout=0.1) returns None when no events pending (AC8)."""
+    """read_next(timeout=0.1) returns None when no events pending."""
     stream = LocalEventStream()
     reader = stream.subscribe(_TEAM_ID, cursor=0)
     result = reader.read_next(timeout=0.1)
@@ -86,11 +86,11 @@ def test_read_next_timeout_returns_none() -> None:
     reader.close()
 
 
-# --- Task 6: Subscribe and replay (AC5, AC6, AC11) ---
+# --- Subscribe and replay ---
 
 
 def test_subscribe_cursor_zero_replays_all_then_blocks() -> None:
-    """subscribe(cursor=0) replays all existing events then blocks (AC5)."""
+    """subscribe(cursor=0) replays all existing events then blocks."""
     stream = LocalEventStream()
     for i in range(3):
         stream.append(_TEAM_ID, _make_event(i))
@@ -108,7 +108,7 @@ def test_subscribe_cursor_zero_replays_all_then_blocks() -> None:
 
 
 def test_subscribe_cursor_n_skips_replay() -> None:
-    """subscribe(cursor=N) skips replay and blocks for new events (AC6)."""
+    """subscribe(cursor=N) skips replay and blocks for new events."""
     stream = LocalEventStream()
     for i in range(3):
         stream.append(_TEAM_ID, _make_event(i))
@@ -120,7 +120,7 @@ def test_subscribe_cursor_n_skips_replay() -> None:
 
 
 def test_two_concurrent_readers_independent() -> None:
-    """Two concurrent readers on same stream receive events independently (AC11)."""
+    """Two concurrent readers on same stream receive events independently."""
     stream = LocalEventStream()
     for i in range(3):
         stream.append(_TEAM_ID, _make_event(i))
@@ -141,7 +141,7 @@ def test_two_concurrent_readers_independent() -> None:
 
 
 def test_reader_receives_live_events_after_replay() -> None:
-    """Reader receives live events after replay is exhausted (AC5)."""
+    """Reader receives live events after replay is exhausted."""
     stream = LocalEventStream()
     stream.append(_TEAM_ID, _make_event(1))
 
@@ -179,11 +179,11 @@ def test_reader_receives_live_events_via_thread() -> None:
     reader.close()
 
 
-# --- Task 7: Remove and close (AC7, AC9) ---
+# --- Remove and close ---
 
 
 def test_remove_causes_read_next_to_raise_stream_closed() -> None:
-    """remove() causes active read_next() to raise StreamClosed (AC7)."""
+    """remove() causes active read_next() to raise StreamClosed."""
     stream = LocalEventStream()
     stream.append(_TEAM_ID, _make_event(1))
     reader = stream.subscribe(_TEAM_ID, cursor=1)  # past existing events
@@ -199,7 +199,6 @@ def test_remove_causes_read_next_to_raise_stream_closed() -> None:
     t = threading.Thread(target=reader_thread)
     t.start()
 
-    import time
     time.sleep(0.05)
     stream.remove(_TEAM_ID)
     t.join(timeout=2.0)
@@ -209,7 +208,7 @@ def test_remove_causes_read_next_to_raise_stream_closed() -> None:
 
 
 def test_remove_deletes_stream_data() -> None:
-    """remove() deletes stream data (subsequent read_from returns empty) (AC7)."""
+    """remove() deletes stream data (subsequent read_from returns empty)."""
     stream = LocalEventStream()
     stream.append(_TEAM_ID, _make_event(1))
     stream.remove(_TEAM_ID)
@@ -217,7 +216,7 @@ def test_remove_deletes_stream_data() -> None:
 
 
 def test_close_is_idempotent() -> None:
-    """close() on reader is idempotent (call twice without error) (AC9)."""
+    """close() on reader is idempotent (call twice without error)."""
     stream = LocalEventStream()
     reader = stream.subscribe(_TEAM_ID, cursor=0)
     reader.close()
@@ -225,59 +224,14 @@ def test_close_is_idempotent() -> None:
 
 
 def test_close_after_remove_does_not_raise() -> None:
-    """close() after remove() does not raise (AC9)."""
+    """close() after remove() does not raise."""
     stream = LocalEventStream()
     reader = stream.subscribe(_TEAM_ID, cursor=0)
     stream.remove(_TEAM_ID)
     reader.close()  # should not raise
 
 
-# --- Task 8: Maxlen eviction (AC10) ---
-
-
-def test_maxlen_evicts_oldest() -> None:
-    """Appending beyond maxlen evicts oldest events (AC10)."""
-    stream = LocalEventStream(maxlen=3)
-    for i in range(5):
-        stream.append(_TEAM_ID, _make_event(i))
-    events = stream.read_from(_TEAM_ID, cursor=0)
-    assert len(events) == 3
-
-
-def test_maxlen_reader_cursors_adjusted() -> None:
-    """Reader cursors are adjusted after eviction (AC10)."""
-    stream = LocalEventStream(maxlen=3)
-    for i in range(3):
-        stream.append(_TEAM_ID, _make_event(i))
-
-    reader = stream.subscribe(_TEAM_ID, cursor=0)
-    # Read first event (cursor=0)
-    ev = reader.read_next(timeout=0.1)
-    assert ev is not None
-
-    # Now append 3 more -- evicts first 3, reader cursor should be adjusted
-    for i in range(3, 6):
-        stream.append(_TEAM_ID, _make_event(i))
-
-    # Reader should still be able to read without error -- cursor adjusted
-    ev = reader.read_next(timeout=0.1)
-    assert ev is not None
-    reader.close()
-
-
-def test_maxlen_sequence_numbers_monotonic() -> None:
-    """Sequence numbers remain monotonic after eviction (AC10)."""
-    stream = LocalEventStream(maxlen=3)
-    seqs = []
-    for i in range(10):
-        seqs.append(stream.append(_TEAM_ID, _make_event(i)))
-
-    # All sequence numbers should be strictly increasing
-    for i in range(1, len(seqs)):
-        assert seqs[i] > seqs[i - 1]
-
-
-# --- Review additions: edge-case coverage ---
+# --- Edge-case coverage ---
 
 
 def test_subscribe_implicitly_creates_stream() -> None:
@@ -302,12 +256,11 @@ def test_read_from_cursor_beyond_end_returns_empty() -> None:
 
 
 def test_subscribe_on_closed_stream_raises() -> None:
-    """subscribe() on a removed stream raises StreamClosed."""
+    """subscribe() on a removed stream creates a new stream (removed was popped)."""
     stream = LocalEventStream()
     stream.append(_TEAM_ID, _make_event(1))
     stream.remove(_TEAM_ID)
-    # Re-creating via subscribe should work (new stream), but subscribing
-    # on the removed internal stream is guarded -- test the safe path
+    # Re-creating via subscribe should work (new stream)
     reader = stream.subscribe(_TEAM_ID, cursor=0)
     assert reader.read_next(timeout=0.1) is None
     reader.close()


### PR DESCRIPTION
## Summary

- Rewrites `LocalEventStream` internals from shared `threading.Condition` to per-reader `threading.Event` signaling
- `_TeamStream` simplified: `events` + `signals: set[Event]` + `lock` + `closed` (no `Condition`, no `readers`, no `base_offset`)
- `read_next()` is lock-free during replay (CPython GIL assumption); blocks on own `Event` only when caught up
- `maxlen` parameter removed; constructor is now `__init__(self) -> None`
- Public API (`append`, `read_from`, `subscribe`, `remove`, `read_next`, `close`) unchanged
- Protocol conformance preserved (`isinstance(LocalEventStream(), EventStream)`)

## Code review fixes

- Extracted `_advance()` and `_check_closed()` helpers to eliminate triplicated cursor-advance pattern
- Renamed misleading `test_subscribe_on_closed_stream_raises` to match actual behavior
- Added 2 edge-case tests: `subscribe()` race on concurrently-closed stream, `read_from()` on closed stream

Closes #223
