### PR TITLE
feat: CLI HTTP client factory with conditional bearer + fail-loud 401 (story 21.2)

### DIFF
--- a/src/akgentic/infra/cli/auth/__init__.py
+++ b/src/akgentic/infra/cli/auth/__init__.py
@@ -1,0 +1,11 @@
+"""CLI auth package.
+
+Public API for pluggable access-token providers used by
+:func:`akgentic.infra.cli.http.build_http_client`. Story 21.2 delivers only the
+:class:`TokenProvider` Protocol (the boundary); Story 21.3 delivers the real
+``OidcTokenProvider`` implementation.
+"""
+
+from akgentic.infra.cli.auth.token_provider import TokenProvider
+
+__all__ = ["TokenProvider"]

--- a/src/akgentic/infra/cli/auth/token_provider.py
+++ b/src/akgentic/infra/cli/auth/token_provider.py
@@ -1,0 +1,35 @@
+"""Token provider protocol used by the CLI HTTP client factory.
+
+Story 21.2 defines ONLY the Protocol. The concrete OIDC implementation
+(``OidcTokenProvider``) lands in Story 21.3. By keeping this boundary as a
+``typing.Protocol`` (not an ABC), tests can supply lightweight fakes without
+inheriting from a framework class, and the production OIDC code never has to
+know about the factory.
+
+``@runtime_checkable`` is applied so tests may ``isinstance(x, TokenProvider)``
+a fake if they want; the Protocol's only method is :meth:`get_access_token`.
+"""
+
+from __future__ import annotations
+
+from typing import Protocol, runtime_checkable
+
+
+@runtime_checkable
+class TokenProvider(Protocol):
+    """Source of bearer tokens for authenticated CLI requests.
+
+    Implementations are expected to handle their own caching / refresh policy.
+    :func:`akgentic.infra.cli.http.build_http_client` calls
+    :meth:`get_access_token` on every outgoing request, so a provider that
+    caches internally picks up rotation transparently without the client being
+    rebuilt.
+    """
+
+    def get_access_token(self) -> str:
+        """Return a valid bearer token as a string.
+
+        Implementations MUST NOT prefix the return value with ``"Bearer "`` —
+        the factory formats the ``Authorization`` header.
+        """
+        ...

--- a/src/akgentic/infra/cli/http/__init__.py
+++ b/src/akgentic/infra/cli/http/__init__.py
@@ -1,0 +1,26 @@
+"""CLI HTTP client factory and typed error surfaces.
+
+Public API for :mod:`akgentic.infra.cli` HTTP access. See ADR-021 for the
+profile-driven auth model (the factory here is the first consumer of the
+``profile.auth is None`` signal delivered by :mod:`akgentic.infra.cli.config`).
+
+This package intentionally stays thin: a single factory, a typed error
+hierarchy, and nothing else. OIDC lives in Story 21.3's ``OidcTokenProvider``;
+inline retry-once auto-auth lands in Story 21.4.
+"""
+
+from akgentic.infra.cli.http.client import build_http_client
+from akgentic.infra.cli.http.errors import (
+    AuthenticationError,
+    HttpClientError,
+    InvalidClientConfigurationError,
+    ServerConfigurationError,
+)
+
+__all__ = [
+    "AuthenticationError",
+    "HttpClientError",
+    "InvalidClientConfigurationError",
+    "ServerConfigurationError",
+    "build_http_client",
+]

