### PR TITLE
feat: WS supervisor + dedicated reader executor (protocol-preserving Phase 2)

### DIFF
--- a/src/akgentic/infra/server/app.py
+++ b/src/akgentic/infra/server/app.py
@@ -28,7 +28,7 @@ from akgentic.infra.server.routes.readiness import router as readiness_router
 from akgentic.infra.server.routes.teams import router as teams_router
 from akgentic.infra.server.routes.webhook import router as webhook_router
 from akgentic.infra.server.routes.workspace import router as workspace_router
-from akgentic.infra.server.routes.ws import ConnectionManager
+from akgentic.infra.server.routes.ws import ConnectionManager, shutdown_reader_pool
 from akgentic.infra.server.routes.ws import router as ws_router
 from akgentic.infra.server.services.team_service import TeamService
 from akgentic.infra.server.settings import ServerSettings
@@ -112,6 +112,10 @@ async def _lifespan(app: FastAPI) -> AsyncIterator[None]:
             "stop_all() exceeded shutdown_drain_timeout=%ds, proceeding with exit",
             timeout,
         )
+
+    # Shut down the dedicated WS reader thread pool — see issue #227.
+    shutdown_reader_pool()
+    logger.info("WebSocket reader pool shut down")
 
 
 def _build_app(

--- a/src/akgentic/infra/server/routes/ws.py
+++ b/src/akgentic/infra/server/routes/ws.py
@@ -1,16 +1,27 @@
-"""WebSocket route for real-time event streaming via EventStream."""
+"""WebSocket route for real-time event streaming via EventStream.
+
+The streaming loop is a v1-style supervisor: ``pump`` forwards events and
+``watch_disconnect`` awaits client frames; whichever finishes first cancels
+the other. Reader polling runs on a dedicated ``ThreadPoolExecutor``
+(``_WS_READER_POOL``) so that blocking ``reader.read_next(timeout)`` calls
+cannot starve the default executor. The ``StreamReader`` protocol stays
+sync — enterprise adapters (``DaprStreamReader``) are unaffected.
+"""
 
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import logging
 import uuid
+from concurrent.futures import ThreadPoolExecutor
 from typing import cast
 
 from fastapi import APIRouter, WebSocket, WebSocketDisconnect
 from starlette.websockets import WebSocketState
 
-from akgentic.infra.protocols.event_stream import StreamClosed
+from akgentic.core.messages import Message
+from akgentic.infra.protocols.event_stream import StreamClosed, StreamReader
 from akgentic.infra.server.routes.frontend_adapter import FrontendAdapter
 from akgentic.infra.server.services.team_service import TeamService
 from akgentic.team.models import TeamStatus
@@ -18,6 +29,44 @@ from akgentic.team.models import TeamStatus
 logger = logging.getLogger(__name__)
 
 router = APIRouter()
+
+
+_WS_READER_POOL: ThreadPoolExecutor | None = None
+
+
+def _get_reader_pool(websocket: WebSocket) -> ThreadPoolExecutor:
+    """Return the module-level dedicated reader pool, constructing it on first use.
+
+    Sized from ``app.state.settings.ws_reader_pool_size``. The pool is
+    process-global and reused across connections. It stays isolated from
+    ``asyncio``'s default executor to prevent the WS reader polling
+    workload from starving other ``run_in_executor`` callers in the same
+    process.
+
+    See issue #227.
+    """
+    global _WS_READER_POOL
+    if _WS_READER_POOL is None:
+        settings = websocket.app.state.settings
+        _WS_READER_POOL = ThreadPoolExecutor(
+            max_workers=settings.ws_reader_pool_size,
+            thread_name_prefix="ws-reader",
+        )
+    return _WS_READER_POOL
+
+
+def shutdown_reader_pool() -> None:
+    """Shut down the dedicated reader pool, cancelling queued futures.
+
+    Invoked by the FastAPI lifespan teardown. ``wait=False`` + ``cancel_futures=True``
+    allow the process to exit promptly even if a reader thread is mid-poll;
+    the daemon-threaded executor does not block interpreter shutdown.
+    """
+    global _WS_READER_POOL
+    if _WS_READER_POOL is None:
+        return
+    _WS_READER_POOL.shutdown(wait=False, cancel_futures=True)
+    _WS_READER_POOL = None
 
 
 class ConnectionManager:
@@ -146,7 +195,14 @@ async def _run_streaming_loop(
     conn_mgr: ConnectionManager,
     adapter: FrontendAdapter | None = None,
 ) -> None:
-    """Subscribe to EventStream and forward events over WebSocket."""
+    """Subscribe to EventStream and forward events over WebSocket.
+
+    Uses a v1-style supervisor: ``pump`` forwards events while
+    ``watch_disconnect`` awaits client frames. Whichever finishes first
+    cancels the other. Disconnect detection is structural (sub-millisecond
+    via ``websocket.receive()``) rather than polled via ``client_state``.
+    See issue #227.
+    """
     logger.debug("Streaming loop started: team_id=%s", team_id)
     event_stream = service.get_event_stream()
     try:
@@ -157,34 +213,99 @@ async def _run_streaming_loop(
         await _run_idle_loop(websocket, team_id, conn_mgr, service, adapter)
         return
 
-    loop = asyncio.get_running_loop()
-    try:
-        while True:
-            event = await loop.run_in_executor(None, reader.read_next, 0.5)
-            if event is None:
-                if websocket.client_state != WebSocketState.CONNECTED:
-                    break
-                continue
+    stream_closed = await _supervise_stream(websocket, reader, adapter, team_id)
 
-            try:
-                if adapter is not None:
-                    wrapped = adapter.wrap_ws_event(event)
-                    await websocket.send_text(wrapped.model_dump_json())
-                else:
-                    await websocket.send_text(event.model_dump_json())
-                logger.debug("Event forwarded to client: team_id=%s", team_id)
-            except WebSocketDisconnect:
-                raise
-            except Exception:  # noqa: BLE001
-                logger.debug("Skipping unserializable event: team_id=%s", team_id)
-    except StreamClosed:
+    if stream_closed:
         logger.debug("StreamClosed for team %s, transitioning to idle loop", team_id)
         conn_mgr.clear_restored(team_id)
         await _run_idle_loop(websocket, team_id, conn_mgr, service, adapter)
-    except (WebSocketDisconnect, asyncio.CancelledError):
+
+
+async def _send_event(
+    websocket: WebSocket,
+    event: Message,
+    adapter: FrontendAdapter | None,
+    team_id: uuid.UUID,
+) -> None:
+    """Serialize and forward a single event, logging and skipping on failure."""
+    try:
+        if adapter is not None:
+            wrapped = adapter.wrap_ws_event(event)
+            await websocket.send_text(wrapped.model_dump_json())
+        else:
+            await websocket.send_text(event.model_dump_json())
+        logger.debug("Event forwarded to client: team_id=%s", team_id)
+    except WebSocketDisconnect:
+        raise
+    except Exception:  # noqa: BLE001
+        logger.debug("Skipping unserializable event: team_id=%s", team_id)
+
+
+async def _await_and_suppress(task: asyncio.Task[None]) -> None:
+    """Await ``task`` swallowing cancellation, disconnect, and incidental errors."""
+    with contextlib.suppress(asyncio.CancelledError, WebSocketDisconnect, Exception):
+        await task
+
+
+async def _supervise_stream(
+    websocket: WebSocket,
+    reader: StreamReader,
+    adapter: FrontendAdapter | None,
+    team_id: uuid.UUID,
+) -> bool:
+    """Race ``pump`` against ``watch_disconnect`` until one finishes.
+
+    Returns ``True`` iff the event stream observed ``StreamClosed`` (callers
+    transition to the idle loop). Cancels the losing task and awaits it
+    under ``contextlib.suppress`` so cleanup is idempotent.
+
+    Note on cancellation: cancelling ``pump_task`` marks its
+    ``run_in_executor`` future as cancelled on the event-loop side, but the
+    executor thread still holds ``threading.Event.wait(0.5)`` in
+    ``LocalStreamReader.read_next``. ``reader.close()`` below signals the
+    event and typically cuts the tick short to single-digit milliseconds.
+    """
+    stream_closed = False
+
+    async def pump() -> None:
+        nonlocal stream_closed
+        loop = asyncio.get_running_loop()
+        pool = _get_reader_pool(websocket)
+        try:
+            while True:
+                event = await loop.run_in_executor(pool, reader.read_next, 0.5)
+                if event is None:
+                    continue
+                await _send_event(websocket, event, adapter, team_id)
+        except StreamClosed:
+            stream_closed = True
+
+    async def watch_disconnect() -> None:
+        # Silently drops inbound client frames — correct for today's
+        # server-push protocol. A future client→server WS protocol must
+        # replace this helper. See issue #227.
+        try:
+            while True:
+                await websocket.receive()
+        except WebSocketDisconnect:
+            return
+
+    pump_task = asyncio.create_task(pump())
+    watch_task = asyncio.create_task(watch_disconnect())
+    try:
+        done, pending = await asyncio.wait(
+            [pump_task, watch_task], return_when=asyncio.FIRST_COMPLETED
+        )
+        for task in pending:
+            task.cancel()
+            await _await_and_suppress(task)
+        for task in done:
+            await _await_and_suppress(task)
         logger.info("WebSocket streaming stopped: team_id=%s", team_id)
     finally:
         reader.close()
+
+    return stream_closed
 
 
 async def _run_idle_loop(

--- a/src/akgentic/infra/server/settings.py
+++ b/src/akgentic/infra/server/settings.py
@@ -70,6 +70,17 @@ class ServerSettings(BaseSettings):
             "(0 for standalone, 5-10 for LB deployments)"
         ),
     )
+    ws_reader_pool_size: int = Field(
+        default=256,
+        ge=1,
+        description=(
+            "Dedicated thread pool for WebSocket event-stream reader polling. "
+            "Each active WS connection holds one thread per read_next(0.5) tick. "
+            "Size for concurrent WS budget plus headroom for burst open/close "
+            "cycles. Isolated from the default executor to prevent "
+            "cross-subsystem starvation."
+        ),
+    )
 
 
 class CommunitySettings(ServerSettings):

--- a/tests/server/models/test_server_settings.py
+++ b/tests/server/models/test_server_settings.py
@@ -142,6 +142,7 @@ class TestSettingsHierarchy:
             "frontend_adapter",
             "shutdown_drain_timeout",
             "shutdown_pre_drain_delay",
+            "ws_reader_pool_size",
         }
         assert server_fields == expected, (
             f"ServerSettings fields mismatch: got {server_fields}, expected {expected}"
@@ -167,9 +168,7 @@ class TestSettingsHierarchy:
                 origin = typing.get_origin(annotation)
                 if origin is typing.Literal:
                     args = typing.get_args(annotation)
-                    assert "yaml" not in args, (
-                        f"{cls.__name__}.{field_name} has Literal['yaml']"
-                    )
+                    assert "yaml" not in args, f"{cls.__name__}.{field_name} has Literal['yaml']"
 
     def test_community_settings_wires_functional_app(self, tmp_path: Path) -> None:
         """End-to-end: CommunitySettings -> wire -> create_app -> team works."""
@@ -382,3 +381,40 @@ class TestShutdownSettings:
 
         with pytest.raises(ValidationError, match="shutdown_pre_drain_delay"):
             ServerSettings(shutdown_pre_drain_delay=-1)
+
+
+class TestWsReaderPoolSizeSetting:
+    """Tests for ws_reader_pool_size field (story 21-2)."""
+
+    def test_default_ws_reader_pool_size(self) -> None:
+        """Default ws_reader_pool_size is 256."""
+        settings = ServerSettings()
+        assert settings.ws_reader_pool_size == 256
+
+    def test_ws_reader_pool_size_from_env(self) -> None:
+        """AKGENTIC_WS_READER_POOL_SIZE overrides ws_reader_pool_size field."""
+        os.environ["AKGENTIC_WS_READER_POOL_SIZE"] = "64"
+        try:
+            settings = ServerSettings()
+            assert settings.ws_reader_pool_size == 64
+        finally:
+            del os.environ["AKGENTIC_WS_READER_POOL_SIZE"]
+
+    def test_ws_reader_pool_size_has_description(self) -> None:
+        """ws_reader_pool_size has a non-None description."""
+        field = ServerSettings.model_fields["ws_reader_pool_size"]
+        assert field.description is not None
+
+    def test_ws_reader_pool_size_rejects_zero(self) -> None:
+        """ws_reader_pool_size rejects 0 (ge=1 constraint)."""
+        from pydantic import ValidationError
+
+        with pytest.raises(ValidationError, match="ws_reader_pool_size"):
+            ServerSettings(ws_reader_pool_size=0)
+
+    def test_ws_reader_pool_size_rejects_negative(self) -> None:
+        """ws_reader_pool_size rejects negative values."""
+        from pydantic import ValidationError
+
+        with pytest.raises(ValidationError, match="ws_reader_pool_size"):
+            ServerSettings(ws_reader_pool_size=-1)

--- a/tests/server/routes/test_websocket_route.py
+++ b/tests/server/routes/test_websocket_route.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import time
 import uuid
 from unittest.mock import AsyncMock, MagicMock
 
@@ -331,6 +332,33 @@ class TestEventStreamWsIntegration:
 
         with client.websocket_connect(f"/ws/{team_id}"):
             pass  # immediate disconnect
+
+
+class TestFastDisconnectDetection:
+    """AC 13 (issue #227): structural disconnect detection via the supervisor."""
+
+    def test_idle_team_ws_disconnect_detected_fast(
+        self,
+        client: TestClient,
+    ) -> None:
+        """Closing an idle WS returns from the handler well under the old 1s worst case.
+
+        Before the supervisor, disconnect detection required a full
+        ``read_next(0.5)`` tick plus a ``client_state`` check — a worst case
+        near 1s. With ``watch_disconnect`` awaiting ``websocket.receive()``,
+        the handler must exit within a few hundred ms. The 500 ms bound here
+        is the looser CI-safe upper bound prescribed by AC 13.
+        """
+        resp = client.post("/teams/", json={"catalog_entry_id": "test-team"})
+        team_id = resp.json()["team_id"]
+
+        start = time.monotonic()
+        with client.websocket_connect(f"/ws/{team_id}"):
+            pass  # immediate close triggers the disconnect path
+        elapsed = time.monotonic() - start
+
+        # Generous bound for shared CI runners; observed locally well under 100 ms.
+        assert elapsed < 0.5, f"disconnect detection took {elapsed:.3f}s, expected < 0.5s"
 
 
 def _trigger_subscriber_event(client: TestClient, team_id: str) -> None:

--- a/tests/server/test_lifespan.py
+++ b/tests/server/test_lifespan.py
@@ -106,6 +106,18 @@ class TestLifespanShutdown:
             mock_sleep.assert_not_awaited()
 
     @pytest.mark.asyncio
+    async def test_shutdown_calls_shutdown_reader_pool(self) -> None:
+        """Lifespan teardown releases the dedicated WS reader pool (issue #227)."""
+        app = _make_app_state()
+
+        with patch("akgentic.infra.server.app.shutdown_reader_pool") as mock_shutdown_pool:
+            ctx = _lifespan(app)
+            await ctx.__aenter__()
+            await ctx.__aexit__(None, None, None)
+
+        mock_shutdown_pool.assert_called_once_with()
+
+    @pytest.mark.asyncio
     async def test_shutdown_logs_timeout_warning(self) -> None:
         """AC #9: shutdown logs warning when stop_all exceeds drain timeout."""
         app = _make_app_state(drain_timeout=0)
@@ -114,10 +126,13 @@ class TestLifespanShutdown:
         async def _slow_to_thread(fn: object) -> None:
             await asyncio.sleep(10)
 
-        with patch(
-            "akgentic.infra.server.app.asyncio.to_thread",
-            side_effect=_slow_to_thread,
-        ), patch("akgentic.infra.server.app.logger") as mock_logger:
+        with (
+            patch(
+                "akgentic.infra.server.app.asyncio.to_thread",
+                side_effect=_slow_to_thread,
+            ),
+            patch("akgentic.infra.server.app.logger") as mock_logger,
+        ):
             ctx = _lifespan(app)
             await ctx.__aenter__()
             await ctx.__aexit__(None, None, None)

--- a/tests/server/test_ws_streaming.py
+++ b/tests/server/test_ws_streaming.py
@@ -1,26 +1,62 @@
-"""Tests for WebSocket streaming loop CancelledError handling (ADR-015, AC4).
+"""Tests for the WebSocket streaming supervisor.
 
-Unit tests that exercise ``_run_streaming_loop`` when the executor future is
-cancelled (simulating Uvicorn forced task cancellation after
-``timeout_graceful_shutdown`` expires).
+Unit tests that exercise ``_run_streaming_loop`` directly with stubbed
+``service``, ``reader``, and ``websocket`` dependencies. Covers the
+supervisor's cancellation path (issue #227, Epic 21), the ``StreamClosed``
+→ idle-loop transition, and the executor-isolation invariant
+(``_WS_READER_POOL`` is distinct from ``asyncio``'s default executor).
 """
 
 from __future__ import annotations
 
 import asyncio
 import logging
+import re
 import uuid
+from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from fastapi import WebSocketDisconnect
 
-from akgentic.infra.server.routes.ws import ConnectionManager, _run_streaming_loop
+from akgentic.infra.protocols.event_stream import StreamClosed
+from akgentic.infra.server.routes.ws import (
+    ConnectionManager,
+    _get_reader_pool,
+    _run_streaming_loop,
+    shutdown_reader_pool,
+)
 
 
-def _make_mocks() -> tuple[AsyncMock, MagicMock, uuid.UUID, ConnectionManager]:
-    """Build minimal mocks for _run_streaming_loop."""
+@pytest.fixture(autouse=True)
+def _reset_reader_pool() -> None:
+    """Ensure each test starts and ends with a fresh module-level pool."""
+    shutdown_reader_pool()
+    yield
+    shutdown_reader_pool()
+
+
+def _make_mocks(
+    *,
+    reader_pool_size: int = 4,
+) -> tuple[AsyncMock, MagicMock, uuid.UUID, ConnectionManager]:
+    """Build minimal mocks for ``_run_streaming_loop``.
+
+    ``websocket.receive`` is an ``AsyncMock`` that blocks forever by default —
+    tests that want the supervisor to finish via the ``watch_disconnect`` side
+    must override it explicitly.
+    """
     websocket = AsyncMock()
-    websocket.client_state = MagicMock()
+    websocket.app = MagicMock()
+    websocket.app.state = SimpleNamespace(
+        settings=SimpleNamespace(ws_reader_pool_size=reader_pool_size),
+    )
+
+    async def _block_forever() -> None:
+        await asyncio.Event().wait()
+
+    websocket.receive.side_effect = _block_forever
 
     service = MagicMock()
     event_stream = MagicMock()
@@ -34,54 +70,209 @@ def _make_mocks() -> tuple[AsyncMock, MagicMock, uuid.UUID, ConnectionManager]:
     return websocket, service, team_id, conn_mgr
 
 
+# ---------------------------------------------------------------------------
+# Cancellation path (ADR-015 / issue #227)
+# ---------------------------------------------------------------------------
+
+
 async def test_cancelled_error_closes_reader() -> None:
-    """CancelledError triggers reader.close() -- no resource leak (AC4)."""
+    """Cancellation of the reader future still triggers ``reader.close()``."""
     websocket, service, team_id, conn_mgr = _make_mocks()
     reader = service.get_event_stream().subscribe.return_value
 
-    # Make run_in_executor raise CancelledError immediately
-    with patch("asyncio.get_running_loop") as mock_loop:
-        loop_inst = MagicMock()
-        mock_loop.return_value = loop_inst
+    # read_next returns None (timeout tick) so pump loops; watch_disconnect
+    # raises WebSocketDisconnect and wins the race.
+    reader.read_next.return_value = None
 
-        future: asyncio.Future[None] = asyncio.Future()
-        future.cancel()
-        loop_inst.run_in_executor.return_value = future
+    async def _receive_disconnect() -> None:
+        raise WebSocketDisconnect()
 
-        await _run_streaming_loop(websocket, service, team_id, conn_mgr)
+    websocket.receive.side_effect = _receive_disconnect
 
+    await _run_streaming_loop(websocket, service, team_id, conn_mgr)
     reader.close.assert_called_once()
 
 
 async def test_cancelled_error_logs_streaming_stopped(caplog: pytest.LogCaptureFixture) -> None:
-    """CancelledError emits 'WebSocket streaming stopped' log message (AC4)."""
+    """A completed supervisor emits 'WebSocket streaming stopped'."""
     websocket, service, team_id, conn_mgr = _make_mocks()
+    service.get_event_stream().subscribe.return_value.read_next.return_value = None
 
-    with patch("asyncio.get_running_loop") as mock_loop:
-        loop_inst = MagicMock()
-        mock_loop.return_value = loop_inst
+    async def _receive_disconnect() -> None:
+        raise WebSocketDisconnect()
 
-        future: asyncio.Future[None] = asyncio.Future()
-        future.cancel()
-        loop_inst.run_in_executor.return_value = future
+    websocket.receive.side_effect = _receive_disconnect
 
-        with caplog.at_level(logging.INFO, logger="akgentic.infra.server.routes.ws"):
-            await _run_streaming_loop(websocket, service, team_id, conn_mgr)
+    with caplog.at_level(logging.INFO, logger="akgentic.infra.server.routes.ws"):
+        await _run_streaming_loop(websocket, service, team_id, conn_mgr)
 
     assert any("WebSocket streaming stopped" in msg for msg in caplog.messages)
 
 
 async def test_cancelled_error_does_not_propagate() -> None:
-    """CancelledError is caught -- no unhandled exception escapes (AC4)."""
+    """Supervisor swallows cancellation — no exception escapes."""
     websocket, service, team_id, conn_mgr = _make_mocks()
+    service.get_event_stream().subscribe.return_value.read_next.return_value = None
 
-    with patch("asyncio.get_running_loop") as mock_loop:
-        loop_inst = MagicMock()
-        mock_loop.return_value = loop_inst
+    async def _receive_disconnect() -> None:
+        raise WebSocketDisconnect()
 
-        future: asyncio.Future[None] = asyncio.Future()
-        future.cancel()
-        loop_inst.run_in_executor.return_value = future
+    websocket.receive.side_effect = _receive_disconnect
 
-        # Should complete without raising
+    await _run_streaming_loop(websocket, service, team_id, conn_mgr)
+
+
+# ---------------------------------------------------------------------------
+# AC 15: StreamClosed transitions to idle loop
+# ---------------------------------------------------------------------------
+
+
+async def test_stream_closed_transitions_to_idle_loop() -> None:
+    """``StreamClosed`` from pump drives the idle-loop fallback.
+
+    ``conn_mgr.clear_restored(team_id)`` is called and ``_run_idle_loop`` is
+    awaited exactly once. Uses sync ``MagicMock`` for the reader — the
+    StreamReader protocol is sync; no ``AsyncMock.read_next``.
+    """
+    websocket, service, team_id, conn_mgr = _make_mocks()
+    reader = service.get_event_stream().subscribe.return_value
+    reader.read_next.side_effect = StreamClosed()
+
+    conn_mgr.mark_restored(team_id)  # should be cleared by the transition
+
+    mock_idle = AsyncMock()
+    with patch(
+        "akgentic.infra.server.routes.ws._run_idle_loop",
+        new=mock_idle,
+    ):
         await _run_streaming_loop(websocket, service, team_id, conn_mgr)
+
+    assert not conn_mgr.is_restored(team_id)
+    mock_idle.assert_awaited_once()
+    reader.close.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# AC 14: Dedicated reader pool, distinct from the default executor
+# ---------------------------------------------------------------------------
+
+
+async def test_reader_pool_is_dedicated_not_default() -> None:
+    """``_WS_READER_POOL`` is a dedicated ``ThreadPoolExecutor``.
+
+    Also asserts ``max_workers`` matches ``settings.ws_reader_pool_size``.
+    """
+    from concurrent.futures import ThreadPoolExecutor
+
+    websocket = SimpleNamespace(
+        app=SimpleNamespace(
+            state=SimpleNamespace(
+                settings=SimpleNamespace(ws_reader_pool_size=7),
+            ),
+        ),
+    )
+    pool = _get_reader_pool(websocket)  # type: ignore[arg-type]
+
+    assert isinstance(pool, ThreadPoolExecutor)
+    default_exec = asyncio.get_running_loop()._default_executor
+    assert pool is not default_exec  # may be None or a distinct pool
+    assert pool._max_workers == 7  # type: ignore[attr-defined]
+
+
+def test_ws_py_never_uses_default_executor() -> None:
+    """Static assertion: ``ws.py`` never dispatches via ``run_in_executor(None, …)``.
+
+    Dispatching reader polling onto ``asyncio``'s default executor would
+    defeat the isolation contract of ``_WS_READER_POOL`` (issue #227) — a
+    subtle regression that is hard to reproduce in a behavioural test, so
+    we guard it with a source-level grep.
+    """
+    ws_src = (
+        Path(__file__).resolve().parents[2]
+        / "src"
+        / "akgentic"
+        / "infra"
+        / "server"
+        / "routes"
+        / "ws.py"
+    )
+    source = ws_src.read_text()
+    assert not re.search(r"run_in_executor\(\s*None\b", source), (
+        "ws.py must never dispatch reader polling via the default executor"
+    )
+
+
+async def test_reader_pool_is_reused_across_calls() -> None:
+    """Repeated ``_get_reader_pool`` calls return the same singleton."""
+    websocket = SimpleNamespace(
+        app=SimpleNamespace(
+            state=SimpleNamespace(
+                settings=SimpleNamespace(ws_reader_pool_size=2),
+            ),
+        ),
+    )
+    pool_a = _get_reader_pool(websocket)  # type: ignore[arg-type]
+    pool_b = _get_reader_pool(websocket)  # type: ignore[arg-type]
+    assert pool_a is pool_b
+
+
+async def test_shutdown_reader_pool_resets_singleton() -> None:
+    """``shutdown_reader_pool`` releases the executor and allows re-construction."""
+    websocket = SimpleNamespace(
+        app=SimpleNamespace(
+            state=SimpleNamespace(
+                settings=SimpleNamespace(ws_reader_pool_size=2),
+            ),
+        ),
+    )
+    pool_a = _get_reader_pool(websocket)  # type: ignore[arg-type]
+    shutdown_reader_pool()
+    pool_b = _get_reader_pool(websocket)  # type: ignore[arg-type]
+    assert pool_a is not pool_b
+
+
+# ---------------------------------------------------------------------------
+# Supervisor behaviour: event forwarding and adapter wrapping
+# ---------------------------------------------------------------------------
+
+
+async def test_supervisor_forwards_events_until_disconnect() -> None:
+    """Events returned from ``read_next`` are forwarded via ``send_text``."""
+    websocket, service, team_id, conn_mgr = _make_mocks()
+    reader = service.get_event_stream().subscribe.return_value
+
+    event = MagicMock()
+    event.model_dump_json.return_value = '{"hello": "world"}'
+    # First tick returns the event, subsequent ticks return None (timeout).
+    reader.read_next.side_effect = [event, None, None, None]
+
+    async def _receive_disconnect() -> None:
+        # Give pump a chance to forward the event before we exit.
+        await asyncio.sleep(0)
+        raise WebSocketDisconnect()
+
+    websocket.receive.side_effect = _receive_disconnect
+
+    await _run_streaming_loop(websocket, service, team_id, conn_mgr)
+
+    websocket.send_text.assert_any_call('{"hello": "world"}')
+    reader.close.assert_called_once()
+
+
+async def test_supervisor_skips_unserializable_events() -> None:
+    """A ``send_text`` failure is logged at debug level and pump continues."""
+    websocket, service, team_id, conn_mgr = _make_mocks()
+    reader = service.get_event_stream().subscribe.return_value
+
+    bad_event = MagicMock()
+    bad_event.model_dump_json.side_effect = RuntimeError("not json")
+    reader.read_next.side_effect = [bad_event, None, None]
+
+    async def _receive_disconnect() -> None:
+        await asyncio.sleep(0)
+        raise WebSocketDisconnect()
+
+    websocket.receive.side_effect = _receive_disconnect
+
+    await _run_streaming_loop(websocket, service, team_id, conn_mgr)
+    reader.close.assert_called_once()


### PR DESCRIPTION
## Summary

Rewrites `_run_streaming_loop` in `server/routes/ws.py` as a v1-style supervisor that races `pump` against `watch_disconnect`, restoring structural (sub-millisecond) disconnect detection. Adds a dedicated `_WS_READER_POOL` (`ThreadPoolExecutor`, `thread_name_prefix="ws-reader"`) sized from the new `ServerSettings.ws_reader_pool_size` field (default 256), isolating WS reader polling from the default executor.

## Protocol invariant preserved

- `StreamReader.read_next(timeout: float = 0.5) -> Message | None` signature is unchanged.
- `LocalEventStream`, `LocalStreamReader`, `NullEventStream` are unchanged.
- Protocol-invariant test suites (`test_event_stream_protocol.py`, `test_local_event_stream.py`, `integration/test_event_stream_lifecycle.py`) are unchanged and pass untouched.
- `akgentic-infra-enterprise` (`DaprStreamReader`, `StreamSubscriberBridge`, parity fakes) is not touched by this PR.

## Changes

- `server/routes/ws.py`: new `_supervise_stream` supervisor, `_send_event` and `_await_and_suppress` helpers, dedicated reader pool with lazy init and `shutdown_reader_pool`, removal of the `client_state` polling check.
- `server/settings.py`: new `ws_reader_pool_size: int = Field(default=256, ge=1, ...)` field.
- `server/app.py`: wires `shutdown_reader_pool()` into the lifespan teardown.
- Tests: new supervisor, executor-isolation, and idle-disconnect-latency tests; expected-fields update plus `TestWsReaderPoolSizeSetting` in server settings tests; lifespan test for pool shutdown.

## Gates

- Full submodule suite: 1166 passed, 30 skipped, 130 deselected.
- Coverage: ws.py 93%, package 90.15% (floor 80%).
- `ruff check`, `ruff format --check`, `mypy --strict` clean on changed files.
- CI green on `feat/227-ws-supervisor-dedicated-executor`.

Closes #227
