### PR TITLE
Fix trailing slash in the api

### DIFF
--- a/src/akgentic/infra/server/routes/teams.py
+++ b/src/akgentic/infra/server/routes/teams.py
@@ -43,7 +43,7 @@ def _process_to_response(process: Process) -> TeamResponse:
     )
 
 
-@router.post("/", status_code=201, response_model=TeamResponse)
+@router.post("", status_code=201, response_model=TeamResponse)
 def create_team(
     body: CreateTeamRequest,
     service: TeamService = Depends(get_team_service),
@@ -63,7 +63,7 @@ def create_team(
     return _process_to_response(process)
 
 
-@router.get("/", response_model=TeamListResponse)
+@router.get("", response_model=TeamListResponse)
 def list_teams(
     service: TeamService = Depends(get_team_service),
 ) -> TeamListResponse:

--- a/src/akgentic/infra/worker/routes/teams.py
+++ b/src/akgentic/infra/worker/routes/teams.py
@@ -65,7 +65,7 @@ def get_team(
     return _process_to_response(process)
 
 
-@router.post("/", status_code=201, response_model=TeamResponse)
+@router.post("", status_code=201, response_model=TeamResponse)
 def create_team(
     body: WorkerCreateTeamRequest,
     services: WorkerServices = Depends(get_services),

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -17,7 +17,7 @@ def test_create_app_returns_fastapi(
     app = create_app(community_services, seeded_settings)
     assert app.title == "Akgentic Platform API"
     route_paths = [r.path for r in app.routes]  # type: ignore[union-attr]
-    assert "/teams/" in route_paths
+    assert "/teams" in route_paths
     assert "/teams/{team_id}" in route_paths
 
 

--- a/tests/worker/test_worker_app.py
+++ b/tests/worker/test_worker_app.py
@@ -106,7 +106,7 @@ class TestCreateTeam:
         transport = ASGITransport(app=worker_app)
         async with AsyncClient(transport=transport, base_url="http://test") as client:
             resp = await client.post(
-                "/teams/",
+                "/teams",
                 json={
                     "team_card": team_card_json,
                     "user_id": "test-user",


### PR DESCRIPTION
## Summary

- Remove trailing slashes from `POST /` and `GET /` route decorators in server and worker team routes
- Update tests to match the new route paths (no trailing slash)
- FastAPI with trailing-slash routes causes 307 redirects when clients call without the slash, breaking some HTTP clients and adding unnecessary latency
