### PR TITLE
feat: wire profile-driven HTTP client into the Typer callback

### DIFF
--- a/src/akgentic/infra/cli/client.py
+++ b/src/akgentic/infra/cli/client.py
@@ -106,22 +106,56 @@ class ApiError(Exception):
 
 
 class ApiClient:
-    """Thin HTTP client mapping CLI commands to server endpoints."""
+    """Thin HTTP client mapping CLI commands to server endpoints.
 
-    def __init__(self, base_url: str, api_key: str | None = None) -> None:
-        headers: dict[str, str] = {}
-        if api_key:
-            headers["Authorization"] = f"Bearer {api_key}"
-        self._client = httpx.Client(
-            base_url=base_url,
-            headers=headers,
-            follow_redirects=True,
-            timeout=httpx.Timeout(30.0, connect=10.0),
-        )
+    Two construction modes are supported:
+
+    * **Legacy** — ``ApiClient(base_url=..., api_key=...)`` constructs its own
+      :class:`httpx.Client` with the same headers, timeout, and redirect policy
+      it has always used. This path is what the Typer callback takes when
+      ``~/.akgentic/config.yaml`` does NOT exist (backward-compat invariant).
+    * **Pre-built** — ``ApiClient(http_client=<client>)`` uses the supplied
+      client verbatim. Ownership stays with the caller: :meth:`close` will NOT
+      close the externally supplied client. The profile-driven Typer callback
+      (story 22.5) uses this mode to hand ``ApiClient`` a client that already
+      has OIDC auto-auth wired.
+
+    Exactly one of ``base_url`` or ``http_client`` MUST be supplied.
+    """
+
+    def __init__(
+        self,
+        base_url: str | None = None,
+        api_key: str | None = None,
+        *,
+        http_client: httpx.Client | None = None,
+    ) -> None:
+        if http_client is not None and base_url is not None:
+            raise ValueError("ApiClient accepts either http_client or base_url, not both.")
+        if http_client is None and base_url is None:
+            raise ValueError("ApiClient requires either http_client or base_url.")
+
+        if http_client is not None:
+            # External client: caller retains ownership; close() is a no-op.
+            self._client = http_client
+            self._owns_client = False
+        else:
+            assert base_url is not None  # narrowed by the guards above
+            headers: dict[str, str] = {}
+            if api_key:
+                headers["Authorization"] = f"Bearer {api_key}"
+            self._client = httpx.Client(
+                base_url=base_url,
+                headers=headers,
+                follow_redirects=True,
+                timeout=httpx.Timeout(30.0, connect=10.0),
+            )
+            self._owns_client = True
 
     def close(self) -> None:
-        """Close the underlying HTTP client."""
-        self._client.close()
+        """Close the underlying HTTP client iff this ``ApiClient`` owns it."""
+        if self._owns_client:
+            self._client.close()
 
     def __enter__(self) -> ApiClient:
         return self

--- a/src/akgentic/infra/cli/main.py
+++ b/src/akgentic/infra/cli/main.py
@@ -1,18 +1,55 @@
-"""Typer CLI application for akgentic-infra."""
+"""Typer CLI application for akgentic-infra.
+
+Profile-driven auth (story 22.5, ADR-021 §Decision 1 / §Decision 2)
+-------------------------------------------------------------------
+
+The top-level ``@app.callback()`` resolves which HTTP client is handed to
+:class:`ApiClient` per-invocation. Two branches:
+
+* **No config file present** — the callback silently falls back to the legacy
+  path and constructs ``ApiClient(base_url=server, api_key=api_key)`` exactly
+  as it did before 22.5. No profile resolution runs. No ``OidcTokenProvider``
+  is instantiated. No device-code traffic can occur. This is the
+  backward-compat invariant (AC #1 / AC #5 / AC #9).
+
+* **Config file present** — ``resolve_profile`` picks the active profile;
+  :func:`build_http_client_with_auto_auth` returns an auth-wired
+  ``httpx.Client``; that client is handed to :class:`ApiClient` via the
+  pre-built-client constructor path.
+
+Flag precedence (AC #4) uses **Shape P1** — we branch on ``--api-key`` and
+``--server`` **before** calling the factory rather than mutating the client
+post-hoc. ``--api-key`` fully preempts OIDC (escape hatch for pre-resolved
+credentials); ``--server`` rewires the profile-driven client's base URL while
+keeping auto-auth intact.
+"""
 
 from __future__ import annotations
 
 import logging
+import os
+import sys
+from collections.abc import Callable
 from pathlib import Path
 from typing import Annotated
 
+import httpx
 import typer
 from pydantic import BaseModel
 
+from akgentic.infra.cli.auth import DeviceAuthorizationResponse
 from akgentic.infra.cli.client import ApiClient, ApiError
 from akgentic.infra.cli.commands import login as login_command
 from akgentic.infra.cli.commands import logout as logout_command
+from akgentic.infra.cli.config import (
+    ConfigFileNotFoundError,
+    ProfileConfig,
+    ProfileConfigError,
+    load_config,
+    resolve_profile,
+)
 from akgentic.infra.cli.formatters import OutputFormat, format_output
+from akgentic.infra.cli.http import build_http_client_with_auto_auth
 from akgentic.infra.cli.renderers import RichRenderer
 from akgentic.infra.cli.tui.app import ChatApp
 
