### PR TITLE
feat(infra): 18.2 migrate TeamService and load_team to catalog v2

### DIFF
--- a/src/akgentic/infra/adapters/community/local_placement.py
+++ b/src/akgentic/infra/adapters/community/local_placement.py
@@ -40,17 +40,32 @@ class LocalPlacement:
         """The worker instance ID representing this process."""
         return self._instance_id
 
-    def create_team(self, team_card: TeamCard, user_id: str) -> TeamHandle:
+    def create_team(
+        self,
+        team_card: TeamCard,
+        user_id: str,
+        catalog_namespace: str | None = None,
+    ) -> TeamHandle:
         """Create a team in the local process and return a handle.
 
         Args:
             team_card: Team configuration card.
             user_id: ID of the user creating the team.
+            catalog_namespace: Opaque tag identifying the catalog namespace
+                the team was instantiated from. Forwarded verbatim to
+                ``TeamManager.create_team`` so the persisted ``Process``
+                records it. ``None`` for teams not sourced from a catalog.
 
         Returns:
             A LocalTeamHandle for interacting with the newly created team.
         """
-        logger.debug("LocalPlacement creating team: user_id=%s", user_id)
-        runtime = self._team_manager.create_team(team_card, user_id)
+        logger.debug(
+            "LocalPlacement creating team: user_id=%s, catalog_namespace=%s",
+            user_id,
+            catalog_namespace,
+        )
+        runtime = self._team_manager.create_team(
+            team_card, user_id, catalog_namespace=catalog_namespace
+        )
         logger.debug("Team created locally: team_id=%s", runtime.id)
         return LocalTeamHandle(runtime)

--- a/src/akgentic/infra/cli/client.py
+++ b/src/akgentic/infra/cli/client.py
@@ -183,9 +183,16 @@ class ApiClient:
         """GET /teams/{team_id} → TeamInfo model."""
         return TeamInfo.model_validate(self._request("GET", f"/teams/{team_id}").json())
 
-    def create_team(self, catalog_entry_id: str) -> TeamInfo:
-        """POST /teams → created TeamInfo model."""
-        resp = self._request("POST", "/teams", json={"catalog_entry_id": catalog_entry_id})
+    def create_team(self, catalog_namespace: str) -> TeamInfo:
+        """POST /teams → created TeamInfo model.
+
+        ``catalog_namespace`` is the v2 namespace holding the team entry.
+        The parameter name on the CLI entry points still reads as
+        ``catalog_entry_id`` for backward-compatibility; callers forward
+        the value verbatim and the server interprets it as a namespace
+        under v2 semantics.
+        """
+        resp = self._request("POST", "/teams", json={"catalog_namespace": catalog_namespace})
         return TeamInfo.model_validate(resp.json())
 
     def stop_team(self, team_id: str) -> None:

--- a/src/akgentic/infra/protocols/placement.py
+++ b/src/akgentic/infra/protocols/placement.py
@@ -33,12 +33,22 @@ class PlacementStrategy(Protocol):
         automatically — surface the error to the user.
     """
 
-    def create_team(self, team_card: TeamCard, user_id: str) -> TeamHandle:
+    def create_team(
+        self,
+        team_card: TeamCard,
+        user_id: str,
+        catalog_namespace: str | None = None,
+    ) -> TeamHandle:
         """Create a team on a worker instance and return a handle.
 
         Args:
             team_card: Team configuration card.
             user_id: ID of the user creating the team.
+            catalog_namespace: Opaque tag identifying the catalog namespace
+                the team was instantiated from. Forwarded through to
+                ``TeamManager.create_team`` (community tier) or the remote
+                worker (department / enterprise tiers). ``None`` for teams
+                not sourced from a v2 catalog namespace.
 
         Returns:
             A TeamHandle for interacting with the newly created team.

--- a/src/akgentic/infra/server/deps.py
+++ b/src/akgentic/infra/server/deps.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from pydantic import BaseModel, ConfigDict, Field, SkipValidation
 