--- a/src/akgentic/infra/cli/http/client.py
+++ b/src/akgentic/infra/cli/http/client.py
@@ -1,0 +1,153 @@
+"""HTTP client factory for CLI commands.
+
+Implements ADR-021 §Decision 1 — the runtime signal for "attach auth" is
+``profile.auth is None`` versus ``profile.auth is not None``; we never branch
+on a side flag. OSS profiles are guaranteed to send NO ``Authorization``
+header, and a 401 from one is translated to :class:`ServerConfigurationError`
+(an operator-actionable mismatch, not a login prompt).
+
+Testing seam
+------------
+
+:func:`build_http_client` accepts a keyword-only ``transport`` argument typed
+as ``httpx.BaseTransport | None``. Production callers leave it ``None`` and
+httpx constructs its default HTTPS transport. Tests pass an
+``httpx.MockTransport`` to intercept requests and assert on outgoing headers /
+inject 401 responses, with zero real network I/O. This seam is documented
+behavior, not an implementation accident — it stays stable for Story 21.4's
+retry wiring.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Generator
+
+import httpx
+
+from akgentic.infra.cli.auth.token_provider import TokenProvider
+from akgentic.infra.cli.config.profile import ProfileConfig
+from akgentic.infra.cli.http.errors import (
+    AuthenticationError,
+    InvalidClientConfigurationError,
+    ServerConfigurationError,
+)
+
+_DEFAULT_TIMEOUT = httpx.Timeout(30.0, connect=10.0)
+
+
+class _BearerAuth(httpx.Auth):
+    """httpx Auth flow that fetches a fresh bearer token per request.
+
+    The token is NOT cached at construction time — each request calls
+    ``token_provider.get_access_token()``, so rotation handled by the provider
+    is observed without rebuilding the client (AC #3).
+    """
+
+    requires_request_body = False
+    requires_response_body = False
+
+    def __init__(self, token_provider: TokenProvider) -> None:
+        self._token_provider = token_provider
+
+    def auth_flow(self, request: httpx.Request) -> Generator[httpx.Request, httpx.Response, None]:
+        token = self._token_provider.get_access_token()
+        request.headers["Authorization"] = f"Bearer {token}"
+        yield request
+
+
+def _enforce_misuse_guards(profile: ProfileConfig, token_provider: TokenProvider | None) -> None:
+    """Reject incoherent ``(profile, token_provider)`` combinations loudly."""
+    if profile.auth is None and token_provider is not None:
+        raise InvalidClientConfigurationError(
+            "Profile has no `auth` block (OSS profile) but a token_provider was "
+            "supplied. OSS profiles must never attach an Authorization header; "
+            "pass token_provider=None or configure an `auth:` block on the profile."
+        )
+    if profile.auth is not None and token_provider is None:
+        raise InvalidClientConfigurationError(
+            "Profile declares an `auth` block but no token_provider was supplied. "
+            "Pass a TokenProvider (Story 21.3 provides OidcTokenProvider) so the "
+            "factory can attach bearer tokens on outgoing requests."
+        )
+
+
+def _build_raise_on_401_hook(
+    profile: ProfileConfig, profile_name: str
+) -> Callable[[httpx.Response], None]:
+    """Return a response event hook that translates 401s into typed errors.
+
+    Non-401 responses pass through untouched; the factory's ONLY behavioral
+    departure from a stock ``httpx.Client`` is this 401 translation.
+    """
+
+    def _on_response(response: httpx.Response) -> None:
+        if response.status_code != 401:
+            return
+        url = str(response.request.url)
+        if profile.auth is None:
+            raise ServerConfigurationError(profile_name=profile_name, url=url)
+        raise AuthenticationError(profile_name=profile_name, url=url)
+
+    return _on_response
+
+
+def build_http_client(
+    profile: ProfileConfig,
+    token_provider: TokenProvider | None = None,
+    *,
+    profile_name: str | None = None,
+    transport: httpx.BaseTransport | None = None,
+) -> httpx.Client:
+    """Construct an ``httpx.Client`` wired for the active CLI profile.
+
+    The returned client:
+
+    * Uses ``profile.endpoint`` as its ``base_url`` (stringified from Pydantic
+      ``HttpUrl``).
+    * Has ``follow_redirects=True`` and a sane default timeout.
+    * Attaches ``Authorization: Bearer <token>`` on every request IFF
+      ``profile.auth is not None`` — otherwise NEVER sends an Authorization
+      header (ADR-021 OSS invariant, AC #2).
+    * Raises :class:`ServerConfigurationError` on a 401 from an OSS profile
+      and :class:`AuthenticationError` on a 401 from an auth-enabled profile.
+      Non-401 responses (2xx, 4xx other than 401, 5xx, network errors) are
+      NOT translated — callers see httpx's native surface.
+
+    Args:
+        profile: The active :class:`ProfileConfig` (from ``resolve_profile``).
+        token_provider: Required when ``profile.auth is not None``; MUST be
+            ``None`` when ``profile.auth is None``. Mismatches raise
+            :class:`InvalidClientConfigurationError` at call time.
+        profile_name: The resolved profile name — used in 401 error messages
+            so operators know which profile to edit. Defaults to the string
+            ``"<unknown>"`` if the caller did not pass one.
+        transport: Test seam. Pass an ``httpx.MockTransport`` to intercept
+            requests in tests. ``None`` in production.
+
+    Returns:
+        A ready-to-use ``httpx.Client`` bound to the profile's endpoint.
+
+    Raises:
+        InvalidClientConfigurationError: When ``profile`` and ``token_provider``
+            are incoherent (AC #7).
+    """
+    _enforce_misuse_guards(profile, token_provider)
+
+    resolved_name = profile_name if profile_name is not None else "<unknown>"
+
+    auth: httpx.Auth | None
+    if profile.auth is not None:
+        assert token_provider is not None  # guaranteed by _enforce_misuse_guards
+        auth = _BearerAuth(token_provider)
+    else:
+        auth = None
+
+    client = httpx.Client(
+        base_url=str(profile.endpoint),
+        follow_redirects=True,
+        timeout=_DEFAULT_TIMEOUT,
+        auth=auth,
+        transport=transport,
+    )
+    client.event_hooks["response"].append(_build_raise_on_401_hook(profile, resolved_name))
+    return client

--- a/src/akgentic/infra/cli/http/errors.py
+++ b/src/akgentic/infra/cli/http/errors.py
@@ -1,0 +1,77 @@
+"""Typed error hierarchy raised by clients built with :func:`build_http_client`.
+
+Implements ADR-021 §Decision 1 — a 401 from a profile with no ``auth`` block is
+a **server configuration error** (the operator pointed the CLI at a protected
+endpoint with an OSS profile), NOT a login prompt. A 401 from a profile that
+does declare ``auth`` is an :class:`AuthenticationError`; Story 21.4 will wrap
+it with a single-shot retry. Story 21.2 only raises the type.
+"""
+
+from __future__ import annotations
+
+
+class HttpClientError(Exception):
+    """Base class for errors raised by clients returned from ``build_http_client``."""
+
+
+class ServerConfigurationError(HttpClientError):
+    """Raised on 401 when the active profile has ``auth is None``.
+
+    The message MUST point the operator at **profile configuration** — never at
+    ``akgentic login``. A 401 here means the server is enforcing auth but the
+    caller's profile is OSS-shaped; that's a configuration mismatch, not a
+    missing credential.
+    """
+
+    def __init__(
+        self,
+        *,
+        profile_name: str,
+        url: str,
+        cause: Exception | None = None,
+    ) -> None:
+        self.profile_name = profile_name
+        self.url = url
+        message = (
+            f"The server at {url} returned 401 but profile '{profile_name}' has no auth "
+            "configured. Check the profile's `auth:` block in ~/.akgentic/config.yaml "
+            "(profile configuration error)."
+        )
+        super().__init__(message)
+        if cause is not None:
+            self.__cause__ = cause
+
+
+class AuthenticationError(HttpClientError):
+    """Raised on 401 when the active profile has an ``auth`` block.
+
+    Story 21.2 only defines the type and ensures it is raised. Story 21.4 adds
+    the retry-once auto-auth wrapper that catches this, re-authenticates, and
+    replays the request.
+    """
+
+    def __init__(
+        self,
+        *,
+        profile_name: str,
+        url: str,
+        cause: Exception | None = None,
+    ) -> None:
+        self.profile_name = profile_name
+        self.url = url
+        message = (
+            f"Authentication failed for profile '{profile_name}' at {url} (HTTP 401). "
+            "The access token was rejected by the server."
+        )
+        super().__init__(message)
+        if cause is not None:
+            self.__cause__ = cause
+
+
+class InvalidClientConfigurationError(HttpClientError):
+    """Raised at factory-build time when profile/token_provider combination is incoherent.
+
+    See :func:`build_http_client` AC #7: mismatches between ``profile.auth`` and
+    ``token_provider`` are rejected loudly at construction rather than silently
+    papered over.
+    """

--- a/tests/cli/http/test_client.py
+++ b/tests/cli/http/test_client.py
@@ -1,0 +1,310 @@
+"""Tests for :func:`akgentic.infra.cli.http.build_http_client` (Story 21.2).
+
+All tests use ``httpx.MockTransport`` — no real network, no live server.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+
+import httpx
+import pytest
+
+from akgentic.infra.cli.auth import TokenProvider
+from akgentic.infra.cli.config.profile import AuthConfig, ProfileConfig
+from akgentic.infra.cli.http import (
+    AuthenticationError,
+    InvalidClientConfigurationError,
+    ServerConfigurationError,
+    build_http_client,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures / helpers
+# ---------------------------------------------------------------------------
+
+
+class FakeTokenProvider:
+    """Test double for :class:`TokenProvider`.
+
+    In constant mode it returns ``constant_token`` every call. In sequence
+    mode, it iterates ``sequence`` and returns the successive values (AC #8's
+    per-request fetch test relies on this).
+    """
+
+    def __init__(
+        self,
+        *,
+        constant_token: str | None = None,
+        sequence: list[str] | None = None,
+    ) -> None:
+        if (constant_token is None) == (sequence is None):
+            raise ValueError("Pass exactly one of constant_token or sequence")
+        self._constant = constant_token
+        self._sequence_iter: Iterator[str] | None = iter(sequence) if sequence else None
+
+    def get_access_token(self) -> str:
+        if self._constant is not None:
+            return self._constant
+        assert self._sequence_iter is not None
+        return next(self._sequence_iter)
+
+
+@pytest.fixture
+def oss_profile() -> ProfileConfig:
+    return ProfileConfig(endpoint="https://oss.example.invalid")  # type: ignore[arg-type]
+
+
+@pytest.fixture
+def auth_profile() -> ProfileConfig:
+    return ProfileConfig(
+        endpoint="https://enterprise.example.invalid",  # type: ignore[arg-type]
+        auth=AuthConfig(
+            type="oidc",
+            issuer="https://example.invalid/realms/acme",  # type: ignore[arg-type]
+            client_id="akgentic-cli",
+        ),
+    )
+
+
+def _ok_transport(capture: list[httpx.Request]) -> httpx.MockTransport:
+    def _handler(request: httpx.Request) -> httpx.Response:
+        capture.append(request)
+        return httpx.Response(200, json={"ok": True})
+
+    return httpx.MockTransport(_handler)
+
+
+def _status_transport(status: int) -> httpx.MockTransport:
+    def _handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(status)
+
+    return httpx.MockTransport(_handler)
+
+
+# ---------------------------------------------------------------------------
+# AC #4: TokenProvider is a runtime_checkable Protocol
+# ---------------------------------------------------------------------------
+
+
+def test_token_provider_is_runtime_checkable() -> None:
+    assert isinstance(FakeTokenProvider(constant_token="x"), TokenProvider)
+
+
+# ---------------------------------------------------------------------------
+# AC #2: OSS profile sends NO Authorization header
+# ---------------------------------------------------------------------------
+
+
+def test_oss_profile_sends_no_authorization_header(oss_profile: ProfileConfig) -> None:
+    captured: list[httpx.Request] = []
+    client = build_http_client(
+        oss_profile,
+        profile_name="oss",
+        transport=_ok_transport(captured),
+    )
+    try:
+        response = client.get("/anything")
+    finally:
+        client.close()
+
+    assert response.status_code == 200
+    assert len(captured) == 1
+    assert "Authorization" not in captured[0].headers
+
+
+# ---------------------------------------------------------------------------
+# AC #5 + #6: 401 on OSS profile raises ServerConfigurationError
+# ---------------------------------------------------------------------------
+
+
+def test_oss_profile_401_raises_server_configuration_error(
+    oss_profile: ProfileConfig,
+) -> None:
+    client = build_http_client(
+        oss_profile,
+        profile_name="oss-local",
+        transport=_status_transport(401),
+    )
+    try:
+        with pytest.raises(ServerConfigurationError) as excinfo:
+            client.get("/protected")
+    finally:
+        client.close()
+
+    msg = str(excinfo.value)
+    # Operator-actionable message — mentions the profile and "profile configuration".
+    assert "oss-local" in msg
+    assert "profile configuration" in msg
+    # MUST NOT tell the operator to "login" — this is a config error, not a creds error.
+    assert "login" not in msg.lower()
+    assert excinfo.value.profile_name == "oss-local"
+
+
+# ---------------------------------------------------------------------------
+# AC #3: Auth-enabled profile attaches Authorization: Bearer <token>
+# ---------------------------------------------------------------------------
+
+
+def test_auth_profile_attaches_bearer_token(auth_profile: ProfileConfig) -> None:
+    captured: list[httpx.Request] = []
+    client = build_http_client(
+        auth_profile,
+        token_provider=FakeTokenProvider(constant_token="tok-1"),
+        profile_name="ent",
+        transport=_ok_transport(captured),
+    )
+    try:
+        client.get("/me")
+    finally:
+        client.close()
+
+    assert captured[0].headers.get("Authorization") == "Bearer tok-1"
+
+
+# ---------------------------------------------------------------------------
+# AC #3: Bearer token is fetched per-request (not frozen at build time)
+# ---------------------------------------------------------------------------
+
+
+def test_auth_profile_fetches_token_per_request(auth_profile: ProfileConfig) -> None:
+    captured: list[httpx.Request] = []
+    provider = FakeTokenProvider(sequence=["tok-A", "tok-B"])
+    client = build_http_client(
+        auth_profile,
+        token_provider=provider,
+        profile_name="ent",
+        transport=_ok_transport(captured),
+    )
+    try:
+        client.get("/first")
+        client.get("/second")
+    finally:
+        client.close()
+
+    assert captured[0].headers.get("Authorization") == "Bearer tok-A"
+    assert captured[1].headers.get("Authorization") == "Bearer tok-B"
+
+
+# ---------------------------------------------------------------------------
+# AC #5 + #6: 401 on auth-enabled profile raises AuthenticationError (no retry)
+# ---------------------------------------------------------------------------
+
+
+def test_auth_profile_401_raises_authentication_error(
+    auth_profile: ProfileConfig,
+) -> None:
+    calls: list[httpx.Request] = []
+
+    def _handler(request: httpx.Request) -> httpx.Response:
+        calls.append(request)
+        return httpx.Response(401)
+
+    client = build_http_client(
+        auth_profile,
+        token_provider=FakeTokenProvider(constant_token="bad-token"),
+        profile_name="ent",
+        transport=httpx.MockTransport(_handler),
+    )
+    try:
+        with pytest.raises(AuthenticationError) as excinfo:
+            client.get("/me")
+    finally:
+        client.close()
+
+    assert not isinstance(excinfo.value, ServerConfigurationError)
+    # No retry in 21.2 — exactly one request was made.
+    assert len(calls) == 1
+    assert excinfo.value.profile_name == "ent"
+
+
+# ---------------------------------------------------------------------------
+# AC #6: Non-401 responses are NOT translated
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("status", [404, 500])
+def test_non_401_responses_are_not_translated(oss_profile: ProfileConfig, status: int) -> None:
+    client = build_http_client(
+        oss_profile,
+        profile_name="oss",
+        transport=_status_transport(status),
+    )
+    try:
+        response = client.get("/boom")
+    finally:
+        client.close()
+
+    # No translation — the raw Response surfaces, status unchanged.
+    assert response.status_code == status
+
+
+# ---------------------------------------------------------------------------
+# AC #7: API-misuse guards (factory-time)
+# ---------------------------------------------------------------------------
+
+
+def test_oss_profile_with_token_provider_raises_invalid_config(
+    oss_profile: ProfileConfig,
+) -> None:
+    with pytest.raises(InvalidClientConfigurationError) as excinfo:
+        build_http_client(
+            oss_profile,
+            token_provider=FakeTokenProvider(constant_token="nope"),
+            profile_name="oss",
+        )
+    msg = str(excinfo.value)
+    assert "token_provider" in msg
+    assert "auth" in msg
+
+
+def test_auth_profile_without_token_provider_raises_invalid_config(
+    auth_profile: ProfileConfig,
+) -> None:
+    with pytest.raises(InvalidClientConfigurationError) as excinfo:
+        build_http_client(
+            auth_profile,
+            token_provider=None,
+            profile_name="ent",
+        )
+    msg = str(excinfo.value)
+    assert "TokenProvider" in msg or "token_provider" in msg
+
+
+# ---------------------------------------------------------------------------
+# AC #1: base_url and returned type
+# ---------------------------------------------------------------------------
+
+
+def test_client_is_bound_to_profile_endpoint(oss_profile: ProfileConfig) -> None:
+    captured: list[httpx.Request] = []
+    client = build_http_client(
+        oss_profile,
+        profile_name="oss",
+        transport=_ok_transport(captured),
+    )
+    try:
+        assert isinstance(client, httpx.Client)
+        client.get("/ping")
+    finally:
+        client.close()
+
+    # base_url + relative path resolve to the profile endpoint host.
+    assert captured[0].url.host == "oss.example.invalid"
+    assert captured[0].url.path == "/ping"
+
+
+def test_build_without_profile_name_falls_back_to_placeholder(
+    oss_profile: ProfileConfig,
+) -> None:
+    """Defensive: callers that forget to pass profile_name still get a usable error."""
+    client = build_http_client(
+        oss_profile,
+        transport=_status_transport(401),
+    )
+    try:
+        with pytest.raises(ServerConfigurationError) as excinfo:
+            client.get("/x")
+    finally:
+        client.close()
+    assert excinfo.value.profile_name == "<unknown>"


### PR DESCRIPTION
## Summary

Introduces the CLI HTTP client factory (Story 21.2) that attaches auth only when the active profile declares an `auth` block.

- `akgentic.infra.cli.http.build_http_client` — httpx.Client factory bound to `profile.endpoint`.
- OSS profiles (`profile.auth is None`) never send an `Authorization` header.
- A 401 from an OSS profile surfaces as `ServerConfigurationError` (profile-config message, NOT a login prompt); a 401 from an auth-enabled profile surfaces as `AuthenticationError`. Non-401 responses pass through unchanged.
- `TokenProvider` Protocol (`runtime_checkable`) defined as the 21.3 boundary — no OIDC code in this story.
- `_BearerAuth(httpx.Auth)` fetches a fresh token per request via `token_provider.get_access_token()` — rotation handled by the provider is picked up without rebuilding the client.
- Typed error hierarchy: `HttpClientError` base + `ServerConfigurationError` + `AuthenticationError` + `InvalidClientConfigurationError`.
- Factory-time misuse guards reject incoherent `(profile, token_provider)` combinations loudly.
- 12 unit tests using `httpx.MockTransport` (no network); 95.18 % coverage on the new `http/` and `auth/` modules.

**Scope boundary (preserved):** no edits to `main.py`, `repl.py`, legacy `ApiClient`, TUI, or any module outside `cli/http/` and `cli/auth/`. Wiring the new factory into the CLI entrypoint and adding retry-once auto-auth land in Stories 21.3 / 21.4.

## Code review

Senior Developer Review (Rex) — approved, no HIGH/MEDIUM issues. All 12 ACs implemented, all six tasks verifiably done, `ruff check` + `ruff format --check` + `mypy --strict` clean, submodule CI green.

## Stacking

This PR stacks on #230 (Story 21.1). Base branch: `feat/229-profile-config-loader`. Merge order: #230 first, then this PR (auto-retargets to `master` after the base merges).

Closes #231