@@ -23,9 +60,28 @@ workspace_app = typer.Typer(name="workspace", help="Manage team workspace files"
 app.add_typer(team_app, name="team")
 app.add_typer(workspace_app, name="workspace")
 
-# Register top-level login/logout commands (Story 21.4).
+# Register top-level login/logout commands (Story 22.4).
 login_command.register(app)
 logout_command.register(app)
+
+
+# Default server — kept as a module constant so tests can compare against it
+# to detect whether the user actually supplied ``--server``. (Typer does not
+# easily distinguish "default" from "explicit default value" without sentinels;
+# we use this value-comparison approach.)
+_DEFAULT_SERVER = "http://localhost:8000"
+
+# -- test seams (monkeypatched by tests; production leaves them ``None``) --
+#
+# These mirror the pattern established in :mod:`akgentic.infra.cli.commands.login`
+# (story 22.4) and :mod:`commands.logout`. Production leaves all of them ``None``
+# and the callback falls through to the real ``~/.akgentic/`` paths.
+_CONFIG_PATH_OVERRIDE: Path | None = None
+_CREDENTIALS_DIR_OVERRIDE: Path | None = None
+# Optional factory swap for tests that want to inject a fully pre-built client
+# without threading transport through every layer. Production leaves ``None``
+# and the callback calls :func:`build_http_client_with_auto_auth` directly.
+_HTTP_CLIENT_FACTORY_OVERRIDE: Callable[..., httpx.Client] | None = None
 
 
 # -- shared state --
@@ -38,6 +94,10 @@ class _State:
     fmt: OutputFormat
     server: str
     api_key: str | None
+    # The resolved profile name on the config-file branch, else ``None`` on
+    # the legacy no-config path. Stored for future debug / observability
+    # hooks; not exposed via any command in this story.
+    profile_name: str | None = None
 
 
 _state = _State()
@@ -57,26 +117,175 @@ def _print(data: object, columns: list[str] | None = None) -> None:
     typer.echo(format_output(_to_serializable(data), _state.fmt, columns))
 
 
+def _emit_user_code(auth: DeviceAuthorizationResponse) -> None:
+    """Write device-code instructions to stderr.
+
+    Mirrors the ``_emit_user_code`` helper in
+    :mod:`akgentic.infra.cli.commands.login` — kept local here to avoid a
+    circular import between :mod:`main` and :mod:`commands.login`.
+    """
+    message = (
+        f"To authenticate, visit: {auth.verification_uri}\nAnd enter the code: {auth.user_code}\n"
+    )
+    if auth.verification_uri_complete:
+        message += f"Or open directly: {auth.verification_uri_complete}\n"
+    sys.stderr.write(message)
+    sys.stderr.flush()
+
+
+def _build_profile_driven_client(
+    profile: ProfileConfig,
+    profile_name: str,
+) -> httpx.Client:
+    """Construct an ``httpx.Client`` via the factory (or the test override)."""
+    factory = _HTTP_CLIENT_FACTORY_OVERRIDE
+    if factory is not None:
+        return factory(
+            profile,
+            profile_name=profile_name,
+            credentials_dir=_CREDENTIALS_DIR_OVERRIDE,
+            on_user_code=_emit_user_code,
+        )
+    return build_http_client_with_auto_auth(
+        profile,
+        profile_name=profile_name,
+        credentials_dir=_CREDENTIALS_DIR_OVERRIDE,
+        on_user_code=_emit_user_code,
+    )
+
+
+def _configure_legacy(server: str, api_key: str | None, fmt: OutputFormat) -> None:
+    """Install a legacy ``ApiClient(base_url=..., api_key=...)`` on ``_state``."""
+    _state.client = ApiClient(base_url=server, api_key=api_key)
+    _state.fmt = fmt
+    _state.server = server
+    _state.api_key = api_key
+    _state.profile_name = None
+
+
+def _configure_profile(
+    *,
+    profile: ProfileConfig,
+    profile_name: str,
+    server: str,
+    api_key: str | None,
+    fmt: OutputFormat,
+    server_is_explicit: bool,
+) -> None:
+    """Wire ``_state`` from a resolved profile, honoring flag overrides.
+
+    Flag precedence (AC #4 / Shape P1):
+
+    * ``--api-key`` supplied → legacy ``ApiClient`` short-circuits OIDC entirely.
+    * ``--server`` supplied → profile-driven client rebound to that base_url
+      (``httpx.Client.base_url`` is a writable property on httpx ≥ 0.24 —
+      documented in story 22.5 Dev Notes §"Latest Tech Information").
+    * Neither flag → profile-driven client used verbatim.
+    """
+    if api_key is not None:
+        # Pre-resolved bearer: escape hatch — bypass profile-driven auth.
+        effective_server = server if server_is_explicit else str(profile.endpoint)
+        _state.client = ApiClient(base_url=effective_server, api_key=api_key)
+        _state.fmt = fmt
+        _state.server = effective_server
+        _state.api_key = api_key
+        _state.profile_name = profile_name
+        return
+
+    http_client = _build_profile_driven_client(profile, profile_name)
+    if server_is_explicit:
+        # Override base_url on the factory-built client. httpx ≥ 0.24 accepts
+        # ``str`` on the setter.
+        http_client.base_url = server
+        effective_server = server
+    else:
+        effective_server = str(profile.endpoint)
+    _state.client = ApiClient(http_client=http_client)
+    _state.fmt = fmt
+    _state.server = effective_server
+    _state.api_key = None
+    _state.profile_name = profile_name
+
+
+def _handle_no_config(
+    *,
+    profile_flag: str | None,
+    server: str,
+    api_key: str | None,
+    fmt: OutputFormat,
+) -> None:
+    """Legacy fallback when ``~/.akgentic/config.yaml`` does not exist."""
+    if profile_flag is not None:
+        typer.echo(
+            (
+                "No config file at ~/.akgentic/config.yaml — --profile requires a "
+                "config file. Create one with a 'profiles:' block or omit --profile "
+                "to use the --server / --api-key flags."
+            ),
+            err=True,
+        )
+        raise typer.Exit(code=1)
+    _configure_legacy(server, api_key, fmt)
+
+
 # -- global callback --
 
 
 @app.callback()
 def main(
-    server: Annotated[
-        str, typer.Option("--server", help="Server base URL")
-    ] = "http://localhost:8000",
+    server: Annotated[str, typer.Option("--server", help="Server base URL")] = _DEFAULT_SERVER,
     api_key: Annotated[
         str | None, typer.Option("--api-key", help="API key for authentication")
     ] = None,
     fmt: Annotated[
         OutputFormat, typer.Option("--format", help="Output format")
     ] = OutputFormat.table,
+    profile: Annotated[
+        str | None,
+        typer.Option(
+            "--profile",
+            help=(
+                "Profile name from ~/.akgentic/config.yaml "
+                "(overrides AKGENTIC_PROFILE and default_profile)."
+            ),
+        ),
+    ] = None,
 ) -> None:
     """Akgentic Infrastructure CLI — manage teams, messaging, and workspace."""
-    _state.client = ApiClient(base_url=server, api_key=api_key)
-    _state.fmt = fmt
-    _state.server = server
-    _state.api_key = api_key
+    server_is_explicit = server != _DEFAULT_SERVER
+
+    try:
+        config = load_config(_CONFIG_PATH_OVERRIDE)
+    except ConfigFileNotFoundError:
+        _handle_no_config(
+            profile_flag=profile,
+            server=server,
+            api_key=api_key,
+            fmt=fmt,
+        )
+        return
+    except ProfileConfigError as exc:
+        typer.echo(f"Cannot load profile config: {exc}", err=True)
+        raise typer.Exit(code=1) from exc
+
+    try:
+        profile_name, active_profile = resolve_profile(
+            config,
+            cli_profile=profile,
+            env=os.environ,
+        )
+    except ProfileConfigError as exc:
+        typer.echo(f"Cannot resolve profile: {exc}", err=True)
+        raise typer.Exit(code=1) from exc
+
+    _configure_profile(
+        profile=active_profile,
+        profile_name=profile_name,
+        server=server,
+        api_key=api_key,
+        fmt=fmt,
+        server_is_explicit=server_is_explicit,
+    )
 
 
 # -- team commands --

--- a/tests/cli/test_callback.py
+++ b/tests/cli/test_callback.py
@@ -1,0 +1,436 @@
+"""Tests for the Typer callback in :mod:`akgentic.infra.cli.main`.
+
+Covers story 22.5 ACs #1 / #2 / #3 / #4 / #6 / #7 / #8 branches. All network
+I/O runs through :class:`httpx.MockTransport`; all filesystem I/O runs through
+``tmp_path`` via the module-level seam constants. No real ``~/.akgentic/``,
+no real device-code flow.
+
+The dedicated backward-compat regression test for AC #9 lives in
+:mod:`test_callback_no_config_regression`.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import httpx
+import pytest
+from typer.testing import CliRunner
+
+from akgentic.infra.cli import main as main_module
+from akgentic.infra.cli.client import ApiClient
+from akgentic.infra.cli.main import app
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+ISSUER = "https://issuer.example.com"
+DEVICE_AUTH_ENDPOINT = f"{ISSUER}/device-auth"
+TOKEN_ENDPOINT = f"{ISSUER}/token"
+DISCOVERY_URL_PATH = "/.well-known/openid-configuration"
+
+
+def _discovery_body() -> bytes:
+    return json.dumps(
+        {
+            "device_authorization_endpoint": DEVICE_AUTH_ENDPOINT,
+            "token_endpoint": TOKEN_ENDPOINT,
+        }
+    ).encode("utf-8")
+
+
+def _device_auth_body() -> dict[str, Any]:
+    return {
+        "device_code": "dev-code",
+        "user_code": "USER-CODE",
+        "verification_uri": "https://verify.example.com",
+        "verification_uri_complete": "https://verify.example.com?code=USER-CODE",
+        "expires_in": 600,
+        "interval": 1,
+    }
+
+
+def _token_body() -> dict[str, Any]:
+    return {
+        "access_token": "access-token-1",
+        "refresh_token": "refresh-token-1",
+        "expires_in": 3600,
+        "token_type": "Bearer",
+    }
+
+
+def _write_noauth_config(path: Path, profile_name: str = "oss") -> None:
+    path.write_text(
+        f"profiles:\n  {profile_name}:\n    endpoint: https://api.example.com\n",
+        encoding="utf-8",
+    )
+
+
+def _write_auth_config(path: Path, profile_name: str = "acme-prod") -> None:
+    path.write_text(
+        "default_profile: " + profile_name + "\n"
+        "profiles:\n"
+        f"  {profile_name}:\n"
+        "    endpoint: https://api.example.com\n"
+        "    auth:\n"
+        "      type: oidc\n"
+        f"      issuer: {ISSUER}\n"
+        "      client_id: akgentic-cli\n",
+        encoding="utf-8",
+    )
+
+
+@pytest.fixture(autouse=True)
+def _reset_overrides_and_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    main_module._CONFIG_PATH_OVERRIDE = None
+    main_module._CREDENTIALS_DIR_OVERRIDE = None
+    main_module._HTTP_CLIENT_FACTORY_OVERRIDE = None
+    monkeypatch.delenv("AKGENTIC_PROFILE", raising=False)
+    yield
+    main_module._CONFIG_PATH_OVERRIDE = None
+    main_module._CREDENTIALS_DIR_OVERRIDE = None
+    main_module._HTTP_CLIENT_FACTORY_OVERRIDE = None
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    # Click 8.3 removed the ``mix_stderr`` kwarg; ``result.stderr`` is always
+    # captured separately.
+    return CliRunner()
+
+
+def _mock_api_client() -> MagicMock:
+    """A MagicMock that impersonates :class:`ApiClient` for command bodies."""
+    mock = MagicMock(spec=ApiClient)
+    mock.list_teams.return_value = []
+    return mock
+
+
+# ---------------------------------------------------------------------------
+# AC #1 + AC #5 — no config file → legacy path
+# ---------------------------------------------------------------------------
+
+
+def _install_recording_api_client(
+    constructed: list[dict[str, Any]],
+) -> MagicMock:
+    """Replace :class:`ApiClient` in main with a recording factory.
+
+    The returned MagicMock impersonates the ApiClient instance; the caller
+    configures its ``list_teams.return_value`` as needed.
+    """
+    instance = _mock_api_client()
+
+    def factory(*args: Any, **kwargs: Any) -> MagicMock:
+        # Normalize positional args to the canonical (base_url, api_key) names.
+        kw = dict(kwargs)
+        if args:
+            kw.setdefault("base_url", args[0])
+        if len(args) > 1:
+            kw.setdefault("api_key", args[1])
+        constructed.append(kw)
+        return instance
+
+    return factory  # type: ignore[return-value]
+
+
+class TestNoConfigLegacyPath:
+    def test_no_config_no_flags_uses_legacy_defaults(
+        self, runner: CliRunner, tmp_path: Path
+    ) -> None:
+        """Config absent + no flags → ``ApiClient("http://localhost:8000", None)``."""
+        main_module._CONFIG_PATH_OVERRIDE = tmp_path / "nope.yaml"
+        constructed: list[dict[str, Any]] = []
+
+        with (
+            patch(
+                "akgentic.infra.cli.main.ApiClient",
+                side_effect=_install_recording_api_client(constructed),
+            ),
+            patch(
+                "akgentic.infra.cli.auth.OidcTokenProvider",
+                side_effect=AssertionError("OIDC must not engage"),
+            ),
+        ):
+            result = runner.invoke(app, ["team", "list"])
+
+        assert result.exit_code == 0, result.stderr
+        assert len(constructed) == 1
+        assert constructed[0].get("base_url") == "http://localhost:8000"
+        assert constructed[0].get("api_key") is None
+        assert constructed[0].get("http_client") is None
+        assert main_module._state.profile_name is None
+
+    def test_no_config_with_server_and_api_key_flags(
+        self, runner: CliRunner, tmp_path: Path
+    ) -> None:
+        main_module._CONFIG_PATH_OVERRIDE = tmp_path / "nope.yaml"
+        constructed: list[dict[str, Any]] = []
+
+        with (
+            patch(
+                "akgentic.infra.cli.main.ApiClient",
+                side_effect=_install_recording_api_client(constructed),
+            ),
+            patch(
+                "akgentic.infra.cli.auth.OidcTokenProvider",
+                side_effect=AssertionError("OIDC must not engage"),
+            ),
+        ):
+            result = runner.invoke(
+                app,
+                ["--server", "http://example.com", "--api-key", "xyz", "team", "list"],
+            )
+
+        assert result.exit_code == 0, result.stderr
+        assert constructed[-1].get("base_url") == "http://example.com"
+        assert constructed[-1].get("api_key") == "xyz"
+
+
+# ---------------------------------------------------------------------------
+# AC #2 — --profile with no config → exit 1, stderr message
+# ---------------------------------------------------------------------------
+
+
+class TestProfileFlagWithoutConfig:
+    def test_profile_flag_without_config_exits_nonzero(
+        self, runner: CliRunner, tmp_path: Path
+    ) -> None:
+        main_module._CONFIG_PATH_OVERRIDE = tmp_path / "nope.yaml"
+        result = runner.invoke(app, ["--profile", "foo", "team", "list"])
+        assert result.exit_code != 0
+        assert "no config file" in result.stderr.lower()
+        assert "~/.akgentic/config.yaml" in result.stderr
+
+
+# ---------------------------------------------------------------------------
+# AC #1 / #4 — config + api-key override bypasses OIDC entirely
+# ---------------------------------------------------------------------------
+
+
+class TestConfigWithApiKeyOverride:
+    def test_api_key_flag_bypasses_oidc(self, runner: CliRunner, tmp_path: Path) -> None:
+        config_path = tmp_path / "config.yaml"
+        _write_auth_config(config_path)
+        main_module._CONFIG_PATH_OVERRIDE = config_path
+
+        constructed: list[dict[str, Any]] = []
+
+        with (
+            patch(
+                "akgentic.infra.cli.main.ApiClient",
+                side_effect=_install_recording_api_client(constructed),
+            ),
+            patch(
+                "akgentic.infra.cli.auth.OidcTokenProvider",
+                side_effect=AssertionError("--api-key must preempt OIDC"),
+            ),
+            patch(
+                "akgentic.infra.cli.main.build_http_client_with_auto_auth",
+                side_effect=AssertionError("factory must not be called when --api-key set"),
+            ),
+        ):
+            result = runner.invoke(
+                app,
+                ["--api-key", "preresolved", "team", "list"],
+            )
+
+        assert result.exit_code == 0, result.stderr
+        assert constructed[-1].get("api_key") == "preresolved"
+        # --server not supplied: use profile.endpoint (pydantic HttpUrl normalizes
+        # the value with a trailing slash).
+        assert constructed[-1].get("base_url", "").startswith("https://api.example.com")
+
+
+# ---------------------------------------------------------------------------
+# AC #4 — --server override rewires profile-driven base_url
+# ---------------------------------------------------------------------------
+
+
+class TestConfigWithServerOverride:
+    def test_server_flag_overrides_profile_endpoint(
+        self, runner: CliRunner, tmp_path: Path
+    ) -> None:
+        config_path = tmp_path / "config.yaml"
+        _write_noauth_config(config_path, profile_name="oss-local")
+        main_module._CONFIG_PATH_OVERRIDE = config_path
+
+        captured_urls: list[str] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            captured_urls.append(str(request.url))
+            return httpx.Response(200, json={"teams": []})
+
+        transport = httpx.MockTransport(handler)
+
+        def factory(profile: Any, **_kwargs: Any) -> httpx.Client:
+            # Production factory uses profile.endpoint; test stub mimics it.
+            return httpx.Client(base_url=str(profile.endpoint), transport=transport)
+
+        main_module._HTTP_CLIENT_FACTORY_OVERRIDE = factory
+
+        result = runner.invoke(app, ["--server", "http://override.local", "team", "list"])
+        assert result.exit_code == 0, result.stderr
+        # Request should hit the override, not the profile endpoint.
+        assert any("override.local" in url for url in captured_urls)
+        assert not any("api.example.com" in url for url in captured_urls)
+
+
+# ---------------------------------------------------------------------------
+# AC #2 — --profile flag selects profile via resolve_profile precedence
+# ---------------------------------------------------------------------------
+
+
+class TestProfileFlagSelection:
+    def test_profile_flag_selects_named_profile(self, runner: CliRunner, tmp_path: Path) -> None:
+        config_path = tmp_path / "config.yaml"
+        config_path.write_text(
+            "profiles:\n"
+            "  alpha:\n"
+            "    endpoint: http://alpha.local\n"
+            "  beta:\n"
+            "    endpoint: http://beta.local\n",
+            encoding="utf-8",
+        )
+        main_module._CONFIG_PATH_OVERRIDE = config_path
+
+        seen_endpoints: list[str] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            seen_endpoints.append(str(request.url))
+            return httpx.Response(200, json={"teams": []})
+
+        transport = httpx.MockTransport(handler)
+
+        def factory(profile: Any, **_kwargs: Any) -> httpx.Client:
+            return httpx.Client(base_url=str(profile.endpoint), transport=transport)
+
+        main_module._HTTP_CLIENT_FACTORY_OVERRIDE = factory
+
+        result = runner.invoke(app, ["--profile", "beta", "team", "list"])
+        assert result.exit_code == 0, result.stderr
+        assert any("beta.local" in u for u in seen_endpoints)
+        assert main_module._state.profile_name == "beta"
+
+
+# ---------------------------------------------------------------------------
+# AC #8 — malformed config surfaces as non-zero exit with stderr message
+# ---------------------------------------------------------------------------
+
+
+class TestMalformedConfig:
+    def test_malformed_config_exits_nonzero(self, runner: CliRunner, tmp_path: Path) -> None:
+        config_path = tmp_path / "config.yaml"
+        # "profiles" is required; this will fail validation.
+        config_path.write_text("not_profiles: []\n", encoding="utf-8")
+        main_module._CONFIG_PATH_OVERRIDE = config_path
+
+        result = runner.invoke(app, ["team", "list"])
+        assert result.exit_code != 0
+        # Operator-facing prefix, does not leak Python symbols.
+        assert "profile config" in result.stderr.lower()
+
+
+# ---------------------------------------------------------------------------
+# AC #6 — no-auth profile never attaches Authorization header
+# ---------------------------------------------------------------------------
+
+
+class TestNoAuthProfileNoAuthHeader:
+    def test_no_auth_profile_omits_authorization(self, runner: CliRunner, tmp_path: Path) -> None:
+        config_path = tmp_path / "config.yaml"
+        _write_noauth_config(config_path, profile_name="oss-local")
+        main_module._CONFIG_PATH_OVERRIDE = config_path
+        main_module._CREDENTIALS_DIR_OVERRIDE = tmp_path / "credentials"
+
+        captured_headers: list[httpx.Headers] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            captured_headers.append(request.headers.copy())
+            return httpx.Response(200, json={"teams": []})
+
+        transport = httpx.MockTransport(handler)
+
+        # Use the real factory with an injected transport so the test exercises
+        # production code paths (AC #6 is an end-to-end invariant, not a stub
+        # assertion).
+        def factory(profile: Any, **kwargs: Any) -> httpx.Client:
+            from akgentic.infra.cli.http import build_http_client_with_auto_auth
+
+            return build_http_client_with_auto_auth(profile, transport=transport, **kwargs)
+
+        main_module._HTTP_CLIENT_FACTORY_OVERRIDE = factory
+
+        with patch(
+            "akgentic.infra.cli.auth.OidcTokenProvider",
+            side_effect=AssertionError("no-auth profile must not construct OIDC"),
+        ):
+            result = runner.invoke(app, ["team", "list"])
+
+        assert result.exit_code == 0, result.stderr
+        assert len(captured_headers) >= 1
+        for headers in captured_headers:
+            assert "authorization" not in {k.lower() for k in headers}
+
+
+# ---------------------------------------------------------------------------
+# AC #7 — auth profile + empty cache → device-code + command succeeds
+# ---------------------------------------------------------------------------
+
+
+class TestAuthProfileDeviceCodeFlow:
+    def test_device_code_flow_on_empty_cache(self, runner: CliRunner, tmp_path: Path) -> None:
+        config_path = tmp_path / "config.yaml"
+        _write_auth_config(config_path, profile_name="acme-prod")
+        credentials_dir = tmp_path / "credentials"
+        main_module._CONFIG_PATH_OVERRIDE = config_path
+        main_module._CREDENTIALS_DIR_OVERRIDE = credentials_dir
+
+        call_log: dict[str, int] = {}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            path = request.url.path
+            url = str(request.url)
+            if path.endswith(DISCOVERY_URL_PATH):
+                call_log["discovery"] = call_log.get("discovery", 0) + 1
+                return httpx.Response(200, content=_discovery_body())
+            if url == DEVICE_AUTH_ENDPOINT:
+                call_log["device_auth"] = call_log.get("device_auth", 0) + 1
+                return httpx.Response(200, json=_device_auth_body())
+            if url == TOKEN_ENDPOINT:
+                call_log["token"] = call_log.get("token", 0) + 1
+                return httpx.Response(200, json=_token_body())
+            # Business endpoint.
+            call_log["business"] = call_log.get("business", 0) + 1
+            return httpx.Response(200, json={"teams": []})
+
+        transport = httpx.MockTransport(handler)
+
+        def factory(profile: Any, **kwargs: Any) -> httpx.Client:
+            from akgentic.infra.cli.http import build_http_client_with_auto_auth
+
+            return build_http_client_with_auto_auth(profile, transport=transport, **kwargs)
+
+        main_module._HTTP_CLIENT_FACTORY_OVERRIDE = factory
+
+        result = runner.invoke(app, ["team", "list"])
+
+        assert result.exit_code == 0, result.stderr
+        # Cache file exists with mode 0600.
+        cache_file = credentials_dir / "acme-prod.json"
+        assert cache_file.exists()
+        import stat
+
+        mode = stat.S_IMODE(cache_file.stat().st_mode)
+        assert mode == 0o600, oct(mode)
+        # stderr carries device-code instructions.
+        assert "USER-CODE" in result.stderr
+        # Discovery + device-auth + token + at least one business request.
+        assert call_log.get("discovery", 0) >= 1
+        assert call_log.get("device_auth", 0) >= 1
+        assert call_log.get("token", 0) >= 1
+        assert call_log.get("business", 0) >= 1

--- a/tests/cli/test_callback_no_config_regression.py
+++ b/tests/cli/test_callback_no_config_regression.py
@@ -1,0 +1,316 @@
+"""Anti-regression gate for story 22.5 AC #1 / AC #5 / AC #9.
+
+When ``~/.akgentic/config.yaml`` does not exist, the CLI MUST behave
+identically to pre-22.5. If you change this file, you are changing the
+backward-compatibility contract — do so only with explicit review approval.
+
+What this suite asserts, parametrized across every existing top-level CLI
+command that makes HTTP calls:
+
+* Exit code 0 (all mocked responses are 2xx).
+* Exactly one :class:`ApiClient` constructed via the legacy
+  ``(base_url, api_key)`` path.
+* Zero :class:`OidcTokenProvider` instances constructed.
+* Zero :func:`build_http_client_with_auto_auth` calls.
+* Outgoing requests attach an ``Authorization`` header only when
+  ``--api-key`` is supplied; its value is always ``Bearer <api_key>``.
+
+``HOME`` is monkeypatched to ``tmp_path`` so a developer's real
+``~/.akgentic/config.yaml`` cannot satisfy the test accidentally.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+import httpx
+import pytest
+from typer.testing import CliRunner
+
+from akgentic.infra.cli import main as main_module
+from akgentic.infra.cli.client import ApiClient
+from akgentic.infra.cli.main import app
+
+
+@pytest.fixture(autouse=True)
+def _reset_overrides_and_home(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Seal the environment: no real config, no leaking env vars."""
+    main_module._CONFIG_PATH_OVERRIDE = None
+    main_module._CREDENTIALS_DIR_OVERRIDE = None
+    main_module._HTTP_CLIENT_FACTORY_OVERRIDE = None
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.delenv("AKGENTIC_PROFILE", raising=False)
+    yield
+    main_module._CONFIG_PATH_OVERRIDE = None
+    main_module._CREDENTIALS_DIR_OVERRIDE = None
+    main_module._HTTP_CLIENT_FACTORY_OVERRIDE = None
+
+
+# ---------------------------------------------------------------------------
+# Per-command scenarios — (argv, mocked-response-kind, mocked-response-body)
+# ---------------------------------------------------------------------------
+
+
+def _team_info_payload() -> dict[str, Any]:
+    return {
+        "team_id": "t1",
+        "name": "Team",
+        "status": "running",
+        "user_id": "u1",
+        "created_at": "2025-01-01T00:00:00",
+        "updated_at": "2025-01-01T00:00:00",
+    }
+
+
+def _event_list_payload() -> dict[str, Any]:
+    return {
+        "events": [
+            {
+                "team_id": "t1",
+                "sequence": 1,
+                "timestamp": "2025-01-01T00:00:00",
+                "event": {"type": "started"},
+            }
+        ]
+    }
+
+
+def _workspace_tree_payload() -> dict[str, Any]:
+    return {"team_id": "t1", "path": "/", "entries": []}
+
+
+def _generic_handler(request: httpx.Request) -> httpx.Response:
+    """Fallback handler: returns plausible-shape responses per URL pattern."""
+    path = request.url.path
+    if path == "/teams" and request.method == "GET":
+        return httpx.Response(200, json={"teams": [_team_info_payload()]})
+    if path == "/teams" and request.method == "POST":
+        return httpx.Response(200, json=_team_info_payload())
+    if path.startswith("/teams/") and path.endswith("/events"):
+        return httpx.Response(200, json=_event_list_payload())
+    if path.startswith("/workspace/") and path.endswith("/tree"):
+        return httpx.Response(200, json=_workspace_tree_payload())
+    if path.startswith("/workspace/") and path.endswith("/file"):
+        if request.method == "GET":
+            return httpx.Response(200, content=b"file contents")
+        # POST multipart upload.
+        return httpx.Response(200, json={"path": "readme.md", "size": 5})
+    if path.startswith("/teams/"):
+        if request.method == "DELETE":
+            return httpx.Response(204, content=b"")
+        if request.method == "POST":
+            return httpx.Response(200, json={})
+        return httpx.Response(200, json=_team_info_payload())
+    return httpx.Response(200, json={})
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    return CliRunner()
+
+
+# Each scenario: (argv, expected_auth_header)
+# ``expected_auth_header`` is ``None`` when no Authorization header should be
+# attached; it is the exact value when ``--api-key`` is supplied.
+_SCENARIOS = [
+    pytest.param(["team", "list"], None, id="team-list-no-flags"),
+    pytest.param(["team", "get", "t1"], None, id="team-get-no-flags"),
+    pytest.param(["team", "create", "entry"], None, id="team-create-no-flags"),
+    pytest.param(["team", "delete", "t1"], None, id="team-delete-no-flags"),
+    pytest.param(["team", "events", "t1"], None, id="team-events-no-flags"),
+    pytest.param(["message", "t1", "hello"], None, id="message-no-flags"),
+    pytest.param(
+        ["reply", "t1", "ok", "--message-id", "m1"],
+        None,
+        id="reply-no-flags",
+    ),
+    pytest.param(["workspace", "tree", "t1"], None, id="workspace-tree-no-flags"),
+    pytest.param(
+        ["--api-key", "tok", "team", "list"],
+        "Bearer tok",
+        id="team-list-api-key",
+    ),
+    pytest.param(
+        ["--server", "http://other.example", "team", "list"],
+        None,
+        id="team-list-server-override",
+    ),
+]
+
+
+@pytest.mark.parametrize(("argv", "expected_auth_header"), _SCENARIOS)
+def test_no_config_command_is_backwards_compatible(
+    runner: CliRunner,
+    tmp_path: Path,
+    argv: list[str],
+    expected_auth_header: str | None,
+) -> None:
+    """Exercises AC #1 / AC #5 / AC #9 on every HTTP-using command."""
+    # Force ConfigFileNotFoundError by pointing the seam at a missing file.
+    main_module._CONFIG_PATH_OVERRIDE = tmp_path / "nope.yaml"
+
+    # Record every ApiClient construction, preserving both args and kwargs.
+    constructed: list[dict[str, Any]] = []
+    instance_holder: dict[str, ApiClient] = {}
+    original_init = ApiClient.__init__
+
+    captured_requests: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured_requests.append(request)
+        return _generic_handler(request)
+
+    transport = httpx.MockTransport(handler)
+
+    def recording_init(self: ApiClient, *args: Any, **kwargs: Any) -> None:
+        kw = dict(kwargs)
+        if args:
+            kw.setdefault("base_url", args[0])
+        if len(args) > 1:
+            kw.setdefault("api_key", args[1])
+        constructed.append(kw)
+        # Still construct the real ApiClient — but swap the internal httpx
+        # client for our MockTransport-backed one so no real network I/O
+        # happens. This exercises the *real* constructor code (the gate for
+        # AC #5: legacy path still works).
+        original_init(self, *args, **kwargs)
+        # Rewire the internal client through MockTransport, preserving the
+        # Authorization header set by the legacy path.
+        existing_auth = self._client.headers.get("authorization")
+        headers: dict[str, str] = {}
+        if existing_auth:
+            headers["Authorization"] = existing_auth
+        self._client.close()
+        self._client = httpx.Client(
+            base_url=kw.get("base_url", "http://localhost:8000"),
+            transport=transport,
+            headers=headers,
+        )
+        instance_holder["client"] = self
+
+    with (
+        patch.object(ApiClient, "__init__", recording_init),
+        patch(
+            "akgentic.infra.cli.auth.OidcTokenProvider",
+            side_effect=AssertionError(
+                "OidcTokenProvider must not be constructed on the no-config path"
+            ),
+        ),
+        patch(
+            "akgentic.infra.cli.main.build_http_client_with_auto_auth",
+            side_effect=AssertionError(
+                "auto-auth factory must not be called on the no-config path"
+            ),
+        ),
+    ):
+        # Workspace upload needs a real file on disk for its argument.
+        result = runner.invoke(app, argv)
+
+    assert result.exit_code == 0, (
+        f"argv={argv} exit_code={result.exit_code} "
+        f"stderr={result.stderr!r} stdout={result.stdout!r}"
+    )
+
+    # Exactly one ApiClient construction via the legacy path.
+    assert len(constructed) == 1, f"expected 1 ApiClient, got {len(constructed)}"
+    kw = constructed[0]
+    assert kw.get("http_client") is None
+    # _owns_client is True when the legacy path is taken.
+    assert instance_holder["client"]._owns_client is True
+
+    # Every outgoing request honors the auth-header invariant.
+    assert captured_requests, f"no outgoing request captured for argv={argv}"
+    for req in captured_requests:
+        auth = req.headers.get("authorization")
+        if expected_auth_header is None:
+            assert auth is None, f"unexpected Authorization header: {auth!r}"
+        else:
+            assert auth == expected_auth_header, (
+                f"wrong Authorization: {auth!r} != {expected_auth_header!r}"
+            )
+
+
+def test_workspace_upload_no_config(runner: CliRunner, tmp_path: Path) -> None:
+    """``workspace upload`` needs a real file; handled separately from the
+    parametrized matrix."""
+    main_module._CONFIG_PATH_OVERRIDE = tmp_path / "nope.yaml"
+
+    upload_file = tmp_path / "readme.md"
+    upload_file.write_text("hello", encoding="utf-8")
+
+    captured_requests: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured_requests.append(request)
+        return _generic_handler(request)
+
+    transport = httpx.MockTransport(handler)
+    original_init = ApiClient.__init__
+
+    def recording_init(self: ApiClient, *args: Any, **kwargs: Any) -> None:
+        original_init(self, *args, **kwargs)
+        self._client.close()
+        self._client = httpx.Client(
+            base_url=kwargs.get("base_url", "http://localhost:8000"),
+            transport=transport,
+        )
+
+    with (
+        patch.object(ApiClient, "__init__", recording_init),
+        patch(
+            "akgentic.infra.cli.auth.OidcTokenProvider",
+            side_effect=AssertionError("OIDC must not engage"),
+        ),
+        patch(
+            "akgentic.infra.cli.main.build_http_client_with_auto_auth",
+            side_effect=AssertionError("auto-auth must not engage"),
+        ),
+    ):
+        result = runner.invoke(
+            app,
+            ["workspace", "upload", "t1", str(upload_file)],
+        )
+
+    assert result.exit_code == 0, result.stderr
+    assert any(
+        req.url.path.endswith("/workspace/t1/file") and req.method == "POST"
+        for req in captured_requests
+    )
+
+
+def test_workspace_read_no_config(runner: CliRunner, tmp_path: Path) -> None:
+    """``workspace read`` returns raw bytes — separate scenario."""
+    main_module._CONFIG_PATH_OVERRIDE = tmp_path / "nope.yaml"
+
+    captured_requests: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured_requests.append(request)
+        return _generic_handler(request)
+
+    transport = httpx.MockTransport(handler)
+    original_init = ApiClient.__init__
+
+    def recording_init(self: ApiClient, *args: Any, **kwargs: Any) -> None:
+        original_init(self, *args, **kwargs)
+        self._client.close()
+        self._client = httpx.Client(
+            base_url=kwargs.get("base_url", "http://localhost:8000"),
+            transport=transport,
+        )
+
+    with (
+        patch.object(ApiClient, "__init__", recording_init),
+        patch(
+            "akgentic.infra.cli.auth.OidcTokenProvider",
+            side_effect=AssertionError("OIDC must not engage"),
+        ),
+    ):
+        result = runner.invoke(app, ["workspace", "read", "t1", "readme.md"])
+
+    assert result.exit_code == 0, result.stderr
+    assert captured_requests
+    for req in captured_requests:
+        assert req.headers.get("authorization") is None

--- a/tests/cli/test_cli_client.py
+++ b/tests/cli/test_cli_client.py
@@ -333,3 +333,66 @@ class TestApiKey:
         client = _client(httpx.MockTransport(handler), api_key="secret-key")
         client.list_teams()
         assert headers.get("authorization") == "Bearer secret-key"
+
+
+# -- ApiClient constructor modes (story 22.5) --
+
+
+class TestApiClientConstruction:
+    """Exercises the dual-mode constructor introduced in story 22.5."""
+
+    def test_legacy_positional_constructs_own_client(self) -> None:
+        """Legacy call site ``ApiClient("http://x", "k")`` still works."""
+        client = ApiClient("http://test", "key")
+        try:
+            assert client._owns_client is True
+            assert client._client.headers.get("authorization") == "Bearer key"
+        finally:
+            client.close()
+
+    def test_legacy_keyword_constructs_own_client(self) -> None:
+        client = ApiClient(base_url="http://test", api_key="k2")
+        try:
+            assert client._owns_client is True
+        finally:
+            client.close()
+
+    def test_prebuilt_http_client_is_used_verbatim(self) -> None:
+        """``ApiClient(http_client=...)`` reuses the given client untouched."""
+        external = httpx.Client(base_url="http://external")
+        client = ApiClient(http_client=external)
+        try:
+            assert client._owns_client is False
+            assert client._client is external
+            # ApiClient must NOT mutate headers when an external client is
+            # supplied — the caller (callback) owns all auth.
+            assert "authorization" not in external.headers
+        finally:
+            external.close()
+
+    def test_both_base_url_and_http_client_raises(self) -> None:
+        external = httpx.Client(base_url="http://external")
+        try:
+            with pytest.raises(ValueError, match="either"):
+                ApiClient(base_url="http://x", http_client=external)
+        finally:
+            external.close()
+
+    def test_neither_base_url_nor_http_client_raises(self) -> None:
+        with pytest.raises(ValueError, match="requires either"):
+            ApiClient()
+
+    def test_close_does_not_close_external_client(self) -> None:
+        """Ownership invariant — external clients survive ``ApiClient.close()``."""
+        external = httpx.Client(base_url="http://external")
+        client = ApiClient(http_client=external)
+        client.close()
+        # External client should still be usable.
+        assert external.is_closed is False
+        external.close()
+
+    def test_close_does_close_owned_client(self) -> None:
+        client = ApiClient(base_url="http://test")
+        inner = client._client
+        client.close()
+        assert inner.is_closed is True


### PR DESCRIPTION
## Summary

Implements story 22.5 — wires `build_http_client_with_auto_auth` into `@app.callback()` in `akgentic.infra.cli.main` so every command (`team`, `message`, `reply`, `workspace`, `chat`, …) dispatches through the profile-driven HTTP client factory when `~/.akgentic/config.yaml` exists, while preserving exact pre-22.5 behaviour on machines without a config file.

- Refactor `ApiClient` with a dual-mode constructor: legacy `base_url` + `api_key` or a pre-built `httpx.Client` (keyword-only). Ownership tracked via `_owns_client` so `close()` is a no-op for externally supplied clients. All legacy call sites (`ApiClient("http://x", "k")`) keep working unchanged.
- Extend the Typer callback with a `--profile` option, silent `ConfigFileNotFoundError` fallback, and Shape P1 flag precedence: `--api-key` fully preempts OIDC (escape hatch for pre-resolved credentials), `--server` rebinds the factory-built client's `base_url` without touching auth.
- Add test seams on `main` (`_CONFIG_PATH_OVERRIDE`, `_CREDENTIALS_DIR_OVERRIDE`, `_HTTP_CLIENT_FACTORY_OVERRIDE`) mirroring the Story 22.4 login/logout pattern.
- Dedicated backward-compat regression suite (`test_callback_no_config_regression.py`) parametrized across every HTTP-using top-level command; asserts zero `OidcTokenProvider` construction, zero `build_http_client_with_auto_auth` calls, and the Authorization-header invariant on the no-config path.
- Config-present integration tests cover no-auth (AC #6) and auth + empty cache (AC #7) flows end-to-end with `httpx.MockTransport`.

Stacked on `feat/235-login-logout-auto-auth` (story 22.4) — that branch must merge first.

Relates to #237