+from akgentic.catalog import Catalog
 from akgentic.catalog.services import (
     AgentCatalog,
     TeamCatalog,
@@ -49,6 +50,7 @@ class TierServices(BaseModel):
     channel_registry: ChannelRegistry = Field(
         description="Registry mapping channel IDs to team IDs"
     )
+    catalog: Catalog = Field(description="v2 unified catalog service")
     team_catalog: TeamCatalog = Field(description="Catalog service for team entry resolution")
     agent_catalog: AgentCatalog = Field(description="Catalog service for agent entry resolution")
     tool_catalog: ToolCatalog = Field(description="Catalog service for tool entry resolution")

--- a/src/akgentic/infra/server/models.py
+++ b/src/akgentic/infra/server/models.py
@@ -11,7 +11,9 @@ from pydantic import BaseModel, Field
 class CreateTeamRequest(BaseModel):
     """Request body for POST /teams."""
 
-    catalog_entry_id: str = Field(description="Catalog entry ID to resolve into a TeamCard")
+    catalog_namespace: str = Field(
+        description="Catalog namespace (v2) whose team entry resolves into a TeamCard"
+    )
     params: dict[str, str] = Field(
         default_factory=dict,
         description="Pass-through configuration parameters",

--- a/src/akgentic/infra/server/routes/frontend_adapter/angular_v1/router.py
+++ b/src/akgentic/infra/server/routes/frontend_adapter/angular_v1/router.py
@@ -134,9 +134,9 @@ def create_process(
     from akgentic.catalog.models.errors import EntryNotFoundError
 
     try:
-        process = service.create_team(catalog_entry_id=type, user_id="anonymous")
+        process = service.create_team(catalog_namespace=type, user_id="anonymous")
     except EntryNotFoundError:
-        raise HTTPException(status_code=404, detail="Catalog entry not found") from None
+        raise HTTPException(status_code=404, detail="Catalog namespace not found") from None
     return _to_v1_process_context(process)
 
 

--- a/src/akgentic/infra/server/routes/teams.py
+++ b/src/akgentic/infra/server/routes/teams.py
@@ -48,18 +48,21 @@ def create_team(
     body: CreateTeamRequest,
     service: TeamService = Depends(get_team_service),
 ) -> TeamResponse:
-    """Create a new team from a catalog entry."""
-    logger.info("POST /teams — catalog_entry=%s", body.catalog_entry_id)
+    """Create a new team from a catalog namespace."""
+    logger.info("POST /teams — catalog_namespace=%s", body.catalog_namespace)
     try:
         # Community-tier hardcoded identity. Department/enterprise tiers must
         # replace with authenticated user identity from auth middleware.
         process = service.create_team(
-            catalog_entry_id=body.catalog_entry_id,
+            catalog_namespace=body.catalog_namespace,
             user_id="anonymous",
         )
     except EntryNotFoundError:
-        logger.warning("Team creation failed: catalog entry %s not found", body.catalog_entry_id)
-        raise HTTPException(status_code=404, detail="Catalog entry not found") from None
+        logger.warning(
+            "Team creation failed: catalog namespace %s not found",
+            body.catalog_namespace,
+        )
+        raise HTTPException(status_code=404, detail="Catalog namespace not found") from None
     return _process_to_response(process)
 
 
@@ -141,9 +144,7 @@ def send_message_from_to(
     service: TeamService = Depends(get_team_service),
 ) -> None:
     """Send a message from a specific agent to another agent in a running team."""
-    logger.info(
-        "POST /teams/%s/message/from/%s/to/%s", team_id, sender_name, recipient_name
-    )
+    logger.info("POST /teams/%s/message/from/%s/to/%s", team_id, sender_name, recipient_name)
     try:
         service.send_message_from_to(team_id, sender_name, recipient_name, body.content)
     except ValueError as exc:

--- a/src/akgentic/infra/server/services/team_service.py
+++ b/src/akgentic/infra/server/services/team_service.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 import uuid
 
-from akgentic.catalog.models.errors import EntryNotFoundError
+from akgentic.catalog.models.errors import CatalogValidationError, EntryNotFoundError
 from akgentic.core.messages.message import Message
 from akgentic.core.messages.orchestrator import SentMessage
 from akgentic.infra.protocols.event_stream import EventStream
@@ -30,22 +30,39 @@ class TeamService:
         self._services = services
         self._cache: RuntimeCache = services.runtime_cache
 
-    def create_team(self, catalog_entry_id: str, user_id: str) -> Process:
-        """Resolve catalog entry and create a running team.
+    def create_team(self, catalog_namespace: str, user_id: str) -> Process:
+        """Resolve a catalog namespace to a TeamCard and create a running team.
+
+        Loads the team definition via the v2 unified ``Catalog.load_team``
+        API and forwards the namespace tag through placement so that the
+        persisted ``Process.catalog_namespace`` records the binding.
+
+        Args:
+            catalog_namespace: v2 catalog namespace holding exactly one
+                ``kind="team"`` entry.
+            user_id: Identifier of the user creating the team.
+
+        Returns:
+            The persisted ``Process`` for the newly created team.
 
         Raises:
-            EntryNotFoundError: If catalog_entry_id is not found.
+            EntryNotFoundError: If ``catalog_namespace`` has no team entry.
+                ``Catalog.load_team`` surfaces the condition as
+                ``CatalogValidationError``; this layer translates it so
+                the existing teams router's ``EntryNotFoundError → 404``
+                handler applies unchanged.
         """
-        logger.debug("Resolving catalog entry: %s", catalog_entry_id)
-        entry = self._services.team_catalog.get(catalog_entry_id)
-        if entry is None:
-            raise EntryNotFoundError(catalog_entry_id)
-        team_card = entry.to_team_card(
-            self._services.agent_catalog,
-            self._services.tool_catalog,
-            self._services.template_catalog,
+        logger.debug("Resolving team for catalog namespace: %s", catalog_namespace)
+        try:
+            team_card = self._services.catalog.load_team(catalog_namespace)
+        except CatalogValidationError as exc:
+            # Translate v2's validation error into the existing 404-mapped
+            # exception so the teams router's error-handling stays a no-op
+            # for this story (Story 18.3 consolidates error handling).
+            raise EntryNotFoundError(catalog_namespace) from exc
+        handle = self._services.placement.create_team(
+            team_card, user_id, catalog_namespace=catalog_namespace
         )
-        handle = self._services.placement.create_team(team_card, user_id)
         self._cache.store(handle.team_id, handle)
         # Consistency invariant: create_team() writes to event store, so
         # get_team() must find it immediately. If this fires, there is a bug
@@ -54,7 +71,11 @@ class TeamService:
         if process is None:  # pragma: no cover
             msg = f"Team {handle.team_id} was created but not found in event store"
             raise RuntimeError(msg)
-        logger.info("Team created: team_id=%s, catalog_entry=%s", process.team_id, catalog_entry_id)
+        logger.info(
+            "Team created: team_id=%s, catalog_namespace=%s",
+            process.team_id,
+            catalog_namespace,
+        )
         return process
 
     def list_teams(self, user_id: str) -> list[Process]:

--- a/src/akgentic/infra/wiring.py
+++ b/src/akgentic/infra/wiring.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import logging
 
+from akgentic.catalog import Catalog, YamlEntryRepository
 from akgentic.catalog.repositories.yaml import (
     YamlAgentCatalogRepository,
     YamlTeamCatalogRepository,
@@ -56,6 +57,9 @@ def wire_community(settings: CommunitySettings) -> CommunityServices:
     event_stream = LocalEventStream()
     actor_system, team_manager = _build_actor_layer(event_store, service_registry, event_stream)
     catalogs = _build_catalogs(settings)
+    # v2 unified catalog — lives alongside the four v1 catalogs during the
+    # 18.2 → 18.3 handoff. Story 18.3 removes the v1 fields.
+    catalog = Catalog(repository=YamlEntryRepository(root=settings.catalog_path))
 
     local_placement = LocalPlacement(team_manager, service_registry)
     local_worker_handle = LocalWorkerHandle(team_manager, service_registry, actor_system)
@@ -85,6 +89,7 @@ def wire_community(settings: CommunitySettings) -> CommunityServices:
         actor_system=actor_system,
         team_manager=team_manager,
         channel_parser_registry=ChannelParserRegistry(channels_config={}),
+        catalog=catalog,
         team_catalog=catalogs[0],
         agent_catalog=catalogs[1],
         tool_catalog=catalogs[2],

--- a/src/akgentic/infra/worker/routes/teams.py
+++ b/src/akgentic/infra/worker/routes/teams.py
@@ -72,7 +72,7 @@ def create_team(
 ) -> TeamResponse:
     """Create a new team from a pre-resolved TeamCard.
 
-    The server resolves catalog_entry_id to a TeamCard and forwards it
+    The server resolves the catalog namespace to a TeamCard and forwards it
     to the worker. The worker calls team_manager.create_team() directly.
     """
     logger.info("POST /teams — user_id=%s", body.user_id)

--- a/tests/adapters/community/test_local_placement.py
+++ b/tests/adapters/community/test_local_placement.py
@@ -32,10 +32,12 @@ class TestLocalPlacementProtocolCompliance:
         assert callable(adapter.create_team)
 
     def test_create_team_signature_matches_protocol(self) -> None:
-        """create_team has team_card and user_id parameters matching PlacementStrategy."""
+        """create_team has team_card, user_id, and catalog_namespace parameters."""
         sig = inspect.signature(LocalPlacement.create_team)
         assert "team_card" in sig.parameters
         assert "user_id" in sig.parameters
+        assert "catalog_namespace" in sig.parameters
+        assert sig.parameters["catalog_namespace"].default is None
 
 
 class TestLocalPlacementBehavior:
@@ -48,7 +50,20 @@ class TestLocalPlacementBehavior:
         adapter = LocalPlacement(team_manager, service_registry)
         team_card = MagicMock()
         adapter.create_team(team_card, "user-1")
-        team_manager.create_team.assert_called_once_with(team_card, "user-1")
+        team_manager.create_team.assert_called_once_with(
+            team_card, "user-1", catalog_namespace=None
+        )
+
+    def test_create_team_forwards_catalog_namespace(self) -> None:
+        """create_team forwards catalog_namespace to TeamManager.create_team."""
+        team_manager = MagicMock()
+        service_registry = MagicMock()
+        adapter = LocalPlacement(team_manager, service_registry)
+        team_card = MagicMock()
+        adapter.create_team(team_card, "user-1", catalog_namespace="ns-abc")
+        team_manager.create_team.assert_called_once_with(
+            team_card, "user-1", catalog_namespace="ns-abc"
+        )
 
     def test_create_team_returns_local_team_handle(self) -> None:
         """create_team wraps TeamManager result in LocalTeamHandle."""

--- a/tests/cli/test_cli_client.py
+++ b/tests/cli/test_cli_client.py
@@ -89,7 +89,7 @@ class TestCreateTeam:
         result = client.create_team("my-entry")
         assert isinstance(result, TeamInfo)
         assert result.team_id == "abc"
-        assert sent_bodies[0] == {"catalog_entry_id": "my-entry"}
+        assert sent_bodies[0] == {"catalog_namespace": "my-entry"}
 
 
 class TestStopTeam:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -34,7 +34,19 @@ def _write_yaml(path: Path, data: dict[str, object]) -> None:
 
 
 def _seed_catalog(catalog_root: Path) -> None:
-    """Create minimal YAML catalog entries for a test team."""
+    """Create minimal YAML catalog entries for a test team.
+
+    Seeds BOTH v1 (per-kind dir layout under ``teams/``, ``agents/``,
+    ``tools/``, ``templates/``) AND v2 (per-namespace dir layout under
+    ``{namespace}/{kind}/{id}.yaml``) so the community wiring can expose a
+    working v1 four-catalog stack alongside the v2 ``Catalog`` that Story
+    18.2 adds. Uses the namespace ``test-team`` so tests can post
+    ``catalog_namespace="test-team"`` and hit the v2 code path, while the
+    v1 entry id is also ``test-team`` so legacy tests that still use
+    ``catalog_entry_id="test-team"`` resolve via the v2 API (the router
+    now forwards ``catalog_namespace`` either way).
+    """
+    # --- v1 layout (kept in place through Story 18.2; removed in 18.3) -----
     _write_yaml(
         catalog_root / "agents" / "human-proxy.yaml",
         {
@@ -82,6 +94,77 @@ def _seed_catalog(catalog_root: Path) -> None:
     # Empty dirs for templates and tools (no entries needed for this team)
     (catalog_root / "templates").mkdir(parents=True, exist_ok=True)
     (catalog_root / "tools").mkdir(parents=True, exist_ok=True)
+
+    # --- v2 unified-entry namespace bundle ----------------------------------
+    # Layout: {catalog_root}/{namespace}/{kind}/{id}.yaml
+    _seed_v2_namespace(catalog_root, namespace="test-team")
+
+
+_TEAM_CARD_TYPE = "akgentic.team.models.TeamCard"
+
+
+def _seed_v2_namespace(catalog_root: Path, namespace: str) -> None:
+    """Write a minimal v2 team-namespace bundle into ``catalog_root``.
+
+    Mirrors the v1 ``Test Team`` definition so the same fixture exercises
+    both the v1 four-catalog pipeline and the v2 ``Catalog.load_team``
+    pipeline. The ``TeamCard`` payload shape is taken from
+    ``akgentic.team.models.TeamCard``; every agent_class / model_type
+    string satisfies the v2 allowlist (``akgentic.*``).
+
+    The member configs use plain ``akgentic.core.agent.Akgent`` (which
+    expects ``BaseConfig``) because the v2 resolver hydrates
+    ``AgentCard.config`` against the declared annotation (``BaseConfig``)
+    and does not upgrade to the agent-class's specific ``ConfigType``
+    subclass the way v1's ``AgentEntry.resolve_config`` validator does.
+    Upgrading v2 to per-agent-class config types is out of scope for
+    Story 18.2 (tracked as part of Epic 19's v1 removal). Tests that
+    only need the agents to *exist* and route messages by name work
+    with the plain base class.
+    """
+    team_payload = {
+        "name": "Test Team",
+        "description": "v2 test team for infra tests",
+        "entry_point": {
+            "card": {
+                "role": "Human",
+                "description": "Human user interface",
+                "skills": [],
+                "agent_class": "akgentic.core.agent.Akgent",
+                "config": {"name": "@Human", "role": "Human"},
+                "routes_to": ["@Manager"],
+            },
+            "headcount": 1,
+            "members": [],
+        },
+        "members": [
+            {
+                "card": {
+                    "role": "Manager",
+                    "description": "Test manager agent",
+                    "skills": ["coordination"],
+                    "agent_class": "akgentic.core.agent.Akgent",
+                    "config": {"name": "@Manager", "role": "Manager"},
+                    "routes_to": [],
+                },
+                "headcount": 1,
+                "members": [],
+            },
+        ],
+        "message_types": [{"__type__": "akgentic.core.messages.UserMessage"}],
+        "agent_profiles": [],
+    }
+    _write_yaml(
+        catalog_root / namespace / "team" / "team.yaml",
+        {
+            "id": "team",
+            "kind": "team",
+            "namespace": namespace,
+            "model_type": _TEAM_CARD_TYPE,
+            "description": "v2 test team namespace bundle",
+            "payload": team_payload,
+        },
+    )
 
 
 @pytest.fixture(autouse=True)

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -49,7 +49,7 @@ def poll_until(
 
 def create_team(client: httpx.Client) -> str:
     """Create a team and return team_id."""
-    resp = client.post("/teams/", json={"catalog_entry_id": CATALOG_ENTRY_ID})
+    resp = client.post("/teams/", json={"catalog_namespace": CATALOG_ENTRY_ID})
     assert resp.status_code == 201, f"Expected 201, got {resp.status_code}: {resp.text}"
     data: dict[str, Any] = resp.json()
     assert data["status"] == "running"

--- a/tests/e2e/test_rest_api.py
+++ b/tests/e2e/test_rest_api.py
@@ -45,7 +45,7 @@ def test_e2e_create_team(e2e_http_client: httpx.Client) -> None:
     try:
         resp = e2e_http_client.post(
             "/teams/",
-            json={"catalog_entry_id": CATALOG_ENTRY_ID},
+            json={"catalog_namespace": CATALOG_ENTRY_ID},
         )
         assert resp.status_code == 201
         data = resp.json()

--- a/tests/frontend_adapter/test_frontend_adapter.py
+++ b/tests/frontend_adapter/test_frontend_adapter.py
@@ -284,7 +284,7 @@ class TestWebSocketAdapterIntegration:
 
     def test_ws_sends_v2_format_without_adapter(self, client: TestClient) -> None:
         """AC #1: No adapter — events sent in V2 format (existing behavior)."""
-        resp = client.post("/teams/", json={"catalog_entry_id": "test-team"})
+        resp = client.post("/teams/", json={"catalog_namespace": "test-team"})
         assert resp.status_code == 201
         team_id = resp.json()["team_id"]
 
@@ -301,7 +301,7 @@ class TestWebSocketAdapterIntegration:
         """AC #1: Adapter present — wrap_ws_event is called."""
         resp = client_with_adapter.post(
             "/teams/",
-            json={"catalog_entry_id": "test-team"},
+            json={"catalog_namespace": "test-team"},
         )
         assert resp.status_code == 201
         team_id = resp.json()["team_id"]

--- a/tests/integration/_helpers.py
+++ b/tests/integration/_helpers.py
@@ -89,7 +89,7 @@ def make_integration_session(cli_server_url: str, team_id: str) -> ChatSession:
 
 def create_team(client: TestClient) -> str:
     """POST /teams and return the team_id."""
-    resp = client.post("/teams/", json={"catalog_entry_id": CATALOG_ENTRY_ID})
+    resp = client.post("/teams/", json={"catalog_namespace": CATALOG_ENTRY_ID})
     assert resp.status_code == 201
     data = resp.json()
     assert data["status"] == "running"
@@ -191,6 +191,91 @@ def seed_integration_catalog(catalog_root: Path) -> None:
     )
     (catalog_root / "templates").mkdir(parents=True, exist_ok=True)
     (catalog_root / "tools").mkdir(parents=True, exist_ok=True)
+    _seed_v2_integration_namespace(catalog_root, namespace="test-team")
+
+
+_INTEGRATION_TEAM_CARD_TYPE = "akgentic.team.models.TeamCard"
+
+
+def _seed_v2_integration_namespace(catalog_root: Path, namespace: str) -> None:
+    """Seed a v2 team-namespace bundle matching the v1 integration team.
+
+    Laid out under ``{catalog_root}/{namespace}/team/team.yaml`` so
+    ``YamlEntryRepository.list_by_namespace(namespace)`` can resolve
+    ``Catalog.load_team(namespace)`` to a ``TeamCard`` equivalent to the
+    v1 fixture above.
+    """
+    # v2 does not upgrade ``AgentCard.config`` to the agent-class's
+    # ConfigType subclass the way v1's ``AgentEntry.resolve_config``
+    # validator does. To get an ``AgentConfig`` instance (with
+    # ``prompt`` / ``model_cfg`` fields) on a member card, this fixture
+    # uses the ``__model__`` serialization marker
+    # (``akgentic.core.utils.deserializer.deserialize_object``) which
+    # imports the declared class and constructs it before pydantic
+    # finalises the ``AgentCard`` instance. Subclass assignment is
+    # then accepted because ``AgentConfig`` is a ``BaseConfig``.
+    team_payload = {
+        "name": "Integration Test Team",
+        "description": "v2 integration test team",
+        "entry_point": {
+            "card": {
+                "role": "Human",
+                "description": "Human user interface",
+                "skills": [],
+                "agent_class": "akgentic.agent.HumanProxy",
+                "config": {"name": "@Human", "role": "Human"},
+                "routes_to": ["@Manager"],
+            },
+            "headcount": 1,
+            "members": [],
+        },
+        "members": [
+            {
+                "card": {
+                    "role": "Manager",
+                    "description": "Integration test manager agent",
+                    "skills": ["coordination"],
+                    "agent_class": "akgentic.agent.BaseAgent",
+                    "config": {
+                        "__model__": "akgentic.agent.config.AgentConfig",
+                        "name": "@Manager",
+                        "role": "Manager",
+                        "prompt": {
+                            "template": (
+                                "You are a helpful assistant. "
+                                "Reply concisely in one or two sentences."
+                            ),
+                        },
+                        "model_cfg": {
+                            "provider": "openai",
+                            "model": "gpt-4o-mini",
+                            "temperature": 0.0,
+                        },
+                        "usage_limits": {
+                            "request_limit": 5,
+                            "total_tokens_limit": 10000,
+                        },
+                    },
+                    "routes_to": [],
+                },
+                "headcount": 1,
+                "members": [],
+            },
+        ],
+        "message_types": [{"__type__": "akgentic.agent.AgentMessage"}],
+        "agent_profiles": [],
+    }
+    _write_yaml(
+        catalog_root / namespace / "team" / "team.yaml",
+        {
+            "id": "team",
+            "kind": "team",
+            "namespace": namespace,
+            "model_type": _INTEGRATION_TEAM_CARD_TYPE,
+            "description": "v2 integration test team namespace bundle",
+            "payload": team_payload,
+        },
+    )
 
 
 def poll_until(

--- a/tests/integration/test_channels.py
+++ b/tests/integration/test_channels.py
@@ -141,7 +141,7 @@ class TestChannelReply:
     ) -> None:
         create_resp = channel_client.post(
             "/teams/",
-            json={"catalog_entry_id": "test-team"},
+            json={"catalog_namespace": "test-team"},
         )
         assert create_resp.status_code == 201
         team_id = create_resp.json()["team_id"]
@@ -242,7 +242,7 @@ class TestDispatcherRestoreSuppression:
     ) -> None:
         create_resp = channel_client.post(
             "/teams/",
-            json={"catalog_entry_id": "test-team"},
+            json={"catalog_namespace": "test-team"},
         )
         assert create_resp.status_code == 201
         team_id = create_resp.json()["team_id"]

--- a/tests/integration/test_repl_commands.py
+++ b/tests/integration/test_repl_commands.py
@@ -51,10 +51,10 @@ class TestReplTeamLifecycle:
     ) -> None:
         """AC #1: /teams lists teams with status indicators."""
         # Create 2 teams via REST
-        resp1 = integration_client.post("/teams/", json={"catalog_entry_id": CATALOG_ENTRY_ID})
+        resp1 = integration_client.post("/teams/", json={"catalog_namespace": CATALOG_ENTRY_ID})
         assert resp1.status_code == 201
         team1_id = resp1.json()["team_id"]
-        resp2 = integration_client.post("/teams/", json={"catalog_entry_id": CATALOG_ENTRY_ID})
+        resp2 = integration_client.post("/teams/", json={"catalog_namespace": CATALOG_ENTRY_ID})
         assert resp2.status_code == 201
         team2_id = resp2.json()["team_id"]
 
@@ -92,7 +92,7 @@ class TestReplTeamLifecycle:
     ) -> None:
         """AC #2: /create creates team and auto-switches session to it."""
         # Create initial team
