### PR TITLE
fix: enforce token_type == 'Bearer' at cache-write time

### DIFF
--- a/src/akgentic/infra/cli/auth/oidc.py
+++ b/src/akgentic/infra/cli/auth/oidc.py
@@ -107,7 +107,7 @@ class TokenResponse(BaseModel):
     access_token: str
     refresh_token: str | None = None
     expires_in: int
-    token_type: str = "Bearer"
+    token_type: str
 
 
 class OidcErrorResponse(BaseModel):

--- a/src/akgentic/infra/cli/auth/token_provider.py
+++ b/src/akgentic/infra/cli/auth/token_provider.py
@@ -292,7 +292,10 @@ class OidcTokenProvider:
     ) -> TokenCacheEntry:
         """Convert a :class:`TokenResponse` to a :class:`TokenCacheEntry`.
 
-        Enforces strict refresh-token presence per the module-level decision.
+        Enforces two invariants in wire-order before writing the cache:
+        (a) ``refresh_token`` must be present (strict module-level decision);
+        (b) ``token_type`` must be ``Bearer`` (case-insensitive) — ADR-021
+        §Decision 2 pins Bearer enforcement to this single cache-write funnel.
         """
         if response.refresh_token is None:
             # Strict path: we require a refresh_token to maintain the cache
@@ -301,6 +304,16 @@ class OidcTokenProvider:
             raise ReAuthRequiredError(
                 f"Token endpoint did not return a refresh_token for profile "
                 f"{self._profile_name!r}; cache purged."
+            )
+        if response.token_type.casefold() != "bearer":
+            # The downstream HTTP layer unconditionally formats the Authorization
+            # header as "Bearer <token>"; any other scheme would silently mis-wrap
+            # into an opaque 401. Purge-first to match the refresh_token branch's
+            # side-effect ordering.
+            delete_token_cache(self._profile_name, credentials_dir=self._credentials_dir)
+            raise OidcProtocolError(
+                f"Token endpoint returned unsupported token_type={response.token_type!r}; "
+                "only 'Bearer' is supported."
             )
         now = fallback_now if fallback_now is not None else self._clock()
         return TokenCacheEntry(

--- a/tests/cli/auth/test_oidc.py
+++ b/tests/cli/auth/test_oidc.py
@@ -192,6 +192,7 @@ def test_poll_slow_down_widens_interval(
                     "access_token": "a",
                     "refresh_token": "r",
                     "expires_in": 3600,
+                    "token_type": "Bearer",
                 }
             )
         raise AssertionError(request.url)
@@ -381,6 +382,7 @@ def test_get_access_token_refreshes_when_expired(
                     "access_token": "new-access",
                     "refresh_token": "new-refresh",
                     "expires_in": 3600,
+                    "token_type": "Bearer",
                 }
             )
         raise AssertionError(request.url)
@@ -533,7 +535,14 @@ def test_default_prompt_hook_writes_to_stderr(
                 }
             )
         if str(request.url) == TOKEN_ENDPOINT:
