### PR TITLE
OIDC Device-Code Flow & Token Cache (Story 21.3)

### DIFF
--- a/src/akgentic/infra/cli/auth/__init__.py
+++ b/src/akgentic/infra/cli/auth/__init__.py
@@ -1,11 +1,72 @@
 """CLI auth package.
 
-Public API for pluggable access-token providers used by
-:func:`akgentic.infra.cli.http.build_http_client`. Story 21.2 delivers only the
-:class:`TokenProvider` Protocol (the boundary); Story 21.3 delivers the real
-``OidcTokenProvider`` implementation.
+Public API:
+
+* :class:`TokenProvider` — Protocol boundary consumed by
+  :func:`akgentic.infra.cli.http.build_http_client` (delivered in Story 21.2).
+* :class:`OidcTokenProvider` — concrete RFC 8628 device-code + refresh-token
+  provider (Story 21.3).
+* :class:`TokenCacheEntry` — on-disk cache schema.
+* :class:`ReAuthRequiredError`, :class:`OidcProtocolError` and its subclasses
+  — typed error surface; callers import these to distinguish
+  "re-auth needed" from "server refused".
+* :func:`load_token_cache`, :func:`save_token_cache`,
+  :func:`delete_token_cache` — cache I/O (used by Story 21.4's
+  ``akgentic logout`` command).
+
+Callers should import from this module, not from the private submodules
+(``.oidc``, ``.cache``, ``.token_provider``) — the submodule layout is an
+implementation detail.
 """
 
-from akgentic.infra.cli.auth.token_provider import TokenProvider
+from akgentic.infra.cli.auth.cache import (
+    TokenCacheCorruptError,
+    TokenCacheEntry,
+    delete_token_cache,
+    load_token_cache,
+    save_token_cache,
+)
+from akgentic.infra.cli.auth.oidc import (
+    AccessDeniedError,
+    AuthorizationPendingError,
+    DeviceAuthorizationResponse,
+    ExpiredTokenError,
+    OidcDiscoveryError,
+    OidcEndpoints,
+    OidcErrorResponse,
+    OidcProtocolError,
+    SlowDownError,
+    TokenResponse,
+    discover_endpoints,
+    initiate_device_flow,
+    poll_for_token,
+)
+from akgentic.infra.cli.auth.token_provider import (
+    OidcTokenProvider,
+    ReAuthRequiredError,
+    TokenProvider,
+)
 
-__all__ = ["TokenProvider"]
+__all__ = [
+    "AccessDeniedError",
+    "AuthorizationPendingError",
+    "DeviceAuthorizationResponse",
+    "ExpiredTokenError",
+    "OidcDiscoveryError",
+    "OidcEndpoints",
+    "OidcErrorResponse",
+    "OidcProtocolError",
+    "OidcTokenProvider",
+    "ReAuthRequiredError",
+    "SlowDownError",
+    "TokenCacheCorruptError",
+    "TokenCacheEntry",
+    "TokenProvider",
+    "TokenResponse",
+    "delete_token_cache",
+    "discover_endpoints",
+    "initiate_device_flow",
+    "load_token_cache",
+    "poll_for_token",
+    "save_token_cache",
+]