-        resp = integration_client.post("/teams/", json={"catalog_entry_id": CATALOG_ENTRY_ID})
+        resp = integration_client.post("/teams/", json={"catalog_namespace": CATALOG_ENTRY_ID})
         assert resp.status_code == 201
         initial_team_id = resp.json()["team_id"]
 
@@ -126,7 +126,7 @@ class TestReplTeamLifecycle:
         capsys: pytest.CaptureFixture[str],
     ) -> None:
         """AC #3: /delete deletes team after confirmation."""
-        resp = integration_client.post("/teams/", json={"catalog_entry_id": CATALOG_ENTRY_ID})
+        resp = integration_client.post("/teams/", json={"catalog_namespace": CATALOG_ENTRY_ID})
         assert resp.status_code == 201
         team_id = resp.json()["team_id"]
 
@@ -156,7 +156,7 @@ class TestReplTeamLifecycle:
         capsys: pytest.CaptureFixture[str],
     ) -> None:
         """AC #4: /info shows current team details."""
-        resp = integration_client.post("/teams/", json={"catalog_entry_id": CATALOG_ENTRY_ID})
+        resp = integration_client.post("/teams/", json={"catalog_namespace": CATALOG_ENTRY_ID})
         assert resp.status_code == 201
         team_id = resp.json()["team_id"]
 