-            return _json_response({"access_token": "a", "refresh_token": "r", "expires_in": 3600})
+            return _json_response(
+                {
+                    "access_token": "a",
+                    "refresh_token": "r",
+                    "expires_in": 3600,
+                    "token_type": "Bearer",
+                }
+            )
         raise AssertionError(request.url)
 
     provider = _make_provider(
@@ -565,7 +574,7 @@ def test_refresh_response_without_refresh_token_purges_and_raises(
             return httpx.Response(200, content=_discovery_body())
         if str(request.url) == TOKEN_ENDPOINT:
             # No refresh_token in response — strict path should purge + raise.
-            return _json_response({"access_token": "a", "expires_in": 3600})
+            return _json_response({"access_token": "a", "expires_in": 3600, "token_type": "Bearer"})
         raise AssertionError(request.url)
 
     provider = _make_provider(
@@ -626,7 +635,14 @@ def test_endpoints_cached_across_calls(
             discovery_calls["n"] += 1
             return httpx.Response(200, content=_discovery_body())
         if str(request.url) == TOKEN_ENDPOINT:
-            return _json_response({"access_token": "a", "refresh_token": "r", "expires_in": 3600})
+            return _json_response(
+                {
+                    "access_token": "a",
+                    "refresh_token": "r",
+                    "expires_in": 3600,
+                    "token_type": "Bearer",
+                }
+            )
         raise AssertionError(request.url)
 
     provider = _make_provider(
@@ -668,7 +684,14 @@ def test_run_device_code_flow_uses_default_prompt_when_hook_none(
                 }
             )
         if str(request.url) == TOKEN_ENDPOINT:
-            return _json_response({"access_token": "a", "refresh_token": "r", "expires_in": 3600})
+            return _json_response(
+                {
+                    "access_token": "a",
+                    "refresh_token": "r",
+                    "expires_in": 3600,
+                    "token_type": "Bearer",
+                }
+            )
         raise AssertionError(request.url)
 
     provider = _make_provider(

--- a/tests/cli/auth/test_token_provider.py
+++ b/tests/cli/auth/test_token_provider.py
@@ -1,0 +1,276 @@
+"""Focused tests for ``_token_response_to_cache_entry``.
+
+The single funnel that validates ``refresh_token`` presence and
+``token_type == 'Bearer'`` before writing the token cache. Story 22.6 adds
+the Bearer check; the ``refresh_token`` check was shipped in Story 22.3 and
+its existing coverage in ``test_oidc.py`` is preserved.
+
+All network I/O runs through :class:`httpx.MockTransport` — NO real network.
+All filesystem I/O runs through ``tmp_path`` via the ``credentials_dir``
+seam — NEVER ``~/.akgentic/``.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+import httpx
+import pydantic
+import pytest
+
+from akgentic.infra.cli.auth import (
+    OidcTokenProvider,
+    ReAuthRequiredError,
+    TokenCacheEntry,
+    save_token_cache,
+)
+from akgentic.infra.cli.auth.oidc import OidcProtocolError, TokenResponse
+from akgentic.infra.cli.config.profile import AuthConfig, ProfileConfig
+
+# ---------------------------------------------------------------------------
+# Test seams
+# ---------------------------------------------------------------------------
+
+ISSUER = "https://issuer.example.com"
+DEVICE_AUTH_ENDPOINT = f"{ISSUER}/device-auth"
+TOKEN_ENDPOINT = f"{ISSUER}/token"
+PROFILE_NAME = "ent-prof"
+
+
+@pytest.fixture
+def auth_profile() -> ProfileConfig:
+    return ProfileConfig(
+        endpoint="https://api.example.com",  # type: ignore[arg-type]
+        auth=AuthConfig(
+            type="oidc",
+            issuer=ISSUER,  # type: ignore[arg-type]
+            client_id="akgentic-cli",
+        ),
+    )
+
+
+@pytest.fixture
+def tmp_credentials_dir(tmp_path: Path) -> Path:
+    return tmp_path / "credentials"
+
+
+def _discovery_body() -> bytes:
+    return json.dumps(
+        {
+            "device_authorization_endpoint": DEVICE_AUTH_ENDPOINT,
+            "token_endpoint": TOKEN_ENDPOINT,
+        }
+    ).encode("utf-8")
+
+
+def _json_response(payload: dict[str, Any], status: int = 200) -> httpx.Response:
+    return httpx.Response(status, content=json.dumps(payload).encode("utf-8"))
+
+
+def _make_provider(
+    auth_profile: ProfileConfig,
+    *,
+    handler: Callable[[httpx.Request], httpx.Response],
+    credentials_dir: Path,
+    clock: Callable[[], int] | None = None,
+) -> OidcTokenProvider:
+    client = httpx.Client(transport=httpx.MockTransport(handler))
+    return OidcTokenProvider(
+        auth_profile,
+        PROFILE_NAME,
+        http_client=client,
+        clock=clock if clock is not None else (lambda: 1_700_000_000),
+        sleep=lambda _s: None,
+        credentials_dir=credentials_dir,
+    )
+
+
+def _cache_file(credentials_dir: Path) -> Path:
+    return credentials_dir / f"{PROFILE_NAME}.json"
+
+
+# ---------------------------------------------------------------------------
+# Happy path — Bearer (canonical and case-insensitive)
+# ---------------------------------------------------------------------------
+
+
+def test_token_type_bearer_writes_cache(
+    auth_profile: ProfileConfig, tmp_credentials_dir: Path
+) -> None:
+    provider = _make_provider(
+        auth_profile,
+        handler=lambda _r: httpx.Response(500),  # should not be used
+        credentials_dir=tmp_credentials_dir,
+    )
+    response = TokenResponse(
+        access_token="access-abc",
+        refresh_token="refresh-xyz",
+        expires_in=3600,
+        token_type="Bearer",
+    )
+    entry = provider._token_response_to_cache_entry(response)
+    assert entry.access_token == "access-abc"
+    assert entry.refresh_token == "refresh-xyz"
+    assert entry.expires_at == 1_700_000_000 + 3600
+    provider.close()
+
+
+@pytest.mark.parametrize("token_type", ["bearer", "BEARER", "BeArEr"])
+def test_token_type_case_insensitive_bearer(
+    auth_profile: ProfileConfig, tmp_credentials_dir: Path, token_type: str
+) -> None:
+    provider = _make_provider(
+        auth_profile,
+        handler=lambda _r: httpx.Response(500),
+        credentials_dir=tmp_credentials_dir,
+    )
+    response = TokenResponse(
+        access_token="a",
+        refresh_token="r",
+        expires_in=3600,
+        token_type=token_type,
+    )
+    entry = provider._token_response_to_cache_entry(response)
+    assert entry.access_token == "a"
+    provider.close()
+
+
+# ---------------------------------------------------------------------------
+# Rejection — device-code path
+# ---------------------------------------------------------------------------
+
+
+def test_token_type_non_bearer_raises_oidc_protocol_error_device_code_path(
+    auth_profile: ProfileConfig, tmp_credentials_dir: Path
+) -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        path = request.url.path
+        if path.endswith("/.well-known/openid-configuration"):
+            return httpx.Response(200, content=_discovery_body())
+        if str(request.url) == DEVICE_AUTH_ENDPOINT:
+            return _json_response(
+                {
+                    "device_code": "dc",
+                    "user_code": "UC",
+                    "verification_uri": "https://verify.example.com",
+                    "expires_in": 600,
+                    "interval": 1,
+                }
+            )
+        if str(request.url) == TOKEN_ENDPOINT:
+            return _json_response(
+                {
+                    "access_token": "a",
+                    "refresh_token": "r",
+                    "expires_in": 3600,
+                    "token_type": "MAC",
+                }
+            )
+        raise AssertionError(request.url)
+
+    provider = _make_provider(
+        auth_profile,
+        handler=handler,
+        credentials_dir=tmp_credentials_dir,
+    )
+    with pytest.raises(OidcProtocolError) as excinfo:
+        provider.run_device_code_flow(on_user_code=lambda _a: None)
+    message = str(excinfo.value)
+    assert "Bearer" in message
+    assert "'MAC'" in message
+    # No cache file should have been created.
+    assert not _cache_file(tmp_credentials_dir).exists()
+    provider.close()
+
+
+# ---------------------------------------------------------------------------
+# Rejection — refresh path with pre-existing cache
+# ---------------------------------------------------------------------------
+
+
+def test_token_type_non_bearer_purges_existing_cache_on_refresh(
+    auth_profile: ProfileConfig, tmp_credentials_dir: Path
+) -> None:
+    now = 1_700_000_000
+    # Pre-seed a valid cache on disk so the refresh path is exercised.
+    save_token_cache(
+        PROFILE_NAME,
+        TokenCacheEntry(
+            access_token="old-access",
+            refresh_token="refresh-me",
+            expires_at=now - 60,  # already expired — forces refresh
+        ),
+        credentials_dir=tmp_credentials_dir,
+    )
+    assert _cache_file(tmp_credentials_dir).exists()
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        path = request.url.path
+        if path.endswith("/.well-known/openid-configuration"):
+            return httpx.Response(200, content=_discovery_body())
+        if str(request.url) == TOKEN_ENDPOINT:
+            return _json_response(
+                {
+                    "access_token": "new",
+                    "refresh_token": "new-refresh",
+                    "expires_in": 3600,
+                    "token_type": "DPoP",
+                }
+            )
+        raise AssertionError(request.url)
+
+    provider = _make_provider(
+        auth_profile,
+        handler=handler,
+        credentials_dir=tmp_credentials_dir,
+        clock=lambda: now,
+    )
+    with pytest.raises(OidcProtocolError) as excinfo:
+        provider.get_access_token()
+    message = str(excinfo.value)
+    assert "Bearer" in message
+    assert "'DPoP'" in message
+    # Prior cache file must be purged.
+    assert _cache_file(tmp_credentials_dir).exists() is False
+    provider.close()
+
+
+# ---------------------------------------------------------------------------
+# Structural rejection — missing token_type field
+# ---------------------------------------------------------------------------
+
+
+def test_token_response_missing_token_type_raises_validation_error() -> None:
+    payload = {
+        "access_token": "a",
+        "refresh_token": "r",
+        "expires_in": 3600,
+    }
+    with pytest.raises(pydantic.ValidationError) as excinfo:
+        TokenResponse.model_validate(payload)
+    assert "token_type" in str(excinfo.value)
+
+
+def test_reauth_required_takes_precedence_over_bearer_check(
+    auth_profile: ProfileConfig, tmp_credentials_dir: Path
+) -> None:
+    """When BOTH refresh_token is missing AND token_type is non-Bearer,
+    ReAuthRequiredError (the refresh_token guard) surfaces first — the
+    in-wire-order check documented in the funnel docstring."""
+    provider = _make_provider(
+        auth_profile,
+        handler=lambda _r: httpx.Response(500),
+        credentials_dir=tmp_credentials_dir,
+    )
+    response = TokenResponse(
+        access_token="a",
+        refresh_token=None,
+        expires_in=3600,
+        token_type="MAC",
+    )
+    with pytest.raises(ReAuthRequiredError):
+        provider._token_response_to_cache_entry(response)
+    provider.close()


### PR DESCRIPTION
## Summary

Spec-compliance remediation for Epic 22 BLOCKING finding V6 (and WARNING V3).

- `TokenResponse.token_type` is now a required field (no default). A non-compliant server that omits it produces a loud `pydantic.ValidationError` instead of silently passing through.
- `_token_response_to_cache_entry` gains a case-insensitive `Bearer` guard immediately after the existing `refresh_token` guard — same purge-first-then-raise shape. Both the device-code path and the refresh path converge on this single funnel.
- Focused unit tests in `tests/cli/auth/test_token_provider.py` cover canonical and case-insensitive acceptance, device-code rejection, refresh-path rejection with prior cache purge, missing-field structural validation, and guard precedence.
- Fixture audit: six `/token` JSON wire-mocks in `test_oidc.py` that previously relied on the removed `"Bearer"` default are now explicit.

Relates to #239. Stacked on top of #238 (branch `feat/237-wire-profile-http-client-callback`).