--- a/src/akgentic/infra/cli/auth/cache.py
+++ b/src/akgentic/infra/cli/auth/cache.py
@@ -1,0 +1,183 @@
+"""Per-profile OIDC token cache I/O.
+
+Implements ADR-021 §Decision 2 — token cache at
+``~/.akgentic/credentials/<profile>.json`` with schema
+``{access_token, refresh_token, expires_at}``. Nothing else is stored; no
+``scope``, no ``id_token``, no ``token_type`` (Story 21.3 Dev Notes).
+
+Design decisions
+----------------
+
+* **File permissions (0600) / directory permissions (0700) are created
+  directly, not fixed after the fact.** The file is opened via
+  :func:`os.open` with mode ``0o600``; the directory is created via
+  :meth:`pathlib.Path.mkdir` with ``mode=0o700`` and re-chmodded if the
+  process umask masked restrictive bits. No ``open(..., "w")`` + ``os.chmod``
+  sequences — those leave a race window where the file is briefly world-
+  readable.
+* **Atomic rewrite via ``os.replace``.** Saves write to ``<path>.tmp`` first
+  (mode 0600), then :func:`os.replace` atomically renames onto the final
+  path. Readers never see a half-written file.
+* **Test seam: ``credentials_dir`` keyword argument.** Each I/O function
+  accepts ``credentials_dir: Path | None = None``; tests pass a ``tmp_path``
+  directory. Production callers leave it ``None`` and we resolve to
+  ``~/.akgentic/credentials``. This is the documented seam — do NOT reach
+  into ``os.environ["HOME"]`` in callers.
+* **No ``dict[str, Any]`` in the public surface.** Serialization goes through
+  :meth:`TokenCacheEntry.model_dump_json` and :meth:`TokenCacheEntry.model_validate_json`
+  (Golden Rule #1).
+
+Corrupt-cache handling
+----------------------
+
+:func:`load_token_cache` catches :class:`pydantic.ValidationError` and
+re-raises as :class:`TokenCacheCorruptError` so raw Pydantic surface does not
+leak to CLI callers. :class:`OidcTokenProvider` decides whether to delete a
+corrupt cache.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from pydantic import BaseModel, ValidationError
+
+from akgentic.infra.cli.auth.oidc import OidcProtocolError
+
+_DEFAULT_CREDENTIALS_DIR = Path.home() / ".akgentic" / "credentials"
+
+
+class TokenCacheEntry(BaseModel):
+    """On-disk shape of a per-profile token cache entry.
+
+    Fields are intentionally minimal — ADR-021 locks the schema and Story
+    21.3 does not extend it. ``expires_at`` is epoch seconds (UTC).
+    """
+
+    access_token: str
+    refresh_token: str
+    expires_at: int
+
+
+class TokenCacheCorruptError(OidcProtocolError):
+    """Raised when a cache file exists but fails Pydantic validation."""
+
+
+def _credentials_dir(credentials_dir: Path | None = None) -> Path:
+    """Resolve the credentials directory.
+
+    Args:
+        credentials_dir: Optional override; tests pass a ``tmp_path``-derived
+            directory. ``None`` resolves to ``~/.akgentic/credentials``.
+    """
+    return credentials_dir if credentials_dir is not None else _DEFAULT_CREDENTIALS_DIR
+
+
+def _cache_path(profile_name: str, credentials_dir: Path | None) -> Path:
+    return _credentials_dir(credentials_dir) / f"{profile_name}.json"
+
+
+def _ensure_restrictive_dir(directory: Path) -> None:
+    """Create ``directory`` with mode 0700; re-chmod if umask stripped bits.
+
+    This runs before any cache-file write, so the parent dir is always
+    restrictive before the file lands inside it. If the directory already
+    exists we also force its mode back to 0700 (operators may fix permissions
+    manually; we keep the invariant locally).
+    """
+    directory.mkdir(mode=0o700, parents=True, exist_ok=True)
+    # umask can mask restrictive bits during mkdir — fix explicitly.
+    os.chmod(directory, 0o700)
+
+
+def load_token_cache(
+    profile_name: str,
+    *,
+    credentials_dir: Path | None = None,
+) -> TokenCacheEntry | None:
+    """Load the per-profile cache entry.
+
+    Returns:
+        A :class:`TokenCacheEntry` if the file exists and parses cleanly;
+        ``None`` if the file is missing.
+
+    Raises:
+        TokenCacheCorruptError: The file exists but fails Pydantic validation
+            (malformed JSON, missing fields, wrong types). The caller decides
+            whether to delete it — this function does not self-purge.
+    """
+    path = _cache_path(profile_name, credentials_dir)
+    if not path.exists():
+        return None
+
+    try:
+        raw = path.read_bytes()
+    except OSError as exc:  # pragma: no cover - defensive
+        raise TokenCacheCorruptError(f"Cannot read cache file {path}: {exc}") from exc
+
+    try:
+        return TokenCacheEntry.model_validate_json(raw)
+    except ValidationError as exc:
+        raise TokenCacheCorruptError(
+            f"Cache file {path} is corrupt or schema-incompatible: {exc}"
+        ) from exc
+
+
+def save_token_cache(
+    profile_name: str,
+    entry: TokenCacheEntry,
+    *,
+    credentials_dir: Path | None = None,
+) -> None:
+    """Atomically write ``entry`` to the per-profile cache file.
+
+    Guarantees:
+
+    * The parent directory exists with mode 0700 before the file is written.
+    * The file is created with mode 0600 directly (no chmod-after-open race).
+    * The write is atomic via ``os.replace`` on a ``.tmp`` sibling — readers
+      never observe a truncated file.
+    """
+    directory = _credentials_dir(credentials_dir)
+    _ensure_restrictive_dir(directory)
+
+    final_path = directory / f"{profile_name}.json"
+    tmp_path = directory / f"{profile_name}.json.tmp"
+
+    payload = entry.model_dump_json().encode("utf-8")
+
+    # Create the tmp file with the restrictive mode directly — no race.
+    fd = os.open(str(tmp_path), os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+    try:
+        with os.fdopen(fd, "wb") as f:
+            f.write(payload)
+    except BaseException:  # pragma: no cover - defensive cleanup
+        if tmp_path.exists():
+            tmp_path.unlink(missing_ok=True)
+        raise
+
+    # Atomic replace — final_path inherits tmp's mode 0600.
+    os.replace(str(tmp_path), str(final_path))
+    # Re-assert mode on final path (paranoid: NFS or odd filesystems).
+    os.chmod(final_path, 0o600)
+
+
+def delete_token_cache(
+    profile_name: str,
+    *,
+    credentials_dir: Path | None = None,
+) -> None:
+    """Remove the per-profile cache file if present. Idempotent."""
+    path = _cache_path(profile_name, credentials_dir)
+    # missing_ok handles both "never existed" and "already removed".
+    path.unlink(missing_ok=True)
+
+
+__all__ = [
+    "TokenCacheCorruptError",
+    "TokenCacheEntry",
+    "delete_token_cache",
+    "load_token_cache",
+    "save_token_cache",
+]

--- a/src/akgentic/infra/cli/auth/oidc.py
+++ b/src/akgentic/infra/cli/auth/oidc.py
@@ -1,0 +1,335 @@
+"""OIDC device-authorization-grant flow (RFC 8628) for the akgentic CLI.
+
+Implements ADR-021 §Decision 2 — the CLI's only supported OIDC flow is the
+device-code flow. This module provides pure protocol plumbing (discovery,
+initiate, poll) and a typed exception hierarchy; the persistent-state glue
+(cache I/O + ``OidcTokenProvider``) lives in :mod:`.cache` and
+:mod:`.token_provider`.
+
+Design decisions (documented per Story 21.3's "Decisions the Dev agent must
+make"):
+
+* **Discovery seam.** :func:`discover_endpoints` fetches
+  ``{issuer}/.well-known/openid-configuration`` once per call. The higher-level
+  orchestrator in :class:`OidcTokenProvider` caches the resolved
+  :class:`OidcEndpoints` for the instance lifetime, so refresh calls do not
+  re-fetch ``.well-known``.
+* **Module-level function vs. method for the orchestrator.** The orchestrator
+  lives on :class:`OidcTokenProvider` (see :mod:`.token_provider`); it already
+  holds profile, clock, sleep, http_client, credentials_dir.
+* **Strict vs. lenient refresh_token.** See :mod:`.token_provider` — the
+  strict path is chosen there.
+* **No network I/O outside the injected ``httpx.Client``.** Tests inject an
+  :class:`httpx.MockTransport`; there is no module-level global client.
+
+Golden Rule #1: every wire payload (:class:`DeviceAuthorizationResponse`,
+:class:`TokenResponse`, :class:`OidcErrorResponse`, :class:`OidcEndpoints`)
+is a Pydantic model. ``response.json()`` into a raw dict is forbidden.
+"""
+
+from __future__ import annotations
+
+import time
+from collections.abc import Callable
+
+import httpx
+from pydantic import BaseModel, ValidationError
+
+# ---------------------------------------------------------------------------
+# Typed error hierarchy (AC #2)
+# ---------------------------------------------------------------------------
+
+
+class OidcProtocolError(Exception):
+    """Base class for all OIDC protocol-layer errors raised by this module."""
+
+
+class AuthorizationPendingError(OidcProtocolError):
+    """RFC 8628 ``authorization_pending`` — internal polling signal."""
+
+
+class SlowDownError(OidcProtocolError):
+    """RFC 8628 ``slow_down`` — internal polling signal; widens the interval."""
+
+
+class AccessDeniedError(OidcProtocolError):
+    """RFC 8628 ``access_denied`` — end user denied consent."""
+
+
+class ExpiredTokenError(OidcProtocolError):
+    """RFC 8628 ``expired_token`` / local budget exhaustion.
+
+    Raised when the device-code flow's ``expires_in`` budget is exhausted
+    before the user completed consent.
+    """
+
+
+class OidcDiscoveryError(OidcProtocolError):
+    """``.well-known/openid-configuration`` fetch failed or returned bad JSON."""
+
+
+# ---------------------------------------------------------------------------
+# Typed wire payloads (AC #1, #8 — Golden Rule #1)
+# ---------------------------------------------------------------------------
+
+
+class OidcEndpoints(BaseModel):
+    """Resolved OIDC endpoints for an issuer.
+
+    Populated by :func:`discover_endpoints` from the issuer's
+    ``.well-known/openid-configuration`` document.
+    """
+
+    device_authorization_endpoint: str
+    token_endpoint: str
+
+
+class DeviceAuthorizationResponse(BaseModel):
+    """RFC 8628 §3.2 device-authorization response."""
+
+    device_code: str
+    user_code: str
+    verification_uri: str
+    verification_uri_complete: str | None = None
+    expires_in: int
+    interval: int = 5  # RFC 8628 default when server omits it
+
+
+class TokenResponse(BaseModel):
+    """RFC 6749 §5.1 token response (success).
+
+    We keep the shape narrow and strict — OIDC servers return more fields
+    (``scope``, ``id_token``, ...) but the CLI cache only stores the three
+    fields specified by ADR-021. Extra fields are ignored by Pydantic's
+    default behavior.
+    """
+
+    access_token: str
+    refresh_token: str | None = None
+    expires_in: int
+    token_type: str = "Bearer"
+
+
+class OidcErrorResponse(BaseModel):
+    """RFC 6749 §5.2 / RFC 8628 §3.5 error response."""
+
+    error: str
+    error_description: str | None = None
+
+
+# ---------------------------------------------------------------------------
+# Protocol helpers
+# ---------------------------------------------------------------------------
+
+
+def _parse_error_response(response: httpx.Response) -> OidcErrorResponse | None:
+    """Parse a non-2xx OIDC response body as :class:`OidcErrorResponse`.
+
+    Returns ``None`` when the body is not valid JSON or does not match the
+    OIDC error schema; callers then surface a generic protocol error.
+    """
+    try:
+        return OidcErrorResponse.model_validate_json(response.content)
+    except ValidationError:
+        return None
+
+
+def discover_endpoints(issuer: str, *, client: httpx.Client) -> OidcEndpoints:
+    """Fetch ``{issuer}/.well-known/openid-configuration`` and extract endpoints.
+
+    Args:
+        issuer: Issuer base URL (string form of ``AuthConfig.issuer``).
+        client: Injected ``httpx.Client`` (test seam — pass one backed by
+            :class:`httpx.MockTransport` in tests).
+
+    Returns:
+        A validated :class:`OidcEndpoints`.
+
+    Raises:
+        OidcDiscoveryError: Network error, non-2xx status, or a response body
+            that fails Pydantic validation (missing endpoint fields, etc.).
+    """
+    url = f"{issuer.rstrip('/')}/.well-known/openid-configuration"
+    try:
+        response = client.get(url)
+    except httpx.HTTPError as exc:
+        raise OidcDiscoveryError(
+            f"Failed to fetch OIDC discovery document from {url}: {exc}"
+        ) from exc
+
+    if response.status_code >= 400:
+        raise OidcDiscoveryError(
+            f"OIDC discovery document at {url} returned HTTP {response.status_code}"
+        )
+
+    try:
+        return OidcEndpoints.model_validate_json(response.content)
+    except ValidationError as exc:
+        raise OidcDiscoveryError(
+            f"OIDC discovery document at {url} is missing required endpoints: {exc}"
+        ) from exc
+
+
+def initiate_device_flow(
+    endpoints: OidcEndpoints,
+    client_id: str,
+    *,
+    client: httpx.Client,
+    scope: str = "openid offline_access",
+) -> DeviceAuthorizationResponse:
+    """POST to ``device_authorization_endpoint`` and parse the response.
+
+    Raises:
+        OidcProtocolError: Network error or a non-2xx response whose body is
+            not a valid :class:`DeviceAuthorizationResponse`.
+    """
+    try:
+        response = client.post(
+            endpoints.device_authorization_endpoint,
+            data={"client_id": client_id, "scope": scope},
+        )
+    except httpx.HTTPError as exc:
+        raise OidcProtocolError(
+            f"Device-authorization request to {endpoints.device_authorization_endpoint} failed: "
+            f"{exc}"
+        ) from exc
+
+    if response.status_code >= 400:
+        err = _parse_error_response(response)
+        if err is not None:
+            raise OidcProtocolError(
+                f"Device-authorization request failed: {err.error}"
+                + (f" — {err.error_description}" if err.error_description else "")
+            )
+        raise OidcProtocolError(
+            f"Device-authorization request failed with HTTP {response.status_code}"
+        )
+
+    try:
+        return DeviceAuthorizationResponse.model_validate_json(response.content)
+    except ValidationError as exc:
+        raise OidcProtocolError(
+            f"Device-authorization response from {endpoints.device_authorization_endpoint} "
+            f"is malformed: {exc}"
+        ) from exc
+
+
+def _classify_token_error(err: OidcErrorResponse) -> OidcProtocolError:
+    """Map an OIDC token-endpoint error payload to a typed exception."""
+    code = err.error
+    description = f" — {err.error_description}" if err.error_description else ""
+    if code == "authorization_pending":
+        return AuthorizationPendingError(f"authorization_pending{description}")
+    if code == "slow_down":
+        return SlowDownError(f"slow_down{description}")
+    if code == "access_denied":
+        return AccessDeniedError(f"access_denied{description}")
+    if code == "expired_token":
+        return ExpiredTokenError(f"expired_token{description}")
+    return OidcProtocolError(f"{code}{description}")
+
+
+def _request_token(
+    endpoints: OidcEndpoints,
+    data: dict[str, str],
+    *,
+    client: httpx.Client,
+) -> TokenResponse:
+    """POST to the token endpoint and parse as :class:`TokenResponse`."""
+    try:
+        response = client.post(endpoints.token_endpoint, data=data)
+    except httpx.HTTPError as exc:
+        raise OidcProtocolError(
+            f"Token request to {endpoints.token_endpoint} failed: {exc}"
+        ) from exc
+
+    if response.status_code >= 400:
+        err = _parse_error_response(response)
+        if err is not None:
+            raise _classify_token_error(err)
+        raise OidcProtocolError(f"Token request failed with HTTP {response.status_code}")
+
+    try:
+        return TokenResponse.model_validate_json(response.content)
+    except ValidationError as exc:
+        raise OidcProtocolError(
+            f"Token response from {endpoints.token_endpoint} is malformed: {exc}"
+        ) from exc
+
+
+def poll_for_token(
+    endpoints: OidcEndpoints,
+    client_id: str,
+    device_code: str,
+    initial_interval: int,
+    expires_in: int,
+    *,
+    client: httpx.Client,
+    clock: Callable[[], int] = lambda: int(time.time()),
+    sleep: Callable[[float], None] = time.sleep,
+) -> TokenResponse:
+    """Poll the token endpoint until success, denial, or budget exhaustion.
+
+    Honors RFC 8628 ``slow_down`` (widen interval by 5s, per spec recommendation)
+    and ``authorization_pending`` (continue polling). Terminal errors are
+    surfaced as typed exceptions.
+
+    Args:
+        endpoints: Resolved :class:`OidcEndpoints`.
+        client_id: OIDC client identifier.
+        device_code: ``device_code`` from the device-auth response.
+        initial_interval: Polling interval in seconds (from the device-auth
+            response's ``interval`` field).
+        expires_in: Flow-level expiry budget from the device-auth response.
+        client: Injected HTTP client (test seam).
+        clock: Returns current epoch seconds (test seam).
+        sleep: Blocks the given number of seconds (test seam — tests pass a
+            mock that records calls).
+
+    Returns:
+        A :class:`TokenResponse` on success.
+
+    Raises:
+        AccessDeniedError: Server returned ``access_denied``.
+        ExpiredTokenError: Server returned ``expired_token`` OR the local
+            budget (``expires_in``) was exhausted.
+        OidcProtocolError: Any other protocol failure.
+    """
+    deadline = clock() + expires_in
+    interval = initial_interval
+    data = {
+        "grant_type": "urn:ietf:params:oauth:grant-type:device_code",
+        "device_code": device_code,
+        "client_id": client_id,
+    }
+
+    while True:
+        if clock() >= deadline:
+            raise ExpiredTokenError(
+                "Device-code flow timed out before the user completed authorization"
+            )
+        sleep(interval)
+        try:
+            return _request_token(endpoints, data, client=client)
+        except AuthorizationPendingError:
+            continue
+        except SlowDownError:
+            interval += 5  # RFC 8628 recommendation
+            continue
+
+
+__all__ = [
+    "AccessDeniedError",
+    "AuthorizationPendingError",
+    "DeviceAuthorizationResponse",
+    "ExpiredTokenError",
+    "OidcDiscoveryError",
+    "OidcEndpoints",
+    "OidcErrorResponse",
+    "OidcProtocolError",
+    "SlowDownError",
+    "TokenResponse",
+    "discover_endpoints",
+    "initiate_device_flow",
+    "poll_for_token",
+]

--- a/src/akgentic/infra/cli/auth/token_provider.py
+++ b/src/akgentic/infra/cli/auth/token_provider.py
@@ -1,18 +1,73 @@
-"""Token provider protocol used by the CLI HTTP client factory.
+"""Token provider Protocol + concrete OIDC implementation.
 
-Story 21.2 defines ONLY the Protocol. The concrete OIDC implementation
-(``OidcTokenProvider``) lands in Story 21.3. By keeping this boundary as a
-``typing.Protocol`` (not an ABC), tests can supply lightweight fakes without
-inheriting from a framework class, and the production OIDC code never has to
-know about the factory.
+Story 21.2 delivered the :class:`TokenProvider` Protocol — the boundary the
+HTTP client factory depends on. Story 21.3 adds :class:`OidcTokenProvider`
+*in the same module* (per Story 21.3 Dev Notes — do not move the Protocol).
 
-``@runtime_checkable`` is applied so tests may ``isinstance(x, TokenProvider)``
-a fake if they want; the Protocol's only method is :meth:`get_access_token`.
+Division of responsibility (intentional — see Story 21.3 Dev Notes):
+
+* :meth:`OidcTokenProvider.get_access_token` is the Protocol surface. It is
+  **non-interactive**: uses cache + refresh only. On missing or invalid cache
+  it raises :class:`ReAuthRequiredError`; Story 21.4's auto-auth wiring
+  catches that and re-runs the device-code flow.
+* :meth:`OidcTokenProvider.run_device_code_flow` is **interactive**: it
+  drives the device-code flow, writes the cache, and returns the entry.
+  Story 21.4's ``akgentic login`` and inline retry wiring calls this method.
+
+Decisions documented here (per Story 21.3 "Decisions the Dev agent must
+make"):
+
+* **Discovery caching.** The instance caches the resolved
+  :class:`OidcEndpoints` for its lifetime; refresh never re-fetches
+  ``.well-known``.
+* **Orchestrator as method, not module function.** Keeps the injection
+  seams (``http_client``, ``clock``, ``sleep``, ``credentials_dir``) in one
+  place rather than threading them through a module function.
+* **Strict ``refresh_token`` handling.** The token endpoint MUST return a
+  ``refresh_token`` on both device-code and refresh responses. If it is
+  missing we treat the cache as unusable and raise
+  :class:`ReAuthRequiredError` after purging. Keycloak (ADR-021's target)
+  always returns one; the strict path is safe for the ADR's scope and keeps
+  ``TokenCacheEntry.refresh_token`` non-optional.
+
+Test seams: ``http_client``, ``clock``, ``sleep``, ``credentials_dir``,
+``on_user_code``.
 """
 
 from __future__ import annotations
 
+import sys
+import time
+from collections.abc import Callable
+from pathlib import Path
 from typing import Protocol, runtime_checkable
+
+import httpx
+
+from akgentic.infra.cli.auth.cache import (
+    TokenCacheEntry,
+    delete_token_cache,
+    load_token_cache,
+    save_token_cache,
+)
+from akgentic.infra.cli.auth.oidc import (
+    DeviceAuthorizationResponse,
+    OidcEndpoints,
+    OidcProtocolError,
+    TokenResponse,
+    _request_token,
+    discover_endpoints,
+    initiate_device_flow,
+    poll_for_token,
+)
+from akgentic.infra.cli.config.profile import ProfileConfig
+
+_REFRESH_LEEWAY_SECONDS = 30
+
+
+# ---------------------------------------------------------------------------
+# Protocol (unchanged from Story 21.2)
+# ---------------------------------------------------------------------------
 
 
 @runtime_checkable
@@ -33,3 +88,230 @@ class TokenProvider(Protocol):
         the factory formats the ``Authorization`` header.
         """
         ...
+
+
+# ---------------------------------------------------------------------------
+# Typed error raised by the concrete provider
+# ---------------------------------------------------------------------------
+
+
+class ReAuthRequiredError(OidcProtocolError):
+    """Raised when :meth:`OidcTokenProvider.get_access_token` cannot produce
+    a valid token without user interaction.
+
+    Story 21.4's auto-auth wiring catches this and re-runs
+    :meth:`OidcTokenProvider.run_device_code_flow`. Story 21.3 never calls
+    the interactive flow from inside ``get_access_token`` — that would break
+    the "non-interactive Protocol surface" contract.
+    """
+
+
+# ---------------------------------------------------------------------------
+# Concrete provider
+# ---------------------------------------------------------------------------
+
+
+def _default_on_user_code(auth: DeviceAuthorizationResponse) -> None:
+    """Default prompt hook — prints verification URL and user code to stderr.
+
+    Story 21.4 replaces this with a TUI-friendly hook; writing to stderr
+    keeps Story 21.3 safe to use in scripts (stdout stays clean for any
+    command output).
+    """
+    message = (
+        f"To authenticate, visit: {auth.verification_uri}\nAnd enter the code: {auth.user_code}\n"
+    )
+    if auth.verification_uri_complete:
+        message += f"Or open directly: {auth.verification_uri_complete}\n"
+    sys.stderr.write(message)
+    sys.stderr.flush()
+
+
+class OidcTokenProvider:
+    """OIDC device-code + refresh-token provider.
+
+    Construct with the active :class:`ProfileConfig` and profile name. The
+    provider assumes ``profile.auth is not None`` — passing an OSS profile
+    is a programming error (the HTTP client factory's guard catches the
+    mismatch if the caller wires one through).
+    """
+
+    def __init__(
+        self,
+        profile: ProfileConfig,
+        profile_name: str,
+        *,
+        http_client: httpx.Client | None = None,
+        clock: Callable[[], int] | None = None,
+        sleep: Callable[[float], None] | None = None,
+        credentials_dir: Path | None = None,
+    ) -> None:
+        if profile.auth is None:
+            raise ValueError(
+                f"OidcTokenProvider requires a profile with an `auth` block; "
+                f"profile {profile_name!r} has none."
+            )
+        self._profile = profile
+        self._profile_name = profile_name
+        self._http_client = http_client if http_client is not None else httpx.Client()
+        self._owns_client = http_client is None
+        self._clock: Callable[[], int] = clock if clock is not None else (lambda: int(time.time()))
+        self._sleep: Callable[[float], None] = sleep if sleep is not None else time.sleep
+        self._credentials_dir = credentials_dir
+        self._endpoints: OidcEndpoints | None = None
+
+    # -- Public API ---------------------------------------------------------
+
+    def get_access_token(self) -> str:
+        """Return a valid access token from cache (refreshing if expired).
+
+        Contract (per AC #5):
+            1. Cache hit with ``expires_at > now + leeway`` → return.
+            2. Expired → refresh via ``grant_type=refresh_token``; on success
+               write new entry and return new token.
+            3. Refresh failure → purge cache, raise
+               :class:`ReAuthRequiredError`.
+            4. Cache missing → raise :class:`ReAuthRequiredError` without
+               touching the network.
+
+        :meth:`run_device_code_flow` is **NOT** called from here — Story
+        21.4 owns the retry decision.
+        """
+        entry = load_token_cache(self._profile_name, credentials_dir=self._credentials_dir)
+        if entry is None:
+            raise ReAuthRequiredError(
+                f"No cached credentials for profile {self._profile_name!r}; "
+                "run the device-code flow to authenticate."
+            )
+
+        now = self._clock()
+        if entry.expires_at > now + _REFRESH_LEEWAY_SECONDS:
+            return entry.access_token
+
+        return self._refresh_and_return(entry, now)
+
+    def run_device_code_flow(
+        self,
+        *,
+        on_user_code: Callable[[DeviceAuthorizationResponse], None] | None = None,
+    ) -> TokenCacheEntry:
+        """Drive the interactive device-code flow and persist the cache.
+
+        Args:
+            on_user_code: Hook invoked with the :class:`DeviceAuthorizationResponse`
+                so the caller can display the user code / verification URL in
+                whatever UX it prefers. Defaults to a stderr writer (Story
+                21.4 injects its own TUI-friendly hook).
+
+        Returns:
+            The freshly persisted :class:`TokenCacheEntry`.
+        """
+        endpoints = self._ensure_endpoints()
+        assert self._profile.auth is not None  # constructor guarded this
+        client_id = self._profile.auth.client_id
+
+        device_auth = initiate_device_flow(
+            endpoints,
+            client_id,
+            client=self._http_client,
+        )
+
+        prompt_hook = on_user_code if on_user_code is not None else _default_on_user_code
+        prompt_hook(device_auth)
+
+        token_response = poll_for_token(
+            endpoints,
+            client_id,
+            device_auth.device_code,
+            device_auth.interval,
+            device_auth.expires_in,
+            client=self._http_client,
+            clock=self._clock,
+            sleep=self._sleep,
+        )
+
+        entry = self._token_response_to_cache_entry(token_response)
+        save_token_cache(self._profile_name, entry, credentials_dir=self._credentials_dir)
+        return entry
+
+    def close(self) -> None:
+        """Close the underlying httpx.Client if we own it."""
+        if self._owns_client:
+            self._http_client.close()
+
+    # -- Internal helpers ---------------------------------------------------
+
+    def _ensure_endpoints(self) -> OidcEndpoints:
+        """Resolve and cache the OIDC endpoints for this provider instance."""
+        if self._endpoints is None:
+            assert self._profile.auth is not None
+            self._endpoints = discover_endpoints(
+                str(self._profile.auth.issuer),
+                client=self._http_client,
+            )
+        return self._endpoints
+
+    def _refresh_and_return(self, entry: TokenCacheEntry, now: int) -> str:
+        """Refresh the access token and return the new value.
+
+        On any refresh failure the cache is purged and
+        :class:`ReAuthRequiredError` is raised.
+        """
+        endpoints = self._ensure_endpoints()
+        assert self._profile.auth is not None
+        client_id = self._profile.auth.client_id
+
+        try:
+            token_response = _request_token(
+                endpoints,
+                {
+                    "grant_type": "refresh_token",
+                    "refresh_token": entry.refresh_token,
+                    "client_id": client_id,
+                },
+                client=self._http_client,
+            )
+        except OidcProtocolError as exc:
+            # ANY refresh failure → purge + re-auth. This includes
+            # invalid_grant, invalid_token, expired refresh token, etc.
+            delete_token_cache(self._profile_name, credentials_dir=self._credentials_dir)
+            raise ReAuthRequiredError(
+                f"Refresh failed for profile {self._profile_name!r}: {exc}. "
+                "Cache purged — re-run the device-code flow to authenticate."
+            ) from exc
+
+        new_entry = self._token_response_to_cache_entry(token_response, fallback_now=now)
+        save_token_cache(self._profile_name, new_entry, credentials_dir=self._credentials_dir)
+        return new_entry.access_token
+
+    def _token_response_to_cache_entry(
+        self,
+        response: TokenResponse,
+        *,
+        fallback_now: int | None = None,
+    ) -> TokenCacheEntry:
+        """Convert a :class:`TokenResponse` to a :class:`TokenCacheEntry`.
+
+        Enforces strict refresh-token presence per the module-level decision.
+        """
+        if response.refresh_token is None:
+            # Strict path: we require a refresh_token to maintain the cache
+            # invariant (TokenCacheEntry.refresh_token is non-optional).
+            delete_token_cache(self._profile_name, credentials_dir=self._credentials_dir)
+            raise ReAuthRequiredError(
+                f"Token endpoint did not return a refresh_token for profile "
+                f"{self._profile_name!r}; cache purged."
+            )
+        now = fallback_now if fallback_now is not None else self._clock()
+        return TokenCacheEntry(
+            access_token=response.access_token,
+            refresh_token=response.refresh_token,
+            expires_at=now + response.expires_in,
+        )
+
+
+__all__ = [
+    "OidcTokenProvider",
+    "ReAuthRequiredError",
+    "TokenProvider",
+]

--- a/tests/cli/auth/test_cache.py
+++ b/tests/cli/auth/test_cache.py
@@ -1,0 +1,131 @@
+"""Tests for :mod:`akgentic.infra.cli.auth.cache` (Story 21.3).
+
+All tests use ``tmp_path`` via the ``credentials_dir`` seam — never touch
+real ``~/.akgentic/``.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from akgentic.infra.cli.auth.cache import (
+    TokenCacheCorruptError,
+    TokenCacheEntry,
+    delete_token_cache,
+    load_token_cache,
+    save_token_cache,
+)
+
+
+@pytest.fixture
+def tmp_credentials_dir(tmp_path: Path) -> Path:
+    """A per-test credentials directory isolated under ``tmp_path``."""
+    return tmp_path / "credentials"
+
+
+def _make_entry(expires_at: int = 1_700_000_000) -> TokenCacheEntry:
+    return TokenCacheEntry(
+        access_token="access-abc",
+        refresh_token="refresh-xyz",
+        expires_at=expires_at,
+    )
+
+
+def test_load_returns_none_when_file_missing(tmp_credentials_dir: Path) -> None:
+    # AC #4: load returns None, never raises, on missing file.
+    assert load_token_cache("profile-x", credentials_dir=tmp_credentials_dir) is None
+
+
+def test_save_then_load_roundtrip(tmp_credentials_dir: Path) -> None:
+    original = _make_entry()
+    save_token_cache("profile-x", original, credentials_dir=tmp_credentials_dir)
+
+    loaded = load_token_cache("profile-x", credentials_dir=tmp_credentials_dir)
+    assert loaded is not None
+    assert loaded.access_token == original.access_token
+    assert loaded.refresh_token == original.refresh_token
+    assert loaded.expires_at == original.expires_at
+
+
+def test_save_creates_file_with_mode_0600(tmp_credentials_dir: Path) -> None:
+    # AC #3: file permission enforcement (behavioral assertion via stat).
+    save_token_cache("profile-x", _make_entry(), credentials_dir=tmp_credentials_dir)
+    path = tmp_credentials_dir / "profile-x.json"
+    assert path.exists()
+    mode = path.stat().st_mode & 0o777
+    assert mode == 0o600, f"expected 0600, got {oct(mode)}"
+
+
+def test_save_rewrite_keeps_mode_0600(tmp_credentials_dir: Path) -> None:
+    # On refresh we rewrite the same path — mode must remain 0600.
+    save_token_cache("profile-x", _make_entry(), credentials_dir=tmp_credentials_dir)
+    save_token_cache(
+        "profile-x",
+        _make_entry(expires_at=1_800_000_000),
+        credentials_dir=tmp_credentials_dir,
+    )
+    path = tmp_credentials_dir / "profile-x.json"
+    mode = path.stat().st_mode & 0o777
+    assert mode == 0o600, f"expected 0600 after rewrite, got {oct(mode)}"
+
+
+def test_save_creates_directory_with_mode_0700(tmp_credentials_dir: Path) -> None:
+    # AC #3: directory permission enforcement.
+    assert not tmp_credentials_dir.exists()
+    save_token_cache("profile-x", _make_entry(), credentials_dir=tmp_credentials_dir)
+    assert tmp_credentials_dir.is_dir()
+    mode = tmp_credentials_dir.stat().st_mode & 0o777
+    assert mode == 0o700, f"expected 0700, got {oct(mode)}"
+
+
+def test_save_subsequent_save_keeps_directory_mode_0700(tmp_credentials_dir: Path) -> None:
+    save_token_cache("profile-a", _make_entry(), credentials_dir=tmp_credentials_dir)
+    save_token_cache("profile-b", _make_entry(), credentials_dir=tmp_credentials_dir)
+    mode = tmp_credentials_dir.stat().st_mode & 0o777
+    assert mode == 0o700
+
+
+def test_load_raises_typed_error_on_malformed_json(tmp_credentials_dir: Path) -> None:
+    # AC #7: corrupt cache surfaces typed error, not raw ValidationError.
+    tmp_credentials_dir.mkdir(mode=0o700)
+    (tmp_credentials_dir / "profile-x.json").write_text("{not valid json")
+
+    with pytest.raises(TokenCacheCorruptError):
+        load_token_cache("profile-x", credentials_dir=tmp_credentials_dir)
+
+
+def test_load_raises_typed_error_on_missing_fields(tmp_credentials_dir: Path) -> None:
+    tmp_credentials_dir.mkdir(mode=0o700)
+    (tmp_credentials_dir / "profile-x.json").write_text(
+        json.dumps({"access_token": "abc"})  # missing refresh_token + expires_at
+    )
+
+    with pytest.raises(TokenCacheCorruptError):
+        load_token_cache("profile-x", credentials_dir=tmp_credentials_dir)
+
+
+def test_delete_is_idempotent_when_absent(tmp_credentials_dir: Path) -> None:
+    # AC #7: second call must not raise.
+    delete_token_cache("profile-x", credentials_dir=tmp_credentials_dir)
+    delete_token_cache("profile-x", credentials_dir=tmp_credentials_dir)
+
+
+def test_delete_removes_existing_file(tmp_credentials_dir: Path) -> None:
+    save_token_cache("profile-x", _make_entry(), credentials_dir=tmp_credentials_dir)
+    path = tmp_credentials_dir / "profile-x.json"
+    assert path.exists()
+
+    delete_token_cache("profile-x", credentials_dir=tmp_credentials_dir)
+    assert not path.exists()
+
+
+def test_save_uses_model_dump_json_not_dict(tmp_credentials_dir: Path) -> None:
+    # Golden Rule #1: persisted payload must be Pydantic-serialized JSON.
+    save_token_cache("profile-x", _make_entry(), credentials_dir=tmp_credentials_dir)
+    raw = (tmp_credentials_dir / "profile-x.json").read_text()
+    # The shape must match TokenCacheEntry fields exactly — no extras, no missing.
+    parsed = json.loads(raw)
+    assert set(parsed.keys()) == {"access_token", "refresh_token", "expires_at"}

--- a/tests/cli/auth/test_oidc.py
+++ b/tests/cli/auth/test_oidc.py
@@ -1,0 +1,682 @@
+"""Tests for :mod:`akgentic.infra.cli.auth.oidc` and :class:`OidcTokenProvider`.
+
+All network I/O runs through :class:`httpx.MockTransport` — NO real network,
+NO live OIDC provider. All filesystem I/O runs through ``tmp_path`` via the
+``credentials_dir`` seam — NEVER ``~/.akgentic/``.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock
+
+import httpx
+import pytest
+
+from akgentic.infra.cli.auth import (
+    AccessDeniedError,
+    ExpiredTokenError,
+    OidcDiscoveryError,
+    OidcTokenProvider,
+    ReAuthRequiredError,
+    TokenCacheEntry,
+    TokenProvider,
+    save_token_cache,
+)
+from akgentic.infra.cli.config.profile import AuthConfig, ProfileConfig
+from akgentic.infra.cli.http import build_http_client
+
+# ---------------------------------------------------------------------------
+# Fixtures & helpers
+# ---------------------------------------------------------------------------
+
+ISSUER = "https://issuer.example.com"
+DEVICE_AUTH_ENDPOINT = f"{ISSUER}/device-auth"
+TOKEN_ENDPOINT = f"{ISSUER}/token"
+DISCOVERY_URL = f"{ISSUER}/.well-known/openid-configuration"
+
+
+@pytest.fixture
+def auth_profile() -> ProfileConfig:
+    return ProfileConfig(
+        endpoint="https://api.example.com",  # type: ignore[arg-type]
+        auth=AuthConfig(
+            type="oidc",
+            issuer=ISSUER,  # type: ignore[arg-type]
+            client_id="akgentic-cli",
+        ),
+    )
+
+
+@pytest.fixture
+def tmp_credentials_dir(tmp_path: Path) -> Path:
+    return tmp_path / "credentials"
+
+
+class FakeClock:
+    """Monotonically incrementing clock — returns the same value until
+    :meth:`advance` is called, so tests have deterministic ``expires_at``."""
+
+    def __init__(self, start: int = 1_700_000_000) -> None:
+        self._now = start
+
+    def __call__(self) -> int:
+        return self._now
+
+    def advance(self, seconds: int) -> None:
+        self._now += seconds
+
+
+def _discovery_body() -> bytes:
+    return json.dumps(
+        {
+            "device_authorization_endpoint": DEVICE_AUTH_ENDPOINT,
+            "token_endpoint": TOKEN_ENDPOINT,
+        }
+    ).encode("utf-8")
+
+
+def _json_response(payload: dict[str, Any], status: int = 200) -> httpx.Response:
+    return httpx.Response(status, content=json.dumps(payload).encode("utf-8"))
+
+
+def _make_provider(
+    auth_profile: ProfileConfig,
+    *,
+    handler: Callable[[httpx.Request], httpx.Response],
+    credentials_dir: Path,
+    clock: Callable[[], int] | None = None,
+    sleep: Callable[[float], None] | None = None,
+) -> OidcTokenProvider:
+    client = httpx.Client(transport=httpx.MockTransport(handler))
+    return OidcTokenProvider(
+        auth_profile,
+        "ent-prof",
+        http_client=client,
+        clock=clock,
+        sleep=sleep if sleep is not None else (lambda _s: None),
+        credentials_dir=credentials_dir,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Device-code happy path + protocol error cases (AC #1, #2, #7)
+# ---------------------------------------------------------------------------
+
+
+def test_run_device_code_flow_happy_path(
+    auth_profile: ProfileConfig, tmp_credentials_dir: Path
+) -> None:
+    clock = FakeClock()
+    poll_count = {"n": 0}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        path = request.url.path
+        if path.endswith("/.well-known/openid-configuration"):
+            return httpx.Response(200, content=_discovery_body())
+        if str(request.url) == DEVICE_AUTH_ENDPOINT:
+            return _json_response(
+                {
+                    "device_code": "dev-code",
+                    "user_code": "USER-CODE",
+                    "verification_uri": "https://verify.example.com",
+                    "verification_uri_complete": "https://verify.example.com?code=USER-CODE",
+                    "expires_in": 600,
+                    "interval": 1,
+                }
+            )
+        if str(request.url) == TOKEN_ENDPOINT:
+            poll_count["n"] += 1
+            if poll_count["n"] == 1:
+                return _json_response({"error": "authorization_pending"}, status=400)
+            return _json_response(
+                {
+                    "access_token": "access-token-1",
+                    "refresh_token": "refresh-token-1",
+                    "expires_in": 3600,
+                    "token_type": "Bearer",
+                }
+            )
+        raise AssertionError(f"unexpected URL: {request.url}")
+
+    sleeps: list[float] = []
+    provider = _make_provider(
+        auth_profile,
+        handler=handler,
+        credentials_dir=tmp_credentials_dir,
+        clock=clock,
+        sleep=sleeps.append,
+    )
+    prompts: list[str] = []
+
+    entry = provider.run_device_code_flow(on_user_code=lambda a: prompts.append(a.user_code))
+
+    assert entry.access_token == "access-token-1"
+    assert entry.refresh_token == "refresh-token-1"
+    assert entry.expires_at == clock() + 3600
+    assert prompts == ["USER-CODE"]
+    # cache file written
+    assert (tmp_credentials_dir / "ent-prof.json").exists()
+    provider.close()
+
+
+def test_poll_slow_down_widens_interval(
+    auth_profile: ProfileConfig, tmp_credentials_dir: Path
+) -> None:
+    # AC #7: slow_down widens the polling interval (assert on recorded sleeps).
+    state = {"n": 0}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        path = request.url.path
+        if path.endswith("/.well-known/openid-configuration"):
+            return httpx.Response(200, content=_discovery_body())
+        if str(request.url) == DEVICE_AUTH_ENDPOINT:
+            return _json_response(
+                {
+                    "device_code": "dev-code",
+                    "user_code": "U",
+                    "verification_uri": "https://verify.example.com",
+                    "expires_in": 600,
+                    "interval": 5,
+                }
+            )
+        if str(request.url) == TOKEN_ENDPOINT:
+            state["n"] += 1
+            if state["n"] == 1:
+                return _json_response({"error": "slow_down"}, status=400)
+            return _json_response(
+                {
+                    "access_token": "a",
+                    "refresh_token": "r",
+                    "expires_in": 3600,
+                }
+            )
+        raise AssertionError(request.url)
+
+    sleeps: list[float] = []
+    provider = _make_provider(
+        auth_profile,
+        handler=handler,
+        credentials_dir=tmp_credentials_dir,
+        clock=FakeClock(),
+        sleep=sleeps.append,
+    )
+    provider.run_device_code_flow(on_user_code=lambda _a: None)
+    # Two sleeps recorded: the initial interval, then the widened one.
+    assert sleeps[0] == 5
+    assert sleeps[1] == 10
+    provider.close()
+
+
+def test_access_denied_surfaces_typed_error(
+    auth_profile: ProfileConfig, tmp_credentials_dir: Path
+) -> None:
+    # AC #7: access_denied → AccessDeniedError; no cache written.
+    def handler(request: httpx.Request) -> httpx.Response:
+        path = request.url.path
+        if path.endswith("/.well-known/openid-configuration"):
+            return httpx.Response(200, content=_discovery_body())
+        if str(request.url) == DEVICE_AUTH_ENDPOINT:
+            return _json_response(
+                {
+                    "device_code": "dev-code",
+                    "user_code": "U",
+                    "verification_uri": "https://verify.example.com",
+                    "expires_in": 600,
+                    "interval": 1,
+                }
+            )
+        if str(request.url) == TOKEN_ENDPOINT:
+            return _json_response({"error": "access_denied"}, status=400)
+        raise AssertionError(request.url)
+
+    provider = _make_provider(
+        auth_profile,
+        handler=handler,
+        credentials_dir=tmp_credentials_dir,
+        clock=FakeClock(),
+    )
+    with pytest.raises(AccessDeniedError):
+        provider.run_device_code_flow(on_user_code=lambda _a: None)
+    assert not (tmp_credentials_dir / "ent-prof.json").exists()
+    provider.close()
+
+
+def test_expires_in_budget_exhaustion_raises_expired_token(
+    auth_profile: ProfileConfig, tmp_credentials_dir: Path
+) -> None:
+    # AC #7: local flow timeout → ExpiredTokenError; no cache written.
+    clock = FakeClock()
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        path = request.url.path
+        if path.endswith("/.well-known/openid-configuration"):
+            return httpx.Response(200, content=_discovery_body())
+        if str(request.url) == DEVICE_AUTH_ENDPOINT:
+            return _json_response(
+                {
+                    "device_code": "dev-code",
+                    "user_code": "U",
+                    "verification_uri": "https://verify.example.com",
+                    "expires_in": 10,
+                    "interval": 5,
+                }
+            )
+        if str(request.url) == TOKEN_ENDPOINT:
+            # Server keeps saying pending; local clock will exhaust first.
+            clock.advance(20)
+            return _json_response({"error": "authorization_pending"}, status=400)
+        raise AssertionError(request.url)
+
+    provider = _make_provider(
+        auth_profile,
+        handler=handler,
+        credentials_dir=tmp_credentials_dir,
+        clock=clock,
+    )
+    with pytest.raises(ExpiredTokenError):
+        provider.run_device_code_flow(on_user_code=lambda _a: None)
+    assert not (tmp_credentials_dir / "ent-prof.json").exists()
+    provider.close()
+
+
+def test_discovery_failure_surfaces_oidc_discovery_error(
+    auth_profile: ProfileConfig, tmp_credentials_dir: Path
+) -> None:
+    # AC #7: malformed/500 discovery → OidcDiscoveryError before device-auth call.
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path.endswith("/.well-known/openid-configuration"):
+            return httpx.Response(500, content=b"oops")
+        raise AssertionError("should not reach device-auth when discovery fails")
+
+    provider = _make_provider(
+        auth_profile,
+        handler=handler,
+        credentials_dir=tmp_credentials_dir,
+        clock=FakeClock(),
+    )
+    with pytest.raises(OidcDiscoveryError):
+        provider.run_device_code_flow(on_user_code=lambda _a: None)
+    provider.close()
+
+
+def test_discovery_malformed_json_surfaces_oidc_discovery_error(
+    auth_profile: ProfileConfig, tmp_credentials_dir: Path
+) -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path.endswith("/.well-known/openid-configuration"):
+            return httpx.Response(200, content=b"{not json")
+        raise AssertionError("unexpected request")
+
+    provider = _make_provider(
+        auth_profile,
+        handler=handler,
+        credentials_dir=tmp_credentials_dir,
+        clock=FakeClock(),
+    )
+    with pytest.raises(OidcDiscoveryError):
+        provider.run_device_code_flow(on_user_code=lambda _a: None)
+    provider.close()
+
+
+# ---------------------------------------------------------------------------
+# get_access_token contract (AC #5, #7)
+# ---------------------------------------------------------------------------
+
+
+def test_get_access_token_returns_cached_when_fresh(
+    auth_profile: ProfileConfig, tmp_credentials_dir: Path
+) -> None:
+    clock = FakeClock()
+    # Cache with expires_at far in the future.
+    save_token_cache(
+        "ent-prof",
+        TokenCacheEntry(
+            access_token="cached-access",
+            refresh_token="cached-refresh",
+            expires_at=clock() + 3600,
+        ),
+        credentials_dir=tmp_credentials_dir,
+    )
+
+    def fail_any_request(request: httpx.Request) -> httpx.Response:
+        raise AssertionError(f"network call not allowed; got {request.url}")
+
+    provider = _make_provider(
+        auth_profile,
+        handler=fail_any_request,
+        credentials_dir=tmp_credentials_dir,
+        clock=clock,
+    )
+    assert provider.get_access_token() == "cached-access"
+    provider.close()
+
+
+def test_get_access_token_refreshes_when_expired(
+    auth_profile: ProfileConfig, tmp_credentials_dir: Path
+) -> None:
+    clock = FakeClock()
+    save_token_cache(
+        "ent-prof",
+        TokenCacheEntry(
+            access_token="old-access",
+            refresh_token="refresh-me",
+            expires_at=clock() - 60,  # already expired
+        ),
+        credentials_dir=tmp_credentials_dir,
+    )
+
+    refresh_requests: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path.endswith("/.well-known/openid-configuration"):
+            return httpx.Response(200, content=_discovery_body())
+        if str(request.url) == TOKEN_ENDPOINT:
+            refresh_requests.append(request)
+            return _json_response(
+                {
+                    "access_token": "new-access",
+                    "refresh_token": "new-refresh",
+                    "expires_in": 3600,
+                }
+            )
+        raise AssertionError(request.url)
+
+    provider = _make_provider(
+        auth_profile,
+        handler=handler,
+        credentials_dir=tmp_credentials_dir,
+        clock=clock,
+    )
+    assert provider.get_access_token() == "new-access"
+    # Request body contained grant_type=refresh_token
+    assert b"grant_type=refresh_token" in refresh_requests[0].content
+    # Cache was updated on disk with new expires_at
+    from akgentic.infra.cli.auth import load_token_cache
+
+    loaded = load_token_cache("ent-prof", credentials_dir=tmp_credentials_dir)
+    assert loaded is not None
+    assert loaded.access_token == "new-access"
+    assert loaded.expires_at == clock() + 3600
+    provider.close()
+
+
+def test_get_access_token_raises_reauth_on_invalid_refresh(
+    auth_profile: ProfileConfig, tmp_credentials_dir: Path
+) -> None:
+    clock = FakeClock()
+    save_token_cache(
+        "ent-prof",
+        TokenCacheEntry(
+            access_token="old",
+            refresh_token="bad-refresh",
+            expires_at=clock() - 60,
+        ),
+        credentials_dir=tmp_credentials_dir,
+    )
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path.endswith("/.well-known/openid-configuration"):
+            return httpx.Response(200, content=_discovery_body())
+        if str(request.url) == TOKEN_ENDPOINT:
+            return _json_response({"error": "invalid_grant"}, status=400)
+        raise AssertionError(request.url)
+
+    provider = _make_provider(
+        auth_profile,
+        handler=handler,
+        credentials_dir=tmp_credentials_dir,
+        clock=clock,
+    )
+    with pytest.raises(ReAuthRequiredError):
+        provider.get_access_token()
+    # Cache must have been purged.
+    assert not (tmp_credentials_dir / "ent-prof.json").exists()
+    provider.close()
+
+
+def test_get_access_token_raises_reauth_when_cache_missing(
+    auth_profile: ProfileConfig, tmp_credentials_dir: Path
+) -> None:
+    def fail_any_request(request: httpx.Request) -> httpx.Response:
+        raise AssertionError(f"must not hit network when cache missing; got {request.url}")
+
+    provider = _make_provider(
+        auth_profile,
+        handler=fail_any_request,
+        credentials_dir=tmp_credentials_dir,
+        clock=FakeClock(),
+    )
+    with pytest.raises(ReAuthRequiredError):
+        provider.get_access_token()
+    provider.close()
+
+
+# ---------------------------------------------------------------------------
+# Protocol conformance with HTTP client factory (AC #6 / Task 5.5)
+# ---------------------------------------------------------------------------
+
+
+def test_provider_satisfies_tokenprovider_protocol_and_wires_with_factory(
+    auth_profile: ProfileConfig, tmp_credentials_dir: Path
+) -> None:
+    clock = FakeClock()
+    save_token_cache(
+        "ent-prof",
+        TokenCacheEntry(
+            access_token="wire-token",
+            refresh_token="r",
+            expires_at=clock() + 3600,
+        ),
+        credentials_dir=tmp_credentials_dir,
+    )
+
+    def oidc_handler(request: httpx.Request) -> httpx.Response:
+        raise AssertionError("token endpoint must not be hit when cache is fresh")
+
+    provider = _make_provider(
+        auth_profile,
+        handler=oidc_handler,
+        credentials_dir=tmp_credentials_dir,
+        clock=clock,
+    )
+    assert isinstance(provider, TokenProvider)
+
+    # Now wire into build_http_client and verify Authorization header.
+    captured_headers: dict[str, str] = {}
+
+    def api_handler(request: httpx.Request) -> httpx.Response:
+        captured_headers.update(request.headers)
+        return httpx.Response(200, content=b"ok")
+
+    client = build_http_client(
+        auth_profile,
+        token_provider=provider,
+        profile_name="ent-prof",
+        transport=httpx.MockTransport(api_handler),
+    )
+    try:
+        client.get("/hello")
+    finally:
+        client.close()
+
+    assert captured_headers.get("authorization") == "Bearer wire-token"
+    provider.close()
+
+
+def test_provider_rejects_oss_profile() -> None:
+    oss_profile = ProfileConfig(endpoint="https://api.example.com")  # type: ignore[arg-type]
+    with pytest.raises(ValueError):
+        OidcTokenProvider(oss_profile, "oss")
+
+
+def test_default_prompt_hook_writes_to_stderr(
+    auth_profile: ProfileConfig, tmp_credentials_dir: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """AC #5 / Task 5.4: default on_user_code writes to stderr, not stdout."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        path = request.url.path
+        if path.endswith("/.well-known/openid-configuration"):
+            return httpx.Response(200, content=_discovery_body())
+        if str(request.url) == DEVICE_AUTH_ENDPOINT:
+            return _json_response(
+                {
+                    "device_code": "dev-code",
+                    "user_code": "VISIBLE-CODE",
+                    "verification_uri": "https://verify.example.com",
+                    "expires_in": 600,
+                    "interval": 1,
+                }
+            )
+        if str(request.url) == TOKEN_ENDPOINT:
+            return _json_response({"access_token": "a", "refresh_token": "r", "expires_in": 3600})
+        raise AssertionError(request.url)
+
+    provider = _make_provider(
+        auth_profile,
+        handler=handler,
+        credentials_dir=tmp_credentials_dir,
+        clock=FakeClock(),
+    )
+    provider.run_device_code_flow()  # default prompt hook
+    captured = capsys.readouterr()
+    assert "VISIBLE-CODE" in captured.err
+    assert "VISIBLE-CODE" not in captured.out
+    provider.close()
+
+
+def test_refresh_response_without_refresh_token_purges_and_raises(
+    auth_profile: ProfileConfig, tmp_credentials_dir: Path
+) -> None:
+    """Strict refresh-token policy (documented module decision)."""
+    clock = FakeClock()
+    save_token_cache(
+        "ent-prof",
+        TokenCacheEntry(access_token="old", refresh_token="r", expires_at=clock() - 60),
+        credentials_dir=tmp_credentials_dir,
+    )
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path.endswith("/.well-known/openid-configuration"):
+            return httpx.Response(200, content=_discovery_body())
+        if str(request.url) == TOKEN_ENDPOINT:
+            # No refresh_token in response — strict path should purge + raise.
+            return _json_response({"access_token": "a", "expires_in": 3600})
+        raise AssertionError(request.url)
+
+    provider = _make_provider(
+        auth_profile,
+        handler=handler,
+        credentials_dir=tmp_credentials_dir,
+        clock=clock,
+    )
+    with pytest.raises(ReAuthRequiredError):
+        provider.get_access_token()
+    assert not (tmp_credentials_dir / "ent-prof.json").exists()
+    provider.close()
+
+
+def test_initiate_device_flow_error_response(
+    auth_profile: ProfileConfig, tmp_credentials_dir: Path
+) -> None:
+    """Covers the error-body path in initiate_device_flow."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path.endswith("/.well-known/openid-configuration"):
+            return httpx.Response(200, content=_discovery_body())
+        if str(request.url) == DEVICE_AUTH_ENDPOINT:
+            return _json_response(
+                {"error": "invalid_client", "error_description": "bad client"},
+                status=400,
+            )
+        raise AssertionError(request.url)
+
+    from akgentic.infra.cli.auth import OidcProtocolError
+
+    provider = _make_provider(
+        auth_profile,
+        handler=handler,
+        credentials_dir=tmp_credentials_dir,
+        clock=FakeClock(),
+    )
+    with pytest.raises(OidcProtocolError):
+        provider.run_device_code_flow(on_user_code=lambda _a: None)
+    provider.close()
+
+
+def test_endpoints_cached_across_calls(
+    auth_profile: ProfileConfig, tmp_credentials_dir: Path
+) -> None:
+    """Discovery should run once per provider instance, not per call."""
+    clock = FakeClock()
+    # Seed a stale cache so get_access_token must refresh (hits token endpoint).
+    save_token_cache(
+        "ent-prof",
+        TokenCacheEntry(access_token="o", refresh_token="r", expires_at=clock() - 60),
+        credentials_dir=tmp_credentials_dir,
+    )
+    discovery_calls = {"n": 0}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path.endswith("/.well-known/openid-configuration"):
+            discovery_calls["n"] += 1
+            return httpx.Response(200, content=_discovery_body())
+        if str(request.url) == TOKEN_ENDPOINT:
+            return _json_response({"access_token": "a", "refresh_token": "r", "expires_in": 3600})
+        raise AssertionError(request.url)
+
+    provider = _make_provider(
+        auth_profile,
+        handler=handler,
+        credentials_dir=tmp_credentials_dir,
+        clock=clock,
+    )
+    provider.get_access_token()  # triggers refresh, runs discovery once
+    # Expire again and refresh a second time — discovery should NOT re-run.
+    save_token_cache(
+        "ent-prof",
+        TokenCacheEntry(access_token="o2", refresh_token="r", expires_at=clock() - 60),
+        credentials_dir=tmp_credentials_dir,
+    )
+    provider.get_access_token()
+    assert discovery_calls["n"] == 1
+    provider.close()
+
+
+def test_run_device_code_flow_uses_default_prompt_when_hook_none(
+    auth_profile: ProfileConfig, tmp_credentials_dir: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """MagicMock spy demonstrating the on_user_code injection path."""
+    spy = MagicMock()
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        path = request.url.path
+        if path.endswith("/.well-known/openid-configuration"):
+            return httpx.Response(200, content=_discovery_body())
+        if str(request.url) == DEVICE_AUTH_ENDPOINT:
+            return _json_response(
+                {
+                    "device_code": "dc",
+                    "user_code": "UC",
+                    "verification_uri": "https://v.example.com",
+                    "expires_in": 600,
+                    "interval": 1,
+                }
+            )
+        if str(request.url) == TOKEN_ENDPOINT:
+            return _json_response({"access_token": "a", "refresh_token": "r", "expires_in": 3600})
+        raise AssertionError(request.url)
+
+    provider = _make_provider(
+        auth_profile,
+        handler=handler,
+        credentials_dir=tmp_credentials_dir,
+        clock=FakeClock(),
+    )
+    provider.run_device_code_flow(on_user_code=spy)
+    assert spy.call_count == 1
+    provider.close()


### PR DESCRIPTION
## Summary

Implements Story 21.3: OIDC device-code flow (RFC 8628) and per-profile token cache for the akgentic CLI.

- `auth/oidc.py`: typed device-authorization protocol (discovery, initiate, poll) with typed error hierarchy (`OidcProtocolError` + subclasses). Honors `interval` / `slow_down` / `expires_in` budget. Pydantic models for every wire payload.
- `auth/cache.py`: per-profile cache at `~/.akgentic/credentials/<profile>.json`. File created with mode 0600 directly (no chmod-after-open race), directory with mode 0700. Atomic rewrite via `os.replace` on `.tmp` sibling. Corrupt cache surfaces `TokenCacheCorruptError`, never raw `ValidationError`.
- `auth/token_provider.py`: `OidcTokenProvider` alongside the Story 21.2 Protocol. `get_access_token` is non-interactive (cache + refresh only, raises `ReAuthRequiredError` on missing/invalid refresh). `run_device_code_flow` drives the interactive flow and writes the cache. Discovery cached per instance. Strict refresh-token policy: missing refresh_token on refresh purges cache + raises.
- 28 new tests, all network via `httpx.MockTransport`, all filesystem via `tmp_path` + `credentials_dir` seam. Permission tests are behavioral (`stat().st_mode & 0o777 == 0o600/0o700`).

Out of scope (Story 21.4): wiring into `build_http_client` / `main.py` / `commands.py`, `akgentic login` command, inline auto-auth retry.

Coverage on new modules: 91.70% (cache.py 100%, token_provider.py 96%, oidc.py 85%).

Stacked on #232 (Story 21.2 HTTP client factory).

Closes #233