@@ -185,10 +185,10 @@ class TestReplTeamLifecycle:
         capsys: pytest.CaptureFixture[str],
     ) -> None:
         """AC #4: /info <team_id> shows a different team's details."""
-        resp1 = integration_client.post("/teams/", json={"catalog_entry_id": CATALOG_ENTRY_ID})
+        resp1 = integration_client.post("/teams/", json={"catalog_namespace": CATALOG_ENTRY_ID})
         assert resp1.status_code == 201
         team1_id = resp1.json()["team_id"]
-        resp2 = integration_client.post("/teams/", json={"catalog_entry_id": CATALOG_ENTRY_ID})
+        resp2 = integration_client.post("/teams/", json={"catalog_namespace": CATALOG_ENTRY_ID})
         assert resp2.status_code == 201
         team2_id = resp2.json()["team_id"]
 
@@ -216,7 +216,7 @@ class TestReplTeamLifecycle:
         capsys: pytest.CaptureFixture[str],
     ) -> None:
         """AC #5: /events shows raw team events."""
-        resp = integration_client.post("/teams/", json={"catalog_entry_id": CATALOG_ENTRY_ID})
+        resp = integration_client.post("/teams/", json={"catalog_namespace": CATALOG_ENTRY_ID})
         assert resp.status_code == 201
         team_id = resp.json()["team_id"]
 
@@ -255,10 +255,10 @@ class TestReplTeamLifecycle:
         capsys: pytest.CaptureFixture[str],
     ) -> None:
         """AC #6: /restore restores a stopped team and auto-switches."""
-        resp1 = integration_client.post("/teams/", json={"catalog_entry_id": CATALOG_ENTRY_ID})
+        resp1 = integration_client.post("/teams/", json={"catalog_namespace": CATALOG_ENTRY_ID})
         assert resp1.status_code == 201
         team1_id = resp1.json()["team_id"]
-        resp2 = integration_client.post("/teams/", json={"catalog_entry_id": CATALOG_ENTRY_ID})
+        resp2 = integration_client.post("/teams/", json={"catalog_namespace": CATALOG_ENTRY_ID})
         assert resp2.status_code == 201
         team2_id = resp2.json()["team_id"]
 
@@ -302,7 +302,7 @@ class TestReplCatalog:
     ) -> None:
         """AC #7: /catalog lists available team templates."""
         # Need a team for the session
-        resp = integration_client.post("/teams/", json={"catalog_entry_id": CATALOG_ENTRY_ID})
+        resp = integration_client.post("/teams/", json={"catalog_namespace": CATALOG_ENTRY_ID})
         assert resp.status_code == 201
         team_id = resp.json()["team_id"]
 
@@ -337,7 +337,7 @@ class TestReplImplicitReply:
         integration_client: TestClient,
     ) -> None:
         """AC #8: _render_event sets pending reply state on HumanInput event."""
-        resp = integration_client.post("/teams/", json={"catalog_entry_id": CATALOG_ENTRY_ID})
+        resp = integration_client.post("/teams/", json={"catalog_namespace": CATALOG_ENTRY_ID})
         assert resp.status_code == 201
         team_id = resp.json()["team_id"]
 
@@ -375,7 +375,7 @@ class TestReplImplicitReply:
         integration_client: TestClient,
     ) -> None:
         """AC #8: pending reply state is consumed when plain text is sent."""
-        resp = integration_client.post("/teams/", json={"catalog_entry_id": CATALOG_ENTRY_ID})
+        resp = integration_client.post("/teams/", json={"catalog_namespace": CATALOG_ENTRY_ID})
         assert resp.status_code == 201
         team_id = resp.json()["team_id"]
 

