### PR TITLE
Story 21.1: Profile configuration loader and AuthConfig model

### DIFF
--- a/src/akgentic/infra/cli/config/__init__.py
+++ b/src/akgentic/infra/cli/config/__init__.py
@@ -1,0 +1,34 @@
+"""CLI profile configuration package.
+
+Public API for loading and resolving CLI profiles from ``~/.akgentic/config.yaml``.
+Implements ADR-021 §Decision 1 (profile-declared auth; absence of ``auth`` means
+"no auth") and §Decision 2 (config-only scope: no network/token code here).
+"""
+
+from akgentic.infra.cli.config.profile import (
+    AmbiguousProfileError,
+    AuthConfig,
+    CliConfig,
+    ConfigFileNotFoundError,
+    MalformedConfigError,
+    ProfileConfig,
+    ProfileConfigError,
+    UnknownProfileError,
+    UnsupportedAuthTypeError,
+    load_config,
+    resolve_profile,
+)
+
+__all__ = [
+    "AmbiguousProfileError",
+    "AuthConfig",
+    "CliConfig",
+    "ConfigFileNotFoundError",
+    "MalformedConfigError",
+    "ProfileConfig",
+    "ProfileConfigError",
+    "UnknownProfileError",
+    "UnsupportedAuthTypeError",
+    "load_config",
+    "resolve_profile",
+]