--- a/tests/integration/test_smoke.py
+++ b/tests/integration/test_smoke.py
@@ -12,11 +12,11 @@ from __future__ import annotations
 from typing import Any
 
 import pytest
+from akgentic.core.messages.message import Message
+from akgentic.core.utils.deserializer import deserialize_object
 from fastapi.testclient import TestClient
 from rich.console import Console
 
-from akgentic.core.messages.message import Message
-from akgentic.core.utils.deserializer import deserialize_object
 from akgentic.infra.cli.renderers import RichRenderer
 from akgentic.infra.cli.repl import _render_event_impl
 
@@ -94,7 +94,7 @@ def test_smoke_create_team(smoke_client: TestClient) -> None:
     """POST /teams/ creates a running team."""
     team_id: str | None = None
     try:
-        resp = smoke_client.post("/teams/", json={"catalog_entry_id": CATALOG_ENTRY_ID})
+        resp = smoke_client.post("/teams/", json={"catalog_namespace": CATALOG_ENTRY_ID})
         assert resp.status_code == 201
         data = resp.json()
         assert data["status"] == "running"

--- a/tests/integration/test_spec_channels.py
+++ b/tests/integration/test_spec_channels.py
@@ -36,7 +36,7 @@ class TestFormEncodedWebhook:
         # Create a team first so we can use reply flow (no LLM initiation)
         create_resp = channel_client.post(
             "/teams/",
-            json={"catalog_entry_id": "test-team"},
+            json={"catalog_namespace": "test-team"},
         )
         assert create_resp.status_code == 201
         team_id = create_resp.json()["team_id"]

--- a/tests/integration/test_team_lifecycle.py
+++ b/tests/integration/test_team_lifecycle.py
@@ -59,7 +59,7 @@ def _has_llm_content(events: list[dict[str, object]]) -> bool:
 
 def _create_team(client: TestClient) -> str:
     """POST /teams and return the team_id."""
-    resp = client.post("/teams/", json={"catalog_entry_id": CATALOG_ENTRY_ID})
+    resp = client.post("/teams/", json={"catalog_namespace": CATALOG_ENTRY_ID})
     assert resp.status_code == 201
     data = resp.json()
     assert data["status"] == "running"

--- a/tests/server/models/test_server_models.py
+++ b/tests/server/models/test_server_models.py
@@ -17,16 +17,16 @@ from akgentic.infra.server.models import (
 
 
 def test_create_team_request_minimal() -> None:
-    """CreateTeamRequest requires only catalog_entry_id."""
-    req = CreateTeamRequest(catalog_entry_id="test-team")
-    assert req.catalog_entry_id == "test-team"
+    """CreateTeamRequest requires only catalog_namespace."""
+    req = CreateTeamRequest(catalog_namespace="test-team")
+    assert req.catalog_namespace == "test-team"
     assert req.params == {}
 
 
 def test_create_team_request_with_params() -> None:
     """CreateTeamRequest accepts optional params."""
     req = CreateTeamRequest(
-        catalog_entry_id="test-team",
+        catalog_namespace="test-team",
         params={"key": "value"},
     )
     assert req.params == {"key": "value"}

--- a/tests/server/routes/test_team_action_routes.py
+++ b/tests/server/routes/test_team_action_routes.py
@@ -9,7 +9,7 @@ from fastapi.testclient import TestClient
 
 def test_send_message_success(client: TestClient) -> None:
     """POST /teams/{id}/message on running team returns 204."""
-    create_resp = client.post("/teams/", json={"catalog_entry_id": "test-team"})
+    create_resp = client.post("/teams/", json={"catalog_namespace": "test-team"})
     team_id = create_resp.json()["team_id"]
     resp = client.post(f"/teams/{team_id}/message", json={"content": "hello"})
     assert resp.status_code == 204
@@ -26,7 +26,7 @@ def test_send_message_not_found(client: TestClient) -> None:
 
 def test_send_message_stopped_team(client: TestClient) -> None:
     """POST /teams/{id}/message on stopped team returns 409."""
-    create_resp = client.post("/teams/", json={"catalog_entry_id": "test-team"})
+    create_resp = client.post("/teams/", json={"catalog_namespace": "test-team"})
     team_id = create_resp.json()["team_id"]
     client.post(f"/teams/{team_id}/stop")
     resp = client.post(f"/teams/{team_id}/message", json={"content": "hello"})
@@ -35,7 +35,7 @@ def test_send_message_stopped_team(client: TestClient) -> None:
 
 def test_send_message_to_agent_success(client: TestClient) -> None:
     """POST /teams/{id}/message/{agent} on running team returns 204."""
-    create_resp = client.post("/teams/", json={"catalog_entry_id": "test-team"})
+    create_resp = client.post("/teams/", json={"catalog_namespace": "test-team"})
     team_id = create_resp.json()["team_id"]
     resp = client.post(f"/teams/{team_id}/message/@Manager", json={"content": "hello"})
     assert resp.status_code == 204
@@ -52,7 +52,7 @@ def test_send_message_to_agent_not_found_team(client: TestClient) -> None:
 
 def test_send_message_to_agent_stopped_team(client: TestClient) -> None:
     """POST /teams/{id}/message/{agent} on stopped team returns 409."""
-    create_resp = client.post("/teams/", json={"catalog_entry_id": "test-team"})
+    create_resp = client.post("/teams/", json={"catalog_namespace": "test-team"})
     team_id = create_resp.json()["team_id"]
     client.post(f"/teams/{team_id}/stop")
     resp = client.post(f"/teams/{team_id}/message/@Manager", json={"content": "hello"})
@@ -61,7 +61,7 @@ def test_send_message_to_agent_stopped_team(client: TestClient) -> None:
 
 def test_send_message_to_agent_unknown_agent(client: TestClient) -> None:
     """POST /teams/{id}/message/{agent} with unknown agent returns 404."""
-    create_resp = client.post("/teams/", json={"catalog_entry_id": "test-team"})
+    create_resp = client.post("/teams/", json={"catalog_namespace": "test-team"})
     team_id = create_resp.json()["team_id"]
     resp = client.post(f"/teams/{team_id}/message/ghost", json={"content": "hello"})
     assert resp.status_code == 404
@@ -69,7 +69,7 @@ def test_send_message_to_agent_unknown_agent(client: TestClient) -> None:
 
 def test_send_message_from_to_success(client: TestClient) -> None:
     """POST /teams/{id}/message/from/{sender}/to/{recipient} returns 204."""
-    create_resp = client.post("/teams/", json={"catalog_entry_id": "test-team"})
+    create_resp = client.post("/teams/", json={"catalog_namespace": "test-team"})
     team_id = create_resp.json()["team_id"]
     resp = client.post(
         f"/teams/{team_id}/message/from/@Human/to/@Manager",
@@ -89,7 +89,7 @@ def test_send_message_from_to_not_found_team(client: TestClient) -> None:
 
 def test_send_message_from_to_stopped_team(client: TestClient) -> None:
     """POST send_from_to on stopped team returns 409."""
-    create_resp = client.post("/teams/", json={"catalog_entry_id": "test-team"})
+    create_resp = client.post("/teams/", json={"catalog_namespace": "test-team"})
     team_id = create_resp.json()["team_id"]
     client.post(f"/teams/{team_id}/stop")
     resp = client.post(
@@ -101,7 +101,7 @@ def test_send_message_from_to_stopped_team(client: TestClient) -> None:
 
 def test_send_message_from_to_unknown_sender(client: TestClient) -> None:
     """POST send_from_to with unknown sender returns 404."""
-    create_resp = client.post("/teams/", json={"catalog_entry_id": "test-team"})
+    create_resp = client.post("/teams/", json={"catalog_namespace": "test-team"})
     team_id = create_resp.json()["team_id"]
     resp = client.post(
         f"/teams/{team_id}/message/from/@Ghost/to/@Manager",
@@ -112,7 +112,7 @@ def test_send_message_from_to_unknown_sender(client: TestClient) -> None:
 
 def test_send_message_from_to_unknown_recipient(client: TestClient) -> None:
     """POST send_from_to with unknown recipient returns 404."""
-    create_resp = client.post("/teams/", json={"catalog_entry_id": "test-team"})
+    create_resp = client.post("/teams/", json={"catalog_namespace": "test-team"})
     team_id = create_resp.json()["team_id"]
     resp = client.post(
         f"/teams/{team_id}/message/from/@Human/to/@Ghost",
@@ -132,7 +132,7 @@ def test_human_input_not_found_team(client: TestClient) -> None:
 
 def test_human_input_invalid_message(client: TestClient) -> None:
     """POST /teams/{id}/human-input with invalid message_id returns 404."""
-    create_resp = client.post("/teams/", json={"catalog_entry_id": "test-team"})
+    create_resp = client.post("/teams/", json={"catalog_namespace": "test-team"})
     team_id = create_resp.json()["team_id"]
     resp = client.post(
         f"/teams/{team_id}/human-input",
@@ -143,7 +143,7 @@ def test_human_input_invalid_message(client: TestClient) -> None:
 
 def test_stop_team_success(client: TestClient) -> None:
     """POST /teams/{id}/stop on running team returns 204."""
-    create_resp = client.post("/teams/", json={"catalog_entry_id": "test-team"})
+    create_resp = client.post("/teams/", json={"catalog_namespace": "test-team"})
     team_id = create_resp.json()["team_id"]
     resp = client.post(f"/teams/{team_id}/stop")
     assert resp.status_code == 204
@@ -154,7 +154,7 @@ def test_stop_team_success(client: TestClient) -> None:
 
 def test_stop_team_already_stopped(client: TestClient) -> None:
     """POST /teams/{id}/stop on already stopped team returns 409."""
-    create_resp = client.post("/teams/", json={"catalog_entry_id": "test-team"})
+    create_resp = client.post("/teams/", json={"catalog_namespace": "test-team"})
     team_id = create_resp.json()["team_id"]
     client.post(f"/teams/{team_id}/stop")
     resp = client.post(f"/teams/{team_id}/stop")
@@ -169,7 +169,7 @@ def test_stop_team_not_found(client: TestClient) -> None:
 
 def test_restore_team_success(client: TestClient) -> None:
     """POST /teams/{id}/restore on stopped team returns 200 + TeamResponse."""
-    create_resp = client.post("/teams/", json={"catalog_entry_id": "test-team"})
+    create_resp = client.post("/teams/", json={"catalog_namespace": "test-team"})
     team_id = create_resp.json()["team_id"]
     client.post(f"/teams/{team_id}/stop")
     resp = client.post(f"/teams/{team_id}/restore")
@@ -181,7 +181,7 @@ def test_restore_team_success(client: TestClient) -> None:
 
 def test_restore_team_already_running(client: TestClient) -> None:
     """POST /teams/{id}/restore on already running team returns 409."""
-    create_resp = client.post("/teams/", json={"catalog_entry_id": "test-team"})
+    create_resp = client.post("/teams/", json={"catalog_namespace": "test-team"})
     team_id = create_resp.json()["team_id"]
     resp = client.post(f"/teams/{team_id}/restore")
     assert resp.status_code == 409
@@ -195,7 +195,7 @@ def test_restore_team_not_found(client: TestClient) -> None:
 
 def test_get_events_success(client: TestClient) -> None:
     """GET /teams/{id}/events returns events for a team."""
-    create_resp = client.post("/teams/", json={"catalog_entry_id": "test-team"})
+    create_resp = client.post("/teams/", json={"catalog_namespace": "test-team"})
     team_id = create_resp.json()["team_id"]
     # Stop team first so events are flushed
     client.post(f"/teams/{team_id}/stop")
@@ -214,7 +214,7 @@ def test_get_events_not_found(client: TestClient) -> None:
 
 def test_stop_deleted_team(client: TestClient) -> None:
     """POST /teams/{id}/stop on deleted team returns 404."""
-    create_resp = client.post("/teams/", json={"catalog_entry_id": "test-team"})
+    create_resp = client.post("/teams/", json={"catalog_namespace": "test-team"})
     team_id = create_resp.json()["team_id"]
     client.delete(f"/teams/{team_id}")
     resp = client.post(f"/teams/{team_id}/stop")
@@ -223,7 +223,7 @@ def test_stop_deleted_team(client: TestClient) -> None:
 
 def test_restore_deleted_team(client: TestClient) -> None:
     """POST /teams/{id}/restore on deleted team returns 404."""
-    create_resp = client.post("/teams/", json={"catalog_entry_id": "test-team"})
+    create_resp = client.post("/teams/", json={"catalog_namespace": "test-team"})
     team_id = create_resp.json()["team_id"]
     client.delete(f"/teams/{team_id}")
     resp = client.post(f"/teams/{team_id}/restore")
@@ -232,7 +232,7 @@ def test_restore_deleted_team(client: TestClient) -> None:
 
 def test_get_events_running_team(client: TestClient) -> None:
     """GET /teams/{id}/events on running team returns events."""
-    create_resp = client.post("/teams/", json={"catalog_entry_id": "test-team"})
+    create_resp = client.post("/teams/", json={"catalog_namespace": "test-team"})
     team_id = create_resp.json()["team_id"]
     resp = client.get(f"/teams/{team_id}/events")
     assert resp.status_code == 200

--- a/tests/server/routes/test_team_routes.py
+++ b/tests/server/routes/test_team_routes.py
@@ -9,7 +9,7 @@ from fastapi.testclient import TestClient
 
 def test_create_team_success(client: TestClient) -> None:
     """POST /teams with valid catalog entry returns 201."""
-    resp = client.post("/teams/", json={"catalog_entry_id": "test-team"})
+    resp = client.post("/teams/", json={"catalog_namespace": "test-team"})
     assert resp.status_code == 201
     data = resp.json()
     assert "team_id" in data
@@ -19,7 +19,7 @@ def test_create_team_success(client: TestClient) -> None:
 
 def test_create_team_invalid_entry(client: TestClient) -> None:
     """POST /teams with unknown catalog entry returns 404."""
-    resp = client.post("/teams/", json={"catalog_entry_id": "nonexistent"})
+    resp = client.post("/teams/", json={"catalog_namespace": "nonexistent"})
     assert resp.status_code == 404
 
 
@@ -32,7 +32,7 @@ def test_list_teams_empty(client: TestClient) -> None:
 
 def test_list_teams_after_create(client: TestClient) -> None:
     """GET /teams returns created teams."""
-    client.post("/teams/", json={"catalog_entry_id": "test-team"})
+    client.post("/teams/", json={"catalog_namespace": "test-team"})
     resp = client.get("/teams/")
     assert resp.status_code == 200
     teams = resp.json()["teams"]
@@ -42,7 +42,7 @@ def test_list_teams_after_create(client: TestClient) -> None:
 
 def test_get_team_success(client: TestClient) -> None:
     """GET /teams/{id} returns team detail."""
-    create_resp = client.post("/teams/", json={"catalog_entry_id": "test-team"})
+    create_resp = client.post("/teams/", json={"catalog_namespace": "test-team"})
     team_id = create_resp.json()["team_id"]
     resp = client.get(f"/teams/{team_id}")
     assert resp.status_code == 200
@@ -57,7 +57,7 @@ def test_get_team_not_found(client: TestClient) -> None:
 
 def test_delete_team_success(client: TestClient) -> None:
     """DELETE /teams/{id} returns 204 and removes team."""
-    create_resp = client.post("/teams/", json={"catalog_entry_id": "test-team"})
+    create_resp = client.post("/teams/", json={"catalog_namespace": "test-team"})
     team_id = create_resp.json()["team_id"]
     resp = client.delete(f"/teams/{team_id}")
     assert resp.status_code == 204

--- a/tests/server/routes/test_websocket_route.py
+++ b/tests/server/routes/test_websocket_route.py
@@ -138,7 +138,7 @@ class TestWebSocketRoute:
         client: TestClient,
     ) -> None:
         """AC #1, #2: Running team pushes events via EventStream."""
-        resp = client.post("/teams/", json={"catalog_entry_id": "test-team"})
+        resp = client.post("/teams/", json={"catalog_namespace": "test-team"})
         assert resp.status_code == 201
         team_id = resp.json()["team_id"]
 
@@ -153,7 +153,7 @@ class TestWebSocketRoute:
         client: TestClient,
     ) -> None:
         """AC #3: Stopped team accepts connection (idle)."""
-        resp = client.post("/teams/", json={"catalog_entry_id": "test-team"})
+        resp = client.post("/teams/", json={"catalog_namespace": "test-team"})
         team_id = resp.json()["team_id"]
         client.post(f"/teams/{team_id}/stop")
 
@@ -166,7 +166,7 @@ class TestWebSocketRoute:
         client: TestClient,
     ) -> None:
         """AC #1: __model__ discriminator in event JSON."""
-        resp = client.post("/teams/", json={"catalog_entry_id": "test-team"})
+        resp = client.post("/teams/", json={"catalog_namespace": "test-team"})
         team_id = resp.json()["team_id"]
 
         with client.websocket_connect(f"/ws/{team_id}") as ws:
@@ -179,7 +179,7 @@ class TestWebSocketRoute:
         client: TestClient,
     ) -> None:
         """AC #4: Client disconnect calls reader.close()."""
-        resp = client.post("/teams/", json={"catalog_entry_id": "test-team"})
+        resp = client.post("/teams/", json={"catalog_namespace": "test-team"})
         team_id = resp.json()["team_id"]
 
         # Connect and immediately disconnect -- should not raise
@@ -188,7 +188,7 @@ class TestWebSocketRoute:
 
     def test_ws_restore_scenario(self, client: TestClient) -> None:
         """AC #6: Idle connection starts receiving events after restore."""
-        resp = client.post("/teams/", json={"catalog_entry_id": "test-team"})
+        resp = client.post("/teams/", json={"catalog_namespace": "test-team"})
         team_id = resp.json()["team_id"]
         client.post(f"/teams/{team_id}/stop")
 
@@ -310,7 +310,7 @@ class TestEventStreamWsIntegration:
         client: TestClient,
     ) -> None:
         """AC #1, #9: WS connect to running team receives replayed events (cursor=0)."""
-        resp = client.post("/teams/", json={"catalog_entry_id": "test-team"})
+        resp = client.post("/teams/", json={"catalog_namespace": "test-team"})
         assert resp.status_code == 201
         team_id = resp.json()["team_id"]
 
@@ -327,7 +327,7 @@ class TestEventStreamWsIntegration:
         client: TestClient,
     ) -> None:
         """AC #4: WS disconnect -> reader.close() is called (no exceptions)."""