--- a/src/akgentic/infra/cli/config/profile.py
+++ b/src/akgentic/infra/cli/config/profile.py
@@ -1,0 +1,226 @@
+"""Profile configuration models, loader, and active-profile resolver.
+
+Implements ADR-021 §Decision 1 — profile-declared auth as the single source of
+truth. The **absence** of the ``auth`` block is the runtime signal for "no
+auth"; its **presence** is the signal to run OIDC. This module is the boundary
+where that distinction becomes typed: downstream callers branch on
+``profile.auth is None`` only.
+
+Scope is intentionally narrow: pure configuration modeling + YAML loading +
+profile selection. No HTTP client wiring, no token cache, no OIDC code.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Literal
+
+import yaml
+from pydantic import BaseModel, HttpUrl, ValidationError
+
+# ---------------------------------------------------------------------------
+# Typed error hierarchy
+# ---------------------------------------------------------------------------
+
+
+class ProfileConfigError(Exception):
+    """Base class for all profile-config errors."""
+
+
+class ConfigFileNotFoundError(ProfileConfigError):
+    """Raised when the config file does not exist on disk."""
+
+
+class MalformedConfigError(ProfileConfigError):
+    """Raised when the config file cannot be parsed or fails top-level validation."""
+
+
+class UnknownProfileError(ProfileConfigError):
+    """Raised when a requested profile name is not in ``config.profiles``."""
+
+
+class AmbiguousProfileError(ProfileConfigError):
+    """Raised when no profile is selected and more than one is available."""
+
+
+class UnsupportedAuthTypeError(ProfileConfigError):
+    """Raised when ``auth.type`` is present but not in the supported set."""
+
+
+# ---------------------------------------------------------------------------
+# Pydantic models
+# ---------------------------------------------------------------------------
+
+
+class AuthConfig(BaseModel):
+    """Authentication config block for a profile.
+
+    Only ``oidc`` is supported today; Pydantic's ``Literal`` rejects other
+    values at validation time, which the loader translates to a clearer
+    ``UnsupportedAuthTypeError``.
+    """
+
+    type: Literal["oidc"]
+    issuer: HttpUrl
+    client_id: str
+    tenant: str | None = None
+
+
+class ProfileConfig(BaseModel):
+    """A single CLI profile.
+
+    ``auth=None`` (the field's absence in YAML) is the signal that the CLI
+    MUST NOT attach an ``Authorization`` header for this profile (ADR-021).
+    """
+
+    endpoint: HttpUrl
+    auth: AuthConfig | None = None
+
+
+class CliConfig(BaseModel):
+    """Top-level config read from ``~/.akgentic/config.yaml``.
+
+    ``profiles`` is the one allowed mapping: keys are profile names (strings),
+    and values are typed ``ProfileConfig`` models — never ``Any``.
+    """
+
+    profiles: dict[str, ProfileConfig]
+    default_profile: str | None = None
+
+
+# ---------------------------------------------------------------------------
+# Loader
+# ---------------------------------------------------------------------------
+
+
+_DEFAULT_CONFIG_PATH = Path.home() / ".akgentic" / "config.yaml"
+
+
+def _is_unsupported_auth_type_error(err: ValidationError) -> bool:
+    """Return True if a ValidationError is caused by an invalid ``auth.type``.
+
+    Pydantic raises ``literal_error`` when a ``Literal[...]`` field receives a
+    value outside the allowed set. We narrow to errors whose location ends at
+    ``('auth', 'type')`` for any profile.
+    """
+    for err_entry in err.errors():
+        loc = err_entry.get("loc", ())
+        err_type = err_entry.get("type", "")
+        if err_type == "literal_error" and len(loc) >= 2 and loc[-2:] == ("auth", "type"):
+            return True
+    return False
+
+
+def load_config(path: Path | None = None) -> CliConfig:
+    """Load and validate the CLI config file.
+
+    Args:
+        path: Optional override path. Defaults to ``~/.akgentic/config.yaml``.
+
+    Returns:
+        A validated :class:`CliConfig`.
+
+    Raises:
+        ConfigFileNotFoundError: If the file does not exist.
+        MalformedConfigError: If the YAML is invalid or fails validation.
+        UnsupportedAuthTypeError: If ``auth.type`` is present but not ``"oidc"``.
+    """
+    resolved_path = path if path is not None else _DEFAULT_CONFIG_PATH
+
+    if not resolved_path.exists():
+        raise ConfigFileNotFoundError(f"Config file not found: {resolved_path}")
+
+    try:
+        raw_text = resolved_path.read_text(encoding="utf-8")
+    except OSError as exc:  # pragma: no cover - defensive
+        raise MalformedConfigError(f"Cannot read config file {resolved_path}: {exc}") from exc
+
+    try:
+        data = yaml.safe_load(raw_text)
+    except yaml.YAMLError as exc:
+        raise MalformedConfigError(f"Invalid YAML in {resolved_path}: {exc}") from exc
+
+    if data is None:
+        raise MalformedConfigError(f"Config file is empty: {resolved_path}")
+
+    if not isinstance(data, dict):
+        raise MalformedConfigError(
+            f"Config file top level must be a mapping, got {type(data).__name__}: {resolved_path}"
+        )
+
+    try:
+        return CliConfig.model_validate(data)
+    except ValidationError as exc:
+        if _is_unsupported_auth_type_error(exc):
+            raise UnsupportedAuthTypeError(
+                f"Unsupported auth.type in {resolved_path}: only 'oidc' is supported"
+            ) from exc
+        raise MalformedConfigError(f"Invalid config in {resolved_path}: {exc}") from exc
+
+
+# ---------------------------------------------------------------------------
+# Resolver
+# ---------------------------------------------------------------------------
+
+
+_ENV_PROFILE_VAR = "AKGENTIC_PROFILE"
+
+
+def _lookup_profile(config: CliConfig, name: str) -> ProfileConfig:
+    """Return the named profile or raise UnknownProfileError with available names."""
+    if name not in config.profiles:
+        available = sorted(config.profiles.keys())
+        raise UnknownProfileError(f"Unknown profile: {name!r}. Available profiles: {available}")
+    return config.profiles[name]
+
+
+def resolve_profile(
+    config: CliConfig,
+    *,
+    cli_profile: str | None,
+    env: Mapping[str, str],
+) -> tuple[str, ProfileConfig]:
+    """Select the active profile from ``config`` using the documented precedence.
+
+    Precedence (highest to lowest):
+
+    1. ``cli_profile`` (typically from a ``--profile`` CLI flag)
+    2. ``AKGENTIC_PROFILE`` in the provided ``env`` mapping
+    3. ``config.default_profile``
+    4. If exactly one profile exists, use it
+    5. Otherwise raise :class:`AmbiguousProfileError`
+
+    Args:
+        config: Loaded :class:`CliConfig`.
+        cli_profile: Profile name from the CLI flag, or ``None``.
+        env: Environment mapping (pass a dict in tests; pass ``os.environ`` in
+            production). Explicit parameter keeps this function pure.
+
+    Returns:
+        A ``(name, ProfileConfig)`` tuple.
+
+    Raises:
+        UnknownProfileError: When the selected name is not in ``config.profiles``.
+        AmbiguousProfileError: When no selection criterion matches and more than
+            one profile exists.
+    """
+    if cli_profile is not None:
+        return cli_profile, _lookup_profile(config, cli_profile)
+
+    env_name = env.get(_ENV_PROFILE_VAR)
+    if env_name:
+        return env_name, _lookup_profile(config, env_name)
+
+    if config.default_profile is not None:
+        return config.default_profile, _lookup_profile(config, config.default_profile)
+
+    if len(config.profiles) == 1:
+        name, profile = next(iter(config.profiles.items()))
+        return name, profile
+
+    available = sorted(config.profiles.keys())
+    raise AmbiguousProfileError(
+        "No profile selected (no --profile, no AKGENTIC_PROFILE, no default_profile) "
+        f"and more than one profile is defined. Available profiles: {available}"
+    )

--- a/tests/cli/config/test_profile.py
+++ b/tests/cli/config/test_profile.py
@@ -1,0 +1,323 @@
+"""Unit tests for ``akgentic.infra.cli.config.profile``.
+
+Covers every behavior listed in Story 21.1 AC #8:
+  - precedence rules of resolve_profile
+  - loader error handling (missing file, malformed YAML, validation, auth type)
+  - typed model parsing (auth absent vs present)
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from pydantic import HttpUrl
+
+from akgentic.infra.cli.config import (
+    AmbiguousProfileError,
+    AuthConfig,
+    CliConfig,
+    ConfigFileNotFoundError,
+    MalformedConfigError,
+    ProfileConfig,
+    UnknownProfileError,
+    UnsupportedAuthTypeError,
+    load_config,
+    resolve_profile,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures / helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_profile(endpoint: str = "https://api.example.com") -> ProfileConfig:
+    return ProfileConfig(endpoint=HttpUrl(endpoint))
+
+
+def _make_profile_with_auth(
+    endpoint: str = "https://api.example.com",
+    issuer: str = "https://auth.example.com",
+    client_id: str = "cli",
+    tenant: str | None = None,
+) -> ProfileConfig:
+    return ProfileConfig(
+        endpoint=HttpUrl(endpoint),
+        auth=AuthConfig(
+            type="oidc",
+            issuer=HttpUrl(issuer),
+            client_id=client_id,
+            tenant=tenant,
+        ),
+    )
+
+
+def _multi_profile_config(default_profile: str | None = None) -> CliConfig:
+    return CliConfig(
+        profiles={
+            "alpha": _make_profile("https://alpha.example.com"),
+            "beta": _make_profile("https://beta.example.com"),
+        },
+        default_profile=default_profile,
+    )
+
+
+def _write_yaml(tmp_path: Path, text: str) -> Path:
+    path = tmp_path / "config.yaml"
+    path.write_text(text, encoding="utf-8")
+    return path
+
+
+# ---------------------------------------------------------------------------
+# resolve_profile — precedence (AC #5, #8)
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_profile_cli_flag_wins_over_env_default_and_single() -> None:
+    """--profile beats env, default_profile, and single-profile auto-select."""
+    config = CliConfig(
+        profiles={
+            "alpha": _make_profile("https://alpha.example.com"),
+            "beta": _make_profile("https://beta.example.com"),
+        },
+        default_profile="alpha",
+    )
+    env = {"AKGENTIC_PROFILE": "alpha"}
+
+    name, profile = resolve_profile(config, cli_profile="beta", env=env)
+
+    assert name == "beta"
+    assert str(profile.endpoint) == "https://beta.example.com/"
+
+
+def test_resolve_profile_env_wins_over_default_and_single() -> None:
+    """AKGENTIC_PROFILE beats default_profile and single-profile auto-select."""
+    config = _multi_profile_config(default_profile="alpha")
+    env = {"AKGENTIC_PROFILE": "beta"}
+
+    name, _profile = resolve_profile(config, cli_profile=None, env=env)
+
+    assert name == "beta"
+
+
+def test_resolve_profile_default_wins_over_single_auto_select() -> None:
+    """default_profile beats single-profile auto-select when multiple profiles exist."""
+    config = _multi_profile_config(default_profile="beta")
+
+    name, _profile = resolve_profile(config, cli_profile=None, env={})
+
+    assert name == "beta"
+
+
+def test_resolve_profile_single_profile_auto_select() -> None:
+    """Single-profile config auto-selects that profile when nothing else is provided."""
+    config = CliConfig(profiles={"solo": _make_profile()})
+
+    name, profile = resolve_profile(config, cli_profile=None, env={})
+
+    assert name == "solo"
+    assert str(profile.endpoint) == "https://api.example.com/"
+
+
+def test_resolve_profile_ambiguous_raises() -> None:
+    """Ambiguous selection (>=2 profiles, no flag/env/default) raises AmbiguousProfileError."""
+    config = _multi_profile_config()
+
+    with pytest.raises(AmbiguousProfileError) as err:
+        resolve_profile(config, cli_profile=None, env={})
+
+    # Error message must list available profiles (operator-actionable).
+    assert "alpha" in str(err.value)
+    assert "beta" in str(err.value)
+
+
+def test_resolve_profile_unknown_cli_profile_raises() -> None:
+    """Unknown name from --profile raises UnknownProfileError with available list."""
+    config = _multi_profile_config()
+
+    with pytest.raises(UnknownProfileError) as err:
+        resolve_profile(config, cli_profile="missing", env={})
+
+    assert "missing" in str(err.value)
+    assert "alpha" in str(err.value)
+
+
+def test_resolve_profile_unknown_env_profile_raises() -> None:
+    """Unknown name from env var raises UnknownProfileError."""
+    config = _multi_profile_config()
+
+    with pytest.raises(UnknownProfileError):
+        resolve_profile(config, cli_profile=None, env={"AKGENTIC_PROFILE": "missing"})
+
+
+def test_resolve_profile_unknown_default_profile_raises() -> None:
+    """Unknown name in default_profile raises UnknownProfileError."""
+    # default_profile set to a name not present in profiles — validates via resolver
+    # (not at model-construction time, since Pydantic doesn't cross-check).
+    config = CliConfig(
+        profiles={"alpha": _make_profile()},
+        default_profile="ghost",
+    )
+
+    with pytest.raises(UnknownProfileError):
+        resolve_profile(config, cli_profile=None, env={})
+
+
+def test_resolve_profile_empty_env_string_ignored() -> None:
+    """An empty AKGENTIC_PROFILE string is treated as absent, not as a profile name."""
+    config = CliConfig(profiles={"solo": _make_profile()})
+
+    name, _profile = resolve_profile(config, cli_profile=None, env={"AKGENTIC_PROFILE": ""})
+
+    # Falls through to single-profile auto-select rather than raising UnknownProfile.
+    assert name == "solo"
+
+
+# ---------------------------------------------------------------------------
+# load_config — file handling and parsing (AC #4, #6, #8)
+# ---------------------------------------------------------------------------
+
+
+def test_load_config_missing_file_raises(tmp_path: Path) -> None:
+    path = tmp_path / "does-not-exist.yaml"
+
+    with pytest.raises(ConfigFileNotFoundError) as err:
+        load_config(path)
+
+    assert str(path) in str(err.value)
+
+
+def test_load_config_malformed_yaml_raises(tmp_path: Path) -> None:
+    path = _write_yaml(tmp_path, "profiles:\n  alpha: {endpoint: [unclosed\n")
+
+    with pytest.raises(MalformedConfigError):
+        load_config(path)
+
+
+def test_load_config_empty_file_raises(tmp_path: Path) -> None:
+    path = _write_yaml(tmp_path, "")
+
+    with pytest.raises(MalformedConfigError):
+        load_config(path)
+
+
+def test_load_config_non_mapping_top_level_raises(tmp_path: Path) -> None:
+    path = _write_yaml(tmp_path, "- just\n- a\n- list\n")
+
+    with pytest.raises(MalformedConfigError):
+        load_config(path)
+
+
+def test_load_config_validation_error_raises_malformed(tmp_path: Path) -> None:
+    """A non-URL endpoint (not an auth-type problem) raises MalformedConfigError."""
+    path = _write_yaml(
+        tmp_path,
+        "profiles:\n  alpha:\n    endpoint: not-a-url\n",
+    )
+
+    with pytest.raises(MalformedConfigError):
+        load_config(path)
+
+
+def test_load_config_no_auth_block_yields_none(tmp_path: Path) -> None:
+    """Profile with no ``auth`` block parses cleanly and yields ``profile.auth is None``."""
+    path = _write_yaml(
+        tmp_path,
+        "profiles:\n  alpha:\n    endpoint: https://api.example.com\n",
+    )
+
+    config = load_config(path)
+
+    assert config.profiles["alpha"].auth is None
+
+
+def test_load_config_with_auth_block_parses_typed(tmp_path: Path) -> None:
+    """Profile ``with`` an auth block parses into a typed AuthConfig with validated URLs."""
+    yaml_text = (
+        "profiles:\n"
+        "  alpha:\n"
+        "    endpoint: https://api.example.com\n"
+        "    auth:\n"
+        "      type: oidc\n"
+        "      issuer: https://auth.example.com\n"
+        "      client_id: my-cli\n"
+        "      tenant: acme\n"
+    )
+    path = _write_yaml(tmp_path, yaml_text)
+
+    config = load_config(path)
+
+    profile = config.profiles["alpha"]
+    assert profile.auth is not None
+    assert profile.auth.type == "oidc"
+    assert str(profile.auth.issuer) == "https://auth.example.com/"
+    assert profile.auth.client_id == "my-cli"
+    assert profile.auth.tenant == "acme"
+
+
+def test_load_config_auth_issuer_rejects_non_url(tmp_path: Path) -> None:
+    """A non-URL issuer fails validation and surfaces as MalformedConfigError."""
+    yaml_text = (
+        "profiles:\n"
+        "  alpha:\n"
+        "    endpoint: https://api.example.com\n"
+        "    auth:\n"
+        "      type: oidc\n"
+        "      issuer: not-a-url\n"
+        "      client_id: my-cli\n"
+    )
+    path = _write_yaml(tmp_path, yaml_text)
+
+    with pytest.raises(MalformedConfigError):
+        load_config(path)
+
+
+def test_load_config_unsupported_auth_type_raises(tmp_path: Path) -> None:
+    """``auth.type`` outside the supported set raises UnsupportedAuthTypeError."""
+    yaml_text = (
+        "profiles:\n"
+        "  alpha:\n"
+        "    endpoint: https://api.example.com\n"
+        "    auth:\n"
+        "      type: saml\n"
+        "      issuer: https://auth.example.com\n"
+        "      client_id: my-cli\n"
+    )
+    path = _write_yaml(tmp_path, yaml_text)
+
+    with pytest.raises(UnsupportedAuthTypeError):
+        load_config(path)
+
+
+def test_load_config_default_profile_roundtrip(tmp_path: Path) -> None:
+    """``default_profile`` is parsed when present."""
+    yaml_text = (
+        "default_profile: alpha\nprofiles:\n  alpha:\n    endpoint: https://api.example.com\n"
+    )
+    path = _write_yaml(tmp_path, yaml_text)
+
+    config = load_config(path)
+
+    assert config.default_profile == "alpha"
+
+
+def test_load_config_default_path_used_when_none_passed(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """load_config() with no args reads the default ``~/.akgentic/config.yaml``."""
+    fake_home = tmp_path / "home"
+    (fake_home / ".akgentic").mkdir(parents=True)
+    (fake_home / ".akgentic" / "config.yaml").write_text(
+        "profiles:\n  alpha:\n    endpoint: https://api.example.com\n",
+        encoding="utf-8",
+    )
+
+    # Patch the module-level constant so we don't depend on the real HOME.
+    from akgentic.infra.cli.config import profile as profile_mod
+
+    monkeypatch.setattr(
+        profile_mod, "_DEFAULT_CONFIG_PATH", fake_home / ".akgentic" / "config.yaml"
+    )
+
+    config = load_config()
+    assert "alpha" in config.profiles


### PR DESCRIPTION
## Summary

Implements Story 21.1 — adds the profile configuration loader and `AuthConfig` model for the CLI, per ADR-021.

- New `akgentic.infra.cli.config` subpackage exposing `load_config`, `resolve_profile`, `CliConfig`, `ProfileConfig`, `AuthConfig`, and the typed `ProfileConfigError` hierarchy (`ConfigFileNotFoundError`, `MalformedConfigError`, `UnknownProfileError`, `AmbiguousProfileError`, `UnsupportedAuthTypeError`).
- `load_config` reads `~/.akgentic/config.yaml` (or an override path) with `yaml.safe_load` and translates Pydantic `Literal["oidc"]` validation failures on `auth.type` into `UnsupportedAuthTypeError` while routing every other validation failure to `MalformedConfigError`.
- `resolve_profile` implements the documented precedence: `--profile` flag → `AKGENTIC_PROFILE` env → `default_profile` → single-profile auto-select → `AmbiguousProfileError`. `env` is injected as `Mapping[str, str]` so tests never touch `os.environ`.
- Absence of the `auth` block is the single runtime signal downstream stories branch on (`profile.auth is None`); `AuthConfig` has no `type == "none"` sentinel.

## Scope

Config-only. No HTTP client wiring, no token code, no `login`/`logout` command. Those are Stories 21.2–21.4.

## Tests

- 20 unit tests in `tests/cli/config/test_profile.py` covering every behavior in AC #8 plus defensive cases (empty env string, unknown `default_profile`, default-path injection via monkeypatch).
- 100% line + branch coverage on both new files (`__init__.py`, `profile.py`).
- CI green on the branch.

Closes #229