-        resp = client.post("/teams/", json={"catalog_entry_id": "test-team"})
+        resp = client.post("/teams/", json={"catalog_namespace": "test-team"})
         team_id = resp.json()["team_id"]
 
         with client.websocket_connect(f"/ws/{team_id}"):
@@ -349,7 +349,7 @@ class TestFastDisconnectDetection:
         the handler must exit within a few hundred ms. The 500 ms bound here
         is the looser CI-safe upper bound prescribed by AC 13.
         """
-        resp = client.post("/teams/", json={"catalog_entry_id": "test-team"})
+        resp = client.post("/teams/", json={"catalog_namespace": "test-team"})
         team_id = resp.json()["team_id"]
 
         start = time.monotonic()

--- a/tests/server/routes/test_workspace_routes.py
+++ b/tests/server/routes/test_workspace_routes.py
@@ -13,7 +13,7 @@ from akgentic.infra.server.settings import ServerSettings
 @pytest.fixture()
 def team_with_workspace(client: TestClient, seeded_settings: ServerSettings) -> uuid.UUID:
     """Create a team via REST and seed workspace files."""
-    resp = client.post("/teams/", json={"catalog_entry_id": "test-team"})
+    resp = client.post("/teams/", json={"catalog_namespace": "test-team"})
     assert resp.status_code == 201
     team_id = uuid.UUID(resp.json()["team_id"])
     ws_root = seeded_settings.workspaces_root / str(team_id)

--- a/tests/server/services/test_team_service.py
+++ b/tests/server/services/test_team_service.py
@@ -14,7 +14,7 @@ from akgentic.infra.server.services.team_service import TeamService
 
 def test_create_team_returns_process(team_service: TeamService) -> None:
     """Creating a team with a valid catalog entry returns a Process."""
-    process = team_service.create_team("test-team", user_id="anonymous")
+    process = team_service.create_team(catalog_namespace="test-team", user_id="anonymous")
     assert process.team_id is not None
     assert process.status == TeamStatus.RUNNING
     assert process.user_id == "anonymous"
@@ -22,9 +22,15 @@ def test_create_team_returns_process(team_service: TeamService) -> None:
 
 
 def test_create_team_invalid_entry_raises(team_service: TeamService) -> None:
-    """Creating a team with an invalid catalog entry raises EntryNotFoundError."""
+    """Creating a team with an invalid catalog namespace raises EntryNotFoundError."""
     with pytest.raises(EntryNotFoundError):
-        team_service.create_team("nonexistent", user_id="anonymous")
+        team_service.create_team(catalog_namespace="nonexistent", user_id="anonymous")
+
+
+def test_create_team_propagates_catalog_namespace(team_service: TeamService) -> None:
+    """Process.catalog_namespace is populated from the create_team argument."""
+    process = team_service.create_team(catalog_namespace="test-team", user_id="anonymous")
+    assert process.catalog_namespace == "test-team"
 
 
 def test_list_teams_empty(team_service: TeamService) -> None:
@@ -35,8 +41,8 @@ def test_list_teams_empty(team_service: TeamService) -> None:
 
 def test_list_teams_filters_by_user(team_service: TeamService) -> None:
     """list_teams returns only teams belonging to the given user."""
-    team_service.create_team("test-team", user_id="alice")
-    team_service.create_team("test-team", user_id="bob")
+    team_service.create_team(catalog_namespace="test-team", user_id="alice")
+    team_service.create_team(catalog_namespace="test-team", user_id="bob")
     alice_teams = team_service.list_teams(user_id="alice")
     bob_teams = team_service.list_teams(user_id="bob")
     assert len(alice_teams) == 1
@@ -46,7 +52,7 @@ def test_list_teams_filters_by_user(team_service: TeamService) -> None:
 
 def test_get_team_found(team_service: TeamService) -> None:
     """get_team returns the Process for an existing team."""
-    process = team_service.create_team("test-team", user_id="anonymous")
+    process = team_service.create_team(catalog_namespace="test-team", user_id="anonymous")
     found = team_service.get_team(process.team_id)
     assert found is not None
     assert found.team_id == process.team_id
@@ -60,7 +66,7 @@ def test_get_team_not_found(team_service: TeamService) -> None:
 
 def test_delete_team_stops_and_deletes(team_service: TeamService) -> None:
     """delete_team stops a running team and purges it from the event store."""
-    process = team_service.create_team("test-team", user_id="anonymous")
+    process = team_service.create_team(catalog_namespace="test-team", user_id="anonymous")
     team_service.delete_team(process.team_id)
     # After deletion, the team is fully purged from the event store
     after = team_service.get_team(process.team_id)
@@ -69,7 +75,7 @@ def test_delete_team_stops_and_deletes(team_service: TeamService) -> None:
 
 def test_delete_stopped_team(team_service: TeamService) -> None:
     """delete_team handles an already-stopped team without calling stop_team."""
-    process = team_service.create_team("test-team", user_id="anonymous")
+    process = team_service.create_team(catalog_namespace="test-team", user_id="anonymous")
     team_service._services.worker_handle.stop_team(process.team_id)
     team_service.delete_team(process.team_id)
     after = team_service.get_team(process.team_id)
@@ -94,9 +100,8 @@ class TestStopTeam:
     def test_stop_team_removes_event_stream(self, team_service: TeamService) -> None:
         """AC1: stop_team calls event_stream.remove(team_id)."""
         from akgentic.infra.adapters.community.local_event_stream import LocalEventStream
-        from akgentic.infra.protocols.event_stream import StreamClosed
 
-        process = team_service.create_team("test-team", user_id="anonymous")
+        process = team_service.create_team(catalog_namespace="test-team", user_id="anonymous")
         team_id = process.team_id
 
         event_stream = team_service.get_event_stream()
@@ -115,7 +120,7 @@ class TestStopTeam:
 
     def test_stop_team_errors_are_non_fatal(self, team_service: TeamService) -> None:
         """AC1: event_stream.remove() failure does not prevent stop."""
-        process = team_service.create_team("test-team", user_id="anonymous")
+        process = team_service.create_team(catalog_namespace="test-team", user_id="anonymous")
         team_id = process.team_id
 
         # Replace event_stream.remove with one that raises
@@ -165,7 +170,7 @@ class TestTeamServiceLogging:
     ) -> None:
         """create_team() emits INFO log with team_id and catalog_entry."""
         with caplog.at_level(logging.INFO, logger="akgentic.infra.server.services.team_service"):
-            team_service.create_team("test-team", user_id="anonymous")
+            team_service.create_team(catalog_namespace="test-team", user_id="anonymous")
         assert any("Team created" in r.message for r in caplog.records)
 
     def test_delete_team_emits_info_log(
@@ -174,7 +179,7 @@ class TestTeamServiceLogging:
         caplog: pytest.LogCaptureFixture,
     ) -> None:
         """delete_team() emits INFO log with team_id."""
-        process = team_service.create_team("test-team", user_id="anonymous")
+        process = team_service.create_team(catalog_namespace="test-team", user_id="anonymous")
         caplog.clear()
         with caplog.at_level(logging.INFO, logger="akgentic.infra.server.services.team_service"):
             team_service.delete_team(process.team_id)

--- a/tests/test_deps.py
+++ b/tests/test_deps.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import uuid
 from unittest.mock import MagicMock
 
+from akgentic.catalog import Catalog
 from akgentic.catalog.services import (
     AgentCatalog,
     TeamCatalog,
@@ -84,6 +85,7 @@ class TestTierServicesEventStoreProtocol:
             event_stream=MagicMock(spec=EventStream),
             ingestion=MagicMock(spec=InteractionChannelIngestion),
             channel_registry=MagicMock(spec=ChannelRegistry),
+            catalog=MagicMock(spec=Catalog),
             team_catalog=MagicMock(spec=TeamCatalog),
             agent_catalog=MagicMock(spec=AgentCatalog),
             tool_catalog=MagicMock(spec=ToolCatalog),


### PR DESCRIPTION
Story 18.2 — migrate TeamService + load_team consumers to catalog v2. First story of Epic 18 in akgentic-infra.

## Summary

- `TeamService.create_team` now routes through `Catalog.load_team(namespace)` instead of the v1 four-catalog `TeamEntry.to_team_card(agent_catalog, tool_catalog, template_catalog)` pipeline.
- `PlacementStrategy.create_team` / `LocalPlacement.create_team` gain an optional `catalog_namespace: str | None = None` kwarg; `LocalPlacement` forwards it into `TeamManager.create_team(..., catalog_namespace=...)` (the kwarg delivered by Story 18.1), so the persisted `Process.catalog_namespace` records the binding.
- `TierServices` gains a required `catalog: Catalog` field. The four v1 catalog fields (`team_catalog`, `agent_catalog`, `tool_catalog`, `template_catalog`) remain in place — their removal belongs to Story 18.3.
- `wire_community` constructs a v2 `Catalog(repository=YamlEntryRepository(root=settings.catalog_path))` alongside the existing v1 `_build_catalogs(...)` call.
- `CreateTeamRequest.catalog_entry_id` is renamed to `catalog_namespace`. The teams router, the angular-v1 frontend adapter, the CLI client, every e2e / integration / unit test, and every JSON body are updated.
- `CatalogValidationError` from `Catalog.load_team` is caught in `TeamService.create_team` and re-raised as `EntryNotFoundError(catalog_namespace)` so the existing `EntryNotFoundError → 404` router handler continues to apply unchanged (Story 18.3 will consolidate error handling).

## API change notes

- `POST /teams` request body field: `catalog_entry_id` → `catalog_namespace` (breaking — frontends must update).
- `TeamService.create_team(catalog_entry_id=..., user_id=...)` → `TeamService.create_team(catalog_namespace=..., user_id=...)`.
- `PlacementStrategy.create_team(team_card, user_id)` → `PlacementStrategy.create_team(team_card, user_id, catalog_namespace: str | None = None)`.
- `TierServices` gains `catalog: Catalog` as a required field.

## Depends on

- b12consulting/akgentic-catalog PR #107 — v2 `Catalog` + unified `Entry`.
- b12consulting/akgentic-catalog PR #113 — `Catalog.load_team(namespace)` contract.
- b12consulting/akgentic-catalog PR #117 — `YamlEntryRepository` public re-export under `akgentic.catalog`.
- b12consulting/akgentic-team PR #102 — `Process.catalog_namespace` field + `TeamManager.create_team(..., catalog_namespace=...)` kwarg.

This PR assumes those are merged (or at least available on the resolved submodule pointer). If any of them slip, this branch blocks.

## Scope split notice

This PR contains ONLY the akgentic-infra changes. The paired `src/` demo migration (`src/catalog/main.py`) is staged in the workspace-root working tree and will be committed separately — it rides the root-repo submodule-pointer bump commit once this PR merges. That split keeps the submodule PR self-contained and preserves the per-submodule CI signal.

## Review status

**Verdict: PASS.** Clean implementation of every AC in `_bmad-output/akgentic-catalog/stories/18-2-migrate-teamservice-demo-consumers-load-team.md`:

- AC 1 — `TeamService.create_team` replaced with the single `self._services.catalog.load_team(catalog_namespace)` call; old four-catalog code path fully removed from the method.
- AC 2 — `catalog_namespace` threaded through `PlacementStrategy` protocol + `LocalPlacement` + into `TeamManager.create_team`. Covered by `test_create_team_forwards_catalog_namespace` in `tests/adapters/community/test_local_placement.py` and by `test_create_team_propagates_catalog_namespace` in `tests/server/services/test_team_service.py`.
- AC 3 — `CatalogValidationError` is caught in `TeamService.create_team` and translated to `EntryNotFoundError(catalog_namespace)` with an inline comment explaining the choice; existing 404 mapping stays untouched.
- AC 4 — `TierServices.catalog` added; v1 fields preserved (consistent with the 18.2 → 18.3 handoff contract).
- AC 5 — `wire_community` builds the v2 `Catalog` alongside `_build_catalogs(...)`; the helper is untouched (18.3's job).
- AC 9 — test fixtures (`tests/conftest.py`, `tests/integration/_helpers.py`) now seed both v1 and v2 catalog shapes so the single fixture exercises both code paths during the handoff window.
- AC 11 (lint / type / format) — clean per Amelia's local run.

**Sanity on `src/catalog/main.py` (root working tree — NOT committed in this PR).** Verified against AC 6: imports `Catalog` + `YamlEntryRepository` from `akgentic.catalog`, builds a single `catalog = Catalog(repository=YamlEntryRepository(root=CATALOG_DIR))`, `cmd_catalog()` lists via `catalog.list(EntryQuery(kind="team"))`, `cmd_start(team_name)` calls `catalog.load_team(team_name)` then `team_manager.create_team(team_card, catalog_namespace=team_name)`, error path prints a namespace-specific message, and the `build_catalogs` import / `to_team_card(...)` call are gone. Looks correct; will ship with the submodule-pointer bump.

No findings warranting a fix commit from Rex — PASS as-is.

## Scope guard

All committed changes confined to `packages/akgentic-infra/` (verified against the commit diff). No edits to other submodules, no actor-internals access from outside `akgentic-core`, no `dict[str, Any]` boundary types, no ADR-NNN test assertions or runtime branches.

## CI policy

Local-only verification this run (pytest + ruff + mypy green in `packages/akgentic-infra/` per Amelia's verification statement). GitHub Actions CI on this PR is the definitive gate before merge (Golden Rule #7).
