### PR TITLE
feat: ak catalog CLI command group (story 23.2)

### DIFF
--- a/src/akgentic/infra/cli/client.py
+++ b/src/akgentic/infra/cli/client.py
@@ -190,13 +190,50 @@ class ApiClient:
             raise ApiError(0, f"Connection failed: {exc}") from exc
 
         if not resp.is_success:
-            detail = ""
-            try:
-                body = resp.json()
-                detail = body.get("detail", "")
-            except Exception:  # noqa: BLE001
-                pass
-            raise ApiError(resp.status_code, detail)
+            raise ApiError(resp.status_code, self._extract_detail(resp))
+        return resp
+
+    @staticmethod
+    def _extract_detail(resp: httpx.Response) -> str:
+        """Pull ``detail`` from a JSON error body, falling back to empty string."""
+        try:
+            body = resp.json()
+        except Exception:  # noqa: BLE001
+            return ""
+        if isinstance(body, dict):
+            detail = body.get("detail", "")
+            if isinstance(detail, str):
+                return detail
+        return ""
+
+    def _raw_request(
+        self,
+        method: str,
+        path: str,
+        *,
+        content: bytes,
+        content_type: str,
+    ) -> httpx.Response:
+        """Send a raw body with an explicit ``Content-Type`` header.
+
+        Reuses the same timeout / connect-error / non-2xx translation as
+        :meth:`_request` but bypasses the ``json=...`` shortcut so the caller
+        can post YAML (or any other encoding) without double-serialization.
+        """
+        try:
+            resp = self._client.request(
+                method,
+                path,
+                content=content,
+                headers={"Content-Type": content_type},
+            )
+        except httpx.TimeoutException as exc:
+            raise ApiError(0, f"Request timed out: {method} {path}") from exc
+        except httpx.ConnectError as exc:
+            raise ApiError(0, f"Connection failed: {exc}") from exc
+
+        if not resp.is_success:
+            raise ApiError(resp.status_code, self._extract_detail(resp))
         return resp
 
     # -- catalog endpoints --
@@ -269,6 +306,76 @@ class ApiClient:
         """GET /workspace/{team_id}/file → raw file bytes."""
         resp = self._request("GET", f"/workspace/{team_id}/file", params={"path": path})
         return resp.content
+
+    # -- admin catalog (thin wire — server is validation point, ADR-022 §D4) --
+
+    def admin_catalog_list(
+        self,
+        entity: str,
+        q: str | None = None,
+    ) -> list[dict[str, Any]]:
+        """GET /admin/catalog/<entity> → list of entries.
+
+        Returns the parsed JSON response body verbatim (``list[dict]``).
+        ``q`` is forwarded as ``?q=<text>`` when supplied.
+        """
+        params: dict[str, str] = {"q": q} if q is not None else {}
+        resp = self._request("GET", f"/admin/catalog/{entity}", params=params or None)
+        body = resp.json()
+        if not isinstance(body, list):
+            return []
+        return list(body)
+
+    def admin_catalog_get(self, entity: str, entry_id: str) -> dict[str, Any]:
+        """GET /admin/catalog/<entity>/<id> → single entry body."""
+        resp = self._request("GET", f"/admin/catalog/{entity}/{entry_id}")
+        body = resp.json()
+        assert isinstance(body, dict)
+        return dict(body)
+
+    def admin_catalog_create(
+        self,
+        entity: str,
+        body: bytes,
+        content_type: str,
+    ) -> dict[str, Any]:
+        """POST /admin/catalog/<entity> → created entry body.
+
+        ``body`` is forwarded unchanged; ``content_type`` is one of
+        ``application/json`` or ``application/yaml``. The server is the
+        validation point — the CLI does not parse the payload.
+        """
+        resp = self._raw_request(
+            "POST",
+            f"/admin/catalog/{entity}",
+            content=body,
+            content_type=content_type,
+        )
+        data = resp.json()
+        assert isinstance(data, dict)
+        return dict(data)
+
+    def admin_catalog_update(
+        self,
+        entity: str,
+        entry_id: str,
+        body: bytes,
+        content_type: str,
+    ) -> dict[str, Any]:
+        """PUT /admin/catalog/<entity>/<id> → updated entry body."""
+        resp = self._raw_request(
+            "PUT",
+            f"/admin/catalog/{entity}/{entry_id}",
+            content=body,
+            content_type=content_type,
+        )
+        data = resp.json()
+        assert isinstance(data, dict)
+        return dict(data)
+
+    def admin_catalog_delete(self, entity: str, entry_id: str) -> None:
+        """DELETE /admin/catalog/<entity>/<id> — 204 on success."""
+        self._request("DELETE", f"/admin/catalog/{entity}/{entry_id}")
 
     def workspace_upload(self, team_id: str, path: str, file_data: bytes) -> WorkspaceUploadInfo:
         """POST /workspace/{team_id}/file → WorkspaceUploadInfo model."""

--- a/src/akgentic/infra/cli/commands/catalog.py
+++ b/src/akgentic/infra/cli/commands/catalog.py
@@ -1,0 +1,224 @@
+"""``ak catalog <entity> <verb>`` — CRUD over catalog entries.
+
+Implements the operator surface described in ADR-022 §D4 / §D6 — five verbs
+(``list``, ``get``, ``create``, ``update``, ``delete``) registered uniformly
+over the four catalog entities (``templates``, ``tools``, ``agents``,
+``teams``). The module is a **thin HTTP wire** against the admin-catalog
+routes shipped by Story 23.1: it ships request bytes to the server unchanged
+(server is the single validation point) and renders server responses verbatim
+under ``--format json|yaml`` or projects selected columns under ``--format
+table``.
+
+Design decisions
+----------------
+
+* **Registration style:** explicit ``register(app)`` helper mirrors Story
+  22.4's ``login`` / ``logout`` commands — test-friendly, no import-time
+  side effects on the top-level app.
+* **Generic over entity:** one ``_register_entity_commands`` helper is
+  applied four times (one line per entity). Adding a fifth entity is a
+  one-line addition. The only per-entity asymmetry lives in
+  ``_COLUMNS_BY_ENTITY`` below.
+* **``_state.client`` access:** the module imports
+  :mod:`akgentic.infra.cli.main` lazily inside each command body. This
+  avoids a circular import (``main`` imports ``catalog`` at module scope)
+  and matches the ``ConnectionManager``-lazy-import pattern in
+  ``main.py::chat``.
+"""
+
+from __future__ import annotations
+
+import sys
+from collections.abc import Callable
+from pathlib import Path
+from typing import TYPE_CHECKING, Annotated
+
+import typer
+
+from akgentic.infra.cli.client import ApiError
+from akgentic.infra.cli.formatters import OutputFormat, format_output
+
+if TYPE_CHECKING:
+    from akgentic.infra.cli.main import _State
+
+# -- per-entity table column projection ---------------------------------------
+
+# The ONLY per-entity asymmetry in this module. See AC #5.
+_COLUMNS_BY_ENTITY: dict[str, list[str]] = {
+    "templates": ["id", "placeholder"],
+    "tools": ["id", "name"],
+    "agents": ["id", "description"],
+    "teams": ["id", "name", "description"],
+}
+
+_ENTITIES: tuple[str, ...] = ("templates", "tools", "agents", "teams")
+
+
+# -- helpers ------------------------------------------------------------------
+
+
+def _content_type_for_extension(path: Path) -> str:
+    """Map a file extension to the HTTP ``Content-Type`` header value.
+
+    Raises :class:`typer.Exit` with the exact stderr message from AC #4 if
+    the extension is unsupported. Strict: no silent guessing.
+    """
+    ext = path.suffix.lower().lstrip(".")
+    if ext in {"yaml", "yml"}:
+        return "application/yaml"
+    if ext == "json":
+        return "application/json"
+    typer.echo(
+        f"Unsupported file extension {ext!r}; use .yaml, .yml, or .json.",
+        err=True,
+    )
+    raise typer.Exit(code=1)
+
+
+def _read_body(
+    file_path: Path | None,
+    fmt: OutputFormat,
+) -> tuple[bytes, str]:
+    """Load request bytes + ``Content-Type`` from ``--file`` or stdin.
+
+    * ``--file`` present → bytes read from the file, content-type inferred
+      from the extension (see :func:`_content_type_for_extension`).
+    * ``--file`` absent → bytes read from stdin. Content type defaults to
+      ``application/json``; ``--format yaml`` promotes it to
+      ``application/yaml``. ``--format json`` is a no-op.
+    """
+    if file_path is not None:
+        return file_path.read_bytes(), _content_type_for_extension(file_path)
+    body = sys.stdin.buffer.read()
+    content_type = "application/yaml" if fmt == OutputFormat.yaml else "application/json"
+    return body, content_type
+
+
+def _render_entity(data: object, entity_name: str, fmt: OutputFormat) -> None:
+    """Render a single entity body or a list of entity bodies."""
+    columns = _COLUMNS_BY_ENTITY[entity_name]
+    typer.echo(format_output(data, fmt, columns))
+
+
+def _current_state() -> _State:
+    """Return the live ``_state`` from :mod:`akgentic.infra.cli.main`.
+
+    Imported lazily to avoid the circular import between ``main`` (which
+    calls ``catalog.register(app)`` at import time) and this module.
+    """
+    from akgentic.infra.cli import main as main_module  # noqa: PLC0415
+
+    return main_module._state
+
+
+def _call_api[T](thunk: Callable[[], T]) -> T:
+    """Run ``thunk`` translating :class:`ApiError` into a Typer exit.
+
+    All five verbs share the identical ``try/except ApiError`` block required
+    by AC #9 — this helper collapses them into one site so the per-verb
+    functions stay well under the 50-line ceiling and free of duplication.
+    """
+    try:
+        return thunk()
+    except ApiError as exc:
+        typer.echo(f"HTTP {exc.status_code}: {exc.detail}", err=True)
+        raise typer.Exit(code=1) from exc
+
+
+def _render_delete(entity_name: str, entry_id: str, fmt: OutputFormat) -> None:
+    """Render the delete confirmation (table or structured)."""
+    if fmt == OutputFormat.table:
+        singular = entity_name.rstrip("s")
+        typer.echo(f"Deleted {singular} '{entry_id}'.")
+        return
+    typer.echo(
+        format_output(
+            {"entity": entity_name, "id": entry_id, "status": "deleted"},
+            fmt,
+        )
+    )
+
+
+# -- per-entity command registration ------------------------------------------
+
+
+def _register_entity_commands(parent_app: typer.Typer, entity_name: str) -> None:
+    """Register the five CRUD verbs for ``entity_name`` on ``parent_app``.
+
+    Public contract: attaches a new ``typer.Typer(name=entity_name)`` subgroup
+    carrying ``list``, ``get``, ``create``, ``update``, ``delete`` under
+    ``parent_app``. Exactly one subgroup is added per call; removing a call
+    eliminates exactly that entity's subgroup (see AC #11 registration test).
+    """
+    entity_app = typer.Typer(name=entity_name, help=f"Manage {entity_name}")
+
+    @entity_app.command("list")
+    def list_cmd(
+        q: Annotated[
+            str | None, typer.Option("--q", help="Optional search query forwarded as ?q=")
+        ] = None,
+    ) -> None:
+        state = _current_state()
+        data = _call_api(lambda: state.client.admin_catalog_list(entity_name, q))
+        _render_entity(data, entity_name, state.fmt)
+
+    @entity_app.command("get")
+    def get_cmd(entry_id: str) -> None:
+        state = _current_state()
+        data = _call_api(lambda: state.client.admin_catalog_get(entity_name, entry_id))
+        _render_entity(data, entity_name, state.fmt)
+
+    @entity_app.command("create")
+    def create_cmd(
+        file: Annotated[
+            Path | None, typer.Option("--file", help="Path to request body (.yaml|.yml|.json).")
+        ] = None,
+    ) -> None:
+        state = _current_state()
+        body, content_type = _read_body(file, state.fmt)
+        data = _call_api(lambda: state.client.admin_catalog_create(entity_name, body, content_type))
+        _render_entity(data, entity_name, state.fmt)
+
+    @entity_app.command("update")
+    def update_cmd(
+        entry_id: str,
+        file: Annotated[
+            Path | None, typer.Option("--file", help="Path to request body (.yaml|.yml|.json).")
+        ] = None,
+    ) -> None:
+        state = _current_state()
+        body, content_type = _read_body(file, state.fmt)
+        data = _call_api(
+            lambda: state.client.admin_catalog_update(entity_name, entry_id, body, content_type)
+        )
+        _render_entity(data, entity_name, state.fmt)
+
+    @entity_app.command("delete")
+    def delete_cmd(entry_id: str) -> None:
+        state = _current_state()
+        _call_api(lambda: state.client.admin_catalog_delete(entity_name, entry_id))
+        _render_delete(entity_name, entry_id, state.fmt)
+
+    parent_app.add_typer(entity_app, name=entity_name)
+
+
+# -- public entry point -------------------------------------------------------
+
+
+def register(app: typer.Typer) -> None:
+    """Register the ``catalog`` command group on ``app``.
+
+    Called from :mod:`akgentic.infra.cli.main`; tests may also call
+    ``register`` against their own Typer instance to isolate the command
+    group.
+    """
+    catalog_app = typer.Typer(
+        name="catalog",
+        help="Manage catalog entries (templates, tools, agents, teams).",
+    )
+    for entity_name in _ENTITIES:
+        _register_entity_commands(catalog_app, entity_name)
+    app.add_typer(catalog_app, name="catalog")
+
+
+__all__ = ["register"]

--- a/src/akgentic/infra/cli/main.py
+++ b/src/akgentic/infra/cli/main.py
@@ -39,6 +39,7 @@ from pydantic import BaseModel
 
 from akgentic.infra.cli.auth import DeviceAuthorizationResponse
 from akgentic.infra.cli.client import ApiClient, ApiError
+from akgentic.infra.cli.commands import catalog as catalog_command
 from akgentic.infra.cli.commands import login as login_command
 from akgentic.infra.cli.commands import logout as logout_command
 from akgentic.infra.cli.config import (
@@ -63,6 +64,7 @@ app.add_typer(workspace_app, name="workspace")
 # Register top-level login/logout commands (Story 22.4).
 login_command.register(app)
 logout_command.register(app)
+catalog_command.register(app)
 
 
 # Default server — kept as a module constant so tests can compare against it

--- a/src/akgentic/infra/server/routes/admin_catalog.py
+++ b/src/akgentic/infra/server/routes/admin_catalog.py
@@ -11,7 +11,7 @@ mappings. Adding a fifth entity is a one-line additional call.
 
 `?q=<s>` per-entity mapping (mirrors AC #6):
 
-* ``templates`` → ``TemplateQuery(placeholder=s)``
+* ``templates`` → ``TemplateQuery(placeholder=s)`` (exact placeholder-name match)
 * ``tools`` → ``ToolQuery(name=s)``
 * ``agents`` → ``AgentQuery(description=s)``
 * ``teams`` → ``TeamQuery(name=s)``
@@ -23,9 +23,10 @@ emitter, where ``services.auth.authenticate(request)`` feeds the
 ``principal_id`` log field.
 """
 
+import builtins
 import logging
 from collections.abc import Callable
-from typing import cast
+from typing import Generic, Protocol, TypeVar, cast
 
 from fastapi import APIRouter, Depends, Request
 from pydantic import BaseModel
@@ -48,9 +49,29 @@ from akgentic.catalog.services import (
     ToolCatalog,
 )
 
+_list = builtins.list  # Alias: the protocol's list() method shadows the built-in.
+
 logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/admin/catalog", tags=["admin-catalog"])
+
+
+# Legacy-style TypeVars required for contravariance on QueryT (PEP 695's
+# class-header generic syntax does not yet support variance annotations in
+# Python 3.12); this also keeps Generic[...] explicit for the Protocol.
+EntryT = TypeVar("EntryT", bound=BaseModel)
+QueryT = TypeVar("QueryT", bound=BaseModel, contravariant=True)
+
+
+class _CatalogProto(Protocol, Generic[EntryT, QueryT]):  # noqa: UP046
+    """Structural protocol shared by all four ``{Entity}Catalog`` services."""
+
+    def list(self) -> _list[EntryT]: ...
+    def get(self, entry_id: str, /) -> EntryT | None: ...
+    def search(self, query: QueryT, /) -> _list[EntryT]: ...
+    def create(self, entry: EntryT, /) -> str: ...
+    def update(self, entry_id: str, entry: EntryT, /) -> None: ...
+    def delete(self, entry_id: str, /) -> None: ...
 
 
 # --- Per-entity dependency accessors (module-private) -------------------------
@@ -103,13 +124,13 @@ def _emit_mutation_log(
 # --- Generic route registration ----------------------------------------------
 
 
-def _register_entity_routes(
+def _register_entity_routes(  # noqa: UP047
     router: APIRouter,
     *,
     entity_name: str,
-    get_catalog: Callable[..., object],
-    entry_model: type[BaseModel],
-    query_from_q: Callable[[str], BaseModel],
+    get_catalog: Callable[[Request], _CatalogProto[EntryT, QueryT]],
+    entry_model: type[EntryT],
+    query_from_q: Callable[[str], QueryT],
 ) -> None:
     """Register the five CRUD verbs for one entity on ``router``.
 
@@ -122,58 +143,65 @@ def _register_entity_routes(
     ``CatalogValidationError`` (→ 409) and ``EntryNotFoundError`` (→ 404)
     propagate to the global handlers registered in
     ``akgentic.catalog.api._errors.add_exception_handlers``.
+
+    Note on the one remaining ``type: ignore[valid-type]`` below: ``entry_model``
+    is a runtime value of type ``type[EntryT]``. FastAPI reads it as a function
+    annotation for request-body validation, which is legal Python but mypy
+    cannot resolve a value-bound ``type[...]`` as a type expression. The ignore
+    is structural to the generic-factory + FastAPI pattern, not a stand-in for
+    a missing type.
     """
     singular = entity_name.rstrip("s").title()
     prefix = f"/{entity_name}"
 
-    @router.get(prefix, response_model=list[entry_model])  # type: ignore[valid-type]
+    @router.get(prefix, response_model=_list[entry_model])  # type: ignore[valid-type]
     def _list_entries(
         q: str | None = None,
-        catalog: object = Depends(get_catalog),
-    ) -> list[BaseModel]:
+        catalog: _CatalogProto[EntryT, QueryT] = Depends(get_catalog),
+    ) -> _list[EntryT]:
         if q is None:
-            return catalog.list()  # type: ignore[attr-defined, no-any-return]
-        return catalog.search(query_from_q(q))  # type: ignore[attr-defined, no-any-return]
+            return catalog.list()
+        return catalog.search(query_from_q(q))
 
     @router.get(prefix + "/{entry_id}", response_model=entry_model)
     def _get_entry(
         entry_id: str,
-        catalog: object = Depends(get_catalog),
-    ) -> BaseModel:
-        result = catalog.get(entry_id)  # type: ignore[attr-defined]
+        catalog: _CatalogProto[EntryT, QueryT] = Depends(get_catalog),
+    ) -> EntryT:
+        result = catalog.get(entry_id)
         if result is None:
             raise EntryNotFoundError(f"{singular} id '{entry_id}' not found")
-        return cast(BaseModel, result)
+        return result
 
     @router.post(prefix, response_model=entry_model, status_code=201)
     def _create_entry(
         entry: entry_model,  # type: ignore[valid-type]
         request: Request,
-        catalog: object = Depends(get_catalog),
-    ) -> BaseModel:
-        catalog.create(entry)  # type: ignore[attr-defined]
-        entry_id: str = entry.id  # type: ignore[attr-defined]
+        catalog: _CatalogProto[EntryT, QueryT] = Depends(get_catalog),
+    ) -> EntryT:
+        catalog.create(entry)
+        entry_id = cast(str, getattr(entry, "id"))  # noqa: B009
         _emit_mutation_log(request, entity_name=entity_name, entity_id=entry_id, operation="create")
-        return cast(BaseModel, entry)
+        return cast(EntryT, entry)
 
     @router.put(prefix + "/{entry_id}", response_model=entry_model)
     def _update_entry(
         entry_id: str,
         entry: entry_model,  # type: ignore[valid-type]
         request: Request,
-        catalog: object = Depends(get_catalog),
-    ) -> BaseModel:
-        catalog.update(entry_id, entry)  # type: ignore[attr-defined]
+        catalog: _CatalogProto[EntryT, QueryT] = Depends(get_catalog),
+    ) -> EntryT:
+        catalog.update(entry_id, entry)
         _emit_mutation_log(request, entity_name=entity_name, entity_id=entry_id, operation="update")
-        return cast(BaseModel, entry)
+        return cast(EntryT, entry)
 
     @router.delete(prefix + "/{entry_id}", status_code=204)
     def _delete_entry(
         entry_id: str,
         request: Request,
-        catalog: object = Depends(get_catalog),
+        catalog: _CatalogProto[EntryT, QueryT] = Depends(get_catalog),
     ) -> None:
-        catalog.delete(entry_id)  # type: ignore[attr-defined]
+        catalog.delete(entry_id)
         _emit_mutation_log(request, entity_name=entity_name, entity_id=entry_id, operation="delete")
 
 

--- a/tests/cli/commands/test_catalog.py
+++ b/tests/cli/commands/test_catalog.py
@@ -171,44 +171,54 @@ class FakeServer:
             return httpx.Response(404, json={"detail": "not an admin route", "errors": []})
         entity = parts[3]
         entry_id = parts[4] if len(parts) >= 5 else None
-        method = request.method
         if entity not in self.store:
             return httpx.Response(404, json={"detail": f"unknown entity {entity}", "errors": []})
         table = self.store[entity]
         if entry_id is None:
-            if method == "GET":
-                q = request.url.params.get("q")
-                entries = list(table.values())
-                if q is not None:
-                    entries = [e for e in entries if q in json.dumps(e)]
-                return httpx.Response(200, json=entries)
-            if method == "POST":
-                return self._create(request, table)
-        else:
-            if method == "GET":
-                if entry_id not in table:
-                    return httpx.Response(
-                        404,
-                        json={
-                            "detail": f"{entity} '{entry_id}' not found",
-                            "errors": [],
-                        },
-                    )
-                return httpx.Response(200, json=table[entry_id])
-            if method == "PUT":
-                return self._update(request, table, entity, entry_id)
-            if method == "DELETE":
-                if entry_id not in table:
-                    return httpx.Response(
-                        404,
-                        json={
-                            "detail": f"{entity} '{entry_id}' not found",
-                            "errors": [],
-                        },
-                    )
-                table.pop(entry_id)
-                return httpx.Response(204)
+            return self._dispatch_collection(request, table)
+        return self._dispatch_item(request, table, entity, entry_id)
+
+    def _dispatch_collection(
+        self,
+        request: httpx.Request,
+        table: dict[str, dict[str, Any]],
+    ) -> httpx.Response:
+        if request.method == "GET":
+            q = request.url.params.get("q")
+            entries = list(table.values())
+            if q is not None:
+                entries = [e for e in entries if q in json.dumps(e)]
+            return httpx.Response(200, json=entries)
+        if request.method == "POST":
+            return self._create(request, table)
         return httpx.Response(405, json={"detail": "method not allowed", "errors": []})
+
+    def _dispatch_item(
+        self,
+        request: httpx.Request,
+        table: dict[str, dict[str, Any]],
+        entity: str,
+        entry_id: str,
+    ) -> httpx.Response:
+        if request.method == "GET":
+            if entry_id not in table:
+                return self._not_found(entity, entry_id)
+            return httpx.Response(200, json=table[entry_id])
+        if request.method == "PUT":
+            return self._update(request, table, entity, entry_id)
+        if request.method == "DELETE":
+            if entry_id not in table:
+                return self._not_found(entity, entry_id)
+            table.pop(entry_id)
+            return httpx.Response(204)
+        return httpx.Response(405, json={"detail": "method not allowed", "errors": []})
+
+    @staticmethod
+    def _not_found(entity: str, entry_id: str) -> httpx.Response:
+        return httpx.Response(
+            404,
+            json={"detail": f"{entity} '{entry_id}' not found", "errors": []},
+        )
 
     def _create(
         self,

--- a/tests/cli/commands/test_catalog.py
+++ b/tests/cli/commands/test_catalog.py
@@ -1,0 +1,724 @@
+"""Tests for :mod:`akgentic.infra.cli.commands.catalog`.
+
+Covers every entity x every verb happy path, the error matrix (404/409/422),
+the ``--format`` flag matrix, the content-type inference rules, the
+registration-count invariant, and the auto-auth inheritance test required by
+AC #10 / AC #11 of Story 23.2.
+
+All network I/O runs through :class:`httpx.MockTransport`; all filesystem I/O
+runs through ``tmp_path`` via the module-level seams on
+:mod:`akgentic.infra.cli.main`. No real ``~/.akgentic/``, no real HTTP.
+"""
+
+from __future__ import annotations
+
+import json
+import stat
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+import httpx
+import pytest
+import typer
+import yaml
+from akgentic.catalog.models import (
+    AgentEntry,
+    TeamEntry,
+    TemplateEntry,
+    ToolEntry,
+)
+from pydantic import BaseModel
+from typer.testing import CliRunner
+
+from akgentic.infra.cli import main as main_module
+from akgentic.infra.cli.auth import TokenCacheEntry, save_token_cache
+from akgentic.infra.cli.commands import catalog as catalog_module
+from akgentic.infra.cli.main import app
+
+# ---------------------------------------------------------------------------
+# Shared fixtures / helpers
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _reset_overrides_and_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    main_module._CONFIG_PATH_OVERRIDE = None
+    main_module._CREDENTIALS_DIR_OVERRIDE = None
+    main_module._HTTP_CLIENT_FACTORY_OVERRIDE = None
+    monkeypatch.delenv("AKGENTIC_PROFILE", raising=False)
+    yield
+    main_module._CONFIG_PATH_OVERRIDE = None
+    main_module._CREDENTIALS_DIR_OVERRIDE = None
+    main_module._HTTP_CLIENT_FACTORY_OVERRIDE = None
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    return CliRunner()
+
+
+def _write_noauth_config(path: Path, *, profile_name: str = "oss") -> None:
+    path.write_text(
+        "default_profile: " + profile_name + "\n"
+        "profiles:\n"
+        f"  {profile_name}:\n"
+        "    endpoint: https://api.example.com\n",
+        encoding="utf-8",
+    )
+
+
+def _write_auth_config(path: Path, *, profile_name: str = "acme-prod") -> None:
+    path.write_text(
+        "default_profile: " + profile_name + "\n"
+        "profiles:\n"
+        f"  {profile_name}:\n"
+        "    endpoint: https://api.example.com\n"
+        "    auth:\n"
+        "      type: oidc\n"
+        "      issuer: https://issuer.example.com\n"
+        "      client_id: akgentic-cli\n",
+        encoding="utf-8",
+    )
+
+
+# --- Payload factories ------------------------------------------------------
+#
+# These mirror the server-side admin-catalog test fixtures so request bodies
+# are constructed from concrete entry models (Golden Rule #1 + AC #13).
+
+
+def _template_payload(tid: str = "cli-tpl") -> TemplateEntry:
+    return TemplateEntry(id=tid, template="Hello {name}, you are {role}.")
+
+
+def _tool_payload(tid: str = "cli-tool") -> ToolEntry:
+    return ToolEntry.model_validate(
+        {
+            "id": tid,
+            "tool_class": "akgentic.tool.search.SearchTool",
+            "tool": {"name": "search", "description": "Search the web"},
+        }
+    )
+
+
+def _agent_payload(tid: str = "cli-agent") -> AgentEntry:
+    return AgentEntry.model_validate(
+        {
+            "id": tid,
+            "tool_ids": [],
+            "card": {
+                "role": "engineer",
+                "description": "cli-catalog test agent",
+                "skills": ["coding"],
+                "agent_class": "akgentic.agent.BaseAgent",
+                "config": {"name": "@Eng", "role": "Engineer"},
+                "routes_to": [],
+            },
+        }
+    )
+
+
+def _team_payload(tid: str = "cli-team") -> TeamEntry:
+    return TeamEntry.model_validate(
+        {
+            "id": tid,
+            "name": f"CLI Team {tid}",
+            "entry_point": "human-proxy",
+            "message_types": ["akgentic.core.messages.UserMessage"],
+            "members": [{"agent_id": "human-proxy"}],
+            "description": "cli-catalog test team",
+        }
+    )
+
+
+EntryFactory = Callable[[str], BaseModel]
+
+# (entity_name, payload_factory, query_field)
+ENTITIES: list[tuple[str, EntryFactory, str]] = [
+    ("templates", _template_payload, "placeholder"),
+    ("tools", _tool_payload, "name"),
+    ("agents", _agent_payload, "description"),
+    ("teams", _team_payload, "name"),
+]
+
+
+# --- In-memory fake server --------------------------------------------------
+
+
+class FakeServer:
+    """Minimal admin-catalog fake routing /admin/catalog/<entity>[/id].
+
+    Each instance owns a per-entity ``dict[id -> entry_dict]``. Incoming
+    requests populate ``captured_requests`` for assertion. The fake echoes
+    the request body on create/update (mirroring the real server contract).
+    """
+
+    def __init__(self) -> None:
+        self.store: dict[str, dict[str, dict[str, Any]]] = {
+            "templates": {},
+            "tools": {},
+            "agents": {},
+            "teams": {},
+        }
+        self.captured_requests: list[httpx.Request] = []
+
+    def handler(self, request: httpx.Request) -> httpx.Response:
+        self.captured_requests.append(request)
+        parts = request.url.path.rstrip("/").split("/")
+        # Expect /admin/catalog/<entity>[/id]
+        if len(parts) < 4 or parts[1] != "admin" or parts[2] != "catalog":
+            return httpx.Response(404, json={"detail": "not an admin route", "errors": []})
+        entity = parts[3]
+        entry_id = parts[4] if len(parts) >= 5 else None
+        method = request.method
+        if entity not in self.store:
+            return httpx.Response(404, json={"detail": f"unknown entity {entity}", "errors": []})
+        table = self.store[entity]
+        if entry_id is None:
+            if method == "GET":
+                q = request.url.params.get("q")
+                entries = list(table.values())
+                if q is not None:
+                    entries = [e for e in entries if q in json.dumps(e)]
+                return httpx.Response(200, json=entries)
+            if method == "POST":
+                return self._create(request, table)
+        else:
+            if method == "GET":
+                if entry_id not in table:
+                    return httpx.Response(
+                        404,
+                        json={
+                            "detail": f"{entity} '{entry_id}' not found",
+                            "errors": [],
+                        },
+                    )
+                return httpx.Response(200, json=table[entry_id])
+            if method == "PUT":
+                return self._update(request, table, entity, entry_id)
+            if method == "DELETE":
+                if entry_id not in table:
+                    return httpx.Response(
+                        404,
+                        json={
+                            "detail": f"{entity} '{entry_id}' not found",
+                            "errors": [],
+                        },
+                    )
+                table.pop(entry_id)
+                return httpx.Response(204)
+        return httpx.Response(405, json={"detail": "method not allowed", "errors": []})
+
+    def _create(
+        self,
+        request: httpx.Request,
+        table: dict[str, dict[str, Any]],
+    ) -> httpx.Response:
+        body = self._parse_body(request)
+        if body is None:
+            return httpx.Response(422, json={"detail": "malformed body", "errors": ["bad"]})
+        entry_id = body.get("id")
+        if not isinstance(entry_id, str):
+            return httpx.Response(422, json={"detail": "missing id", "errors": ["id required"]})
+        if entry_id in table:
+            return httpx.Response(
+                409, json={"detail": f"id {entry_id!r} already exists", "errors": []}
+            )
+        table[entry_id] = body
+        return httpx.Response(201, json=body)
+
+    def _update(
+        self,
+        request: httpx.Request,
+        table: dict[str, dict[str, Any]],
+        entity: str,
+        entry_id: str,
+    ) -> httpx.Response:
+        body = self._parse_body(request)
+        if body is None:
+            return httpx.Response(422, json={"detail": "malformed body", "errors": ["bad"]})
+        if entry_id not in table:
+            return httpx.Response(
+                404,
+                json={"detail": f"{entity} '{entry_id}' not found", "errors": []},
+            )
+        body_id = body.get("id")
+        if body_id != entry_id:
+            return httpx.Response(
+                409,
+                json={
+                    "detail": f"id mismatch: path {entry_id!r} vs body {body_id!r}",
+                    "errors": [],
+                },
+            )
+        table[entry_id] = body
+        return httpx.Response(200, json=body)
+
+    @staticmethod
+    def _parse_body(request: httpx.Request) -> dict[str, Any] | None:
+        try:
+            parsed = json.loads(request.content.decode("utf-8"))
+        except (UnicodeDecodeError, json.JSONDecodeError):
+            return None
+        if not isinstance(parsed, dict):
+            return None
+        return parsed
+
+
+def _install_fake_server(
+    tmp_path: Path,
+    *,
+    pre_seed: list[tuple[str, dict[str, Any]]] | None = None,
+) -> FakeServer:
+    """Install a FakeServer wired via ``_HTTP_CLIENT_FACTORY_OVERRIDE``.
+
+    Writes a no-auth config to ``tmp_path`` so the callback takes the
+    config-file branch and the test seam is honoured.
+    """
+    config_path = tmp_path / "config.yaml"
+    _write_noauth_config(config_path)
+    main_module._CONFIG_PATH_OVERRIDE = config_path
+
+    fake = FakeServer()
+    for entity, entry in pre_seed or []:
+        fake.store[entity][entry["id"]] = entry
+
+    transport = httpx.MockTransport(fake.handler)
+
+    def factory(profile: Any, **_kwargs: Any) -> httpx.Client:
+        return httpx.Client(base_url=str(profile.endpoint), transport=transport)
+
+    main_module._HTTP_CLIENT_FACTORY_OVERRIDE = factory
+    return fake
+
+
+# ---------------------------------------------------------------------------
+# Structural tests (AC #11)
+# ---------------------------------------------------------------------------
+
+
+def test_no_direct_httpx_and_no_apiclient_construction() -> None:
+    """AC #7 / AC #11 — the module is a thin wire over ``_state.client``."""
+    src = Path(catalog_module.__file__).read_text(encoding="utf-8")
+    assert "import httpx" not in src
+    assert "ApiClient(base_url" not in src
+
+
+def test_main_py_has_exactly_one_catalog_import_and_register() -> None:
+    """AC #12 — ``main.py`` gains exactly one import + one register call."""
+    src = Path(main_module.__file__).read_text(encoding="utf-8")
+    assert "from akgentic.infra.cli.commands import catalog as catalog_command" in src
+    assert "catalog_command.register(app)" in src
+
+
+@pytest.mark.parametrize("skipped_entity", ["templates", "tools", "agents", "teams"])
+def test_registration_removal_eliminates_only_that_entity(skipped_entity: str) -> None:
+    """AC #2 / AC #11 — skipping one call eliminates exactly that subgroup."""
+    fresh_catalog = typer.Typer(name="catalog")
+    for entity in ("templates", "tools", "agents", "teams"):
+        if entity == skipped_entity:
+            continue
+        catalog_module._register_entity_commands(fresh_catalog, entity)
+
+    names = {group.name for group in fresh_catalog.registered_groups}
+    expected = {"templates", "tools", "agents", "teams"} - {skipped_entity}
+    assert names == expected
+
+
+def test_all_four_entities_registered_on_main_app() -> None:
+    """AC #1 / AC #6 — ``ak catalog`` gains all four entities on the main app."""
+    catalog_groups = [g for g in app.registered_groups if g.name == "catalog"]
+    assert len(catalog_groups) == 1
+    catalog_app = catalog_groups[0].typer_instance
+    subnames = {g.name for g in catalog_app.registered_groups}
+    assert subnames == {"templates", "tools", "agents", "teams"}
+
+
+# ---------------------------------------------------------------------------
+# list (AC #10: happy + --q forwarding)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(("entity", "factory", "_qfield"), ENTITIES)
+def test_list_happy_path_table(
+    runner: CliRunner,
+    tmp_path: Path,
+    entity: str,
+    factory: EntryFactory,
+    _qfield: str,
+) -> None:
+    payload = factory("list-1").model_dump()
+    fake = _install_fake_server(tmp_path, pre_seed=[(entity, payload)])
+
+    result = runner.invoke(app, ["catalog", entity, "list"])
+
+    assert result.exit_code == 0, result.stderr
+    assert "ID" in result.stdout  # upper-cased table header
+    assert "list-1" in result.stdout
+    assert any(r.url.path == f"/admin/catalog/{entity}" for r in fake.captured_requests)
+
+
+@pytest.mark.parametrize(("entity", "factory", "_qfield"), ENTITIES)
+def test_list_happy_path_json(
+    runner: CliRunner,
+    tmp_path: Path,
+    entity: str,
+    factory: EntryFactory,
+    _qfield: str,
+) -> None:
+    payload = factory("list-json").model_dump()
+    _install_fake_server(tmp_path, pre_seed=[(entity, payload)])
+
+    result = runner.invoke(app, ["--format", "json", "catalog", entity, "list"])
+    assert result.exit_code == 0, result.stderr
+    decoded = json.loads(result.stdout)
+    assert isinstance(decoded, list)
+    assert any(entry["id"] == "list-json" for entry in decoded)
+
+
+@pytest.mark.parametrize(("entity", "factory", "_qfield"), ENTITIES)
+def test_list_with_q_forwards_query(
+    runner: CliRunner,
+    tmp_path: Path,
+    entity: str,
+    factory: EntryFactory,
+    _qfield: str,
+) -> None:
+    payload = factory("q-target").model_dump()
+    fake = _install_fake_server(tmp_path, pre_seed=[(entity, payload)])
+
+    result = runner.invoke(app, ["catalog", entity, "list", "--q", "q-target"])
+    assert result.exit_code == 0, result.stderr
+    # The CLI forwarded ?q=q-target to the server.
+    list_requests = [r for r in fake.captured_requests if r.url.path == f"/admin/catalog/{entity}"]
+    assert list_requests
+    assert list_requests[-1].url.params.get("q") == "q-target"
+
+
+# ---------------------------------------------------------------------------
+# get (happy + yaml render + 404)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(("entity", "factory", "_qfield"), ENTITIES)
+def test_get_happy_path_table(
+    runner: CliRunner,
+    tmp_path: Path,
+    entity: str,
+    factory: EntryFactory,
+    _qfield: str,
+) -> None:
+    payload = factory("get-1").model_dump()
+    _install_fake_server(tmp_path, pre_seed=[(entity, payload)])
+
+    result = runner.invoke(app, ["catalog", entity, "get", "get-1"])
+    assert result.exit_code == 0, result.stderr
+    assert "get-1" in result.stdout
+
+
+@pytest.mark.parametrize(("entity", "factory", "_qfield"), ENTITIES)
+def test_get_happy_path_yaml(
+    runner: CliRunner,
+    tmp_path: Path,
+    entity: str,
+    factory: EntryFactory,
+    _qfield: str,
+) -> None:
+    payload = factory("get-yaml").model_dump()
+    _install_fake_server(tmp_path, pre_seed=[(entity, payload)])
+
+    result = runner.invoke(app, ["--format", "yaml", "catalog", entity, "get", "get-yaml"])
+    assert result.exit_code == 0, result.stderr
+    loaded = yaml.safe_load(result.stdout)
+    assert isinstance(loaded, dict)
+    assert loaded["id"] == "get-yaml"
+
+
+@pytest.mark.parametrize(("entity", "factory", "_qfield"), ENTITIES)
+def test_get_unknown_404(
+    runner: CliRunner,
+    tmp_path: Path,
+    entity: str,
+    factory: EntryFactory,
+    _qfield: str,
+) -> None:
+    _install_fake_server(tmp_path)
+    result = runner.invoke(app, ["catalog", entity, "get", "nope"])
+    assert result.exit_code == 1
+    assert "HTTP 404" in result.stderr
+    assert "nope" in result.stderr
+
+
+# ---------------------------------------------------------------------------
+# create (file yaml + stdin json + duplicate 409 + malformed 422 + bad ext)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(("entity", "factory", "_qfield"), ENTITIES)
+def test_create_file_yaml_forwards_content_type(
+    runner: CliRunner,
+    tmp_path: Path,
+    entity: str,
+    factory: EntryFactory,
+    _qfield: str,
+) -> None:
+    fake = _install_fake_server(tmp_path)
+    payload = factory("create-yaml").model_dump()
+    body_path = tmp_path / "body.yaml"
+    # Ship JSON-shaped bytes through the YAML path — the fake server reads
+    # JSON only; this still proves the outbound Content-Type header.
+    body_path.write_text(json.dumps(payload), encoding="utf-8")
+
+    result = runner.invoke(app, ["catalog", entity, "create", "--file", str(body_path)])
+    assert result.exit_code == 0, result.stderr
+    assert "create-yaml" in result.stdout
+    # Outbound Content-Type header check.
+    post = [r for r in fake.captured_requests if r.method == "POST"][-1]
+    assert post.headers["content-type"] == "application/yaml"
+
+
+@pytest.mark.parametrize(("entity", "factory", "_qfield"), ENTITIES)
+def test_create_file_yml_forwards_yaml_content_type(
+    runner: CliRunner,
+    tmp_path: Path,
+    entity: str,
+    factory: EntryFactory,
+    _qfield: str,
+) -> None:
+    fake = _install_fake_server(tmp_path)
+    payload = factory("create-yml").model_dump()
+    body_path = tmp_path / "body.yml"
+    body_path.write_text(json.dumps(payload), encoding="utf-8")
+
+    result = runner.invoke(app, ["catalog", entity, "create", "--file", str(body_path)])
+    assert result.exit_code == 0, result.stderr
+    post = [r for r in fake.captured_requests if r.method == "POST"][-1]
+    assert post.headers["content-type"] == "application/yaml"
+
+
+@pytest.mark.parametrize(("entity", "factory", "_qfield"), ENTITIES)
+def test_create_file_json(
+    runner: CliRunner,
+    tmp_path: Path,
+    entity: str,
+    factory: EntryFactory,
+    _qfield: str,
+) -> None:
+    fake = _install_fake_server(tmp_path)
+    payload = factory("create-json").model_dump()
+    body_path = tmp_path / "body.json"
+    body_path.write_text(json.dumps(payload), encoding="utf-8")
+
+    result = runner.invoke(app, ["catalog", entity, "create", "--file", str(body_path)])
+    assert result.exit_code == 0, result.stderr
+    assert "create-json" in result.stdout
+    post = [r for r in fake.captured_requests if r.method == "POST"][-1]
+    assert post.headers["content-type"] == "application/json"
+
+
+@pytest.mark.parametrize(("entity", "factory", "_qfield"), ENTITIES)
+def test_create_stdin_defaults_to_json(
+    runner: CliRunner,
+    tmp_path: Path,
+    entity: str,
+    factory: EntryFactory,
+    _qfield: str,
+) -> None:
+    fake = _install_fake_server(tmp_path)
+    payload = factory("stdin-json").model_dump()
+    result = runner.invoke(app, ["catalog", entity, "create"], input=json.dumps(payload))
+    assert result.exit_code == 0, result.stderr
+    assert "stdin-json" in result.stdout
+    post = [r for r in fake.captured_requests if r.method == "POST"][-1]
+    assert post.headers["content-type"] == "application/json"
+
+
+@pytest.mark.parametrize(("entity", "factory", "_qfield"), ENTITIES)
+def test_create_stdin_yaml_format_flips_content_type(
+    runner: CliRunner,
+    tmp_path: Path,
+    entity: str,
+    factory: EntryFactory,
+    _qfield: str,
+) -> None:
+    fake = _install_fake_server(tmp_path)
+    payload = factory("stdin-yaml").model_dump()
+    result = runner.invoke(
+        app,
+        ["--format", "yaml", "catalog", entity, "create"],
+        input=json.dumps(payload),
+    )
+    assert result.exit_code == 0, result.stderr
+    post = [r for r in fake.captured_requests if r.method == "POST"][-1]
+    assert post.headers["content-type"] == "application/yaml"
+
+
+@pytest.mark.parametrize(("entity", "factory", "_qfield"), ENTITIES)
+def test_create_duplicate_409(
+    runner: CliRunner,
+    tmp_path: Path,
+    entity: str,
+    factory: EntryFactory,
+    _qfield: str,
+) -> None:
+    payload = factory("dup").model_dump()
+    _install_fake_server(tmp_path, pre_seed=[(entity, payload)])
+    body_path = tmp_path / "body.json"
+    body_path.write_text(json.dumps(payload), encoding="utf-8")
+
+    result = runner.invoke(app, ["catalog", entity, "create", "--file", str(body_path)])
+    assert result.exit_code == 1
+    assert "HTTP 409" in result.stderr
+    assert "dup" in result.stderr
+
+
+def test_create_malformed_body_422(runner: CliRunner, tmp_path: Path) -> None:
+    """AC #10 — a malformed body → server 422 → CLI exits 1 with detail."""
+    _install_fake_server(tmp_path)
+    body_path = tmp_path / "bad.json"
+    body_path.write_text("not-json-at-all-{{", encoding="utf-8")
+
+    result = runner.invoke(app, ["catalog", "templates", "create", "--file", str(body_path)])
+    assert result.exit_code == 1
+    assert "HTTP 422" in result.stderr
+    assert "malformed body" in result.stderr
+
+
+def test_create_unsupported_extension_no_http(runner: CliRunner, tmp_path: Path) -> None:
+    """AC #4 — ``.txt`` exits non-zero; no HTTP call is made."""
+    fake = _install_fake_server(tmp_path)
+    body_path = tmp_path / "body.txt"
+    body_path.write_text("ignored", encoding="utf-8")
+
+    result = runner.invoke(app, ["catalog", "templates", "create", "--file", str(body_path)])
+    assert result.exit_code == 1
+    assert "Unsupported file extension 'txt'" in result.stderr
+    assert "use .yaml, .yml, or .json" in result.stderr
+    assert fake.captured_requests == []
+
+
+# ---------------------------------------------------------------------------
+# update (file json + unknown 404)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(("entity", "factory", "_qfield"), ENTITIES)
+def test_update_file_json_happy_path(
+    runner: CliRunner,
+    tmp_path: Path,
+    entity: str,
+    factory: EntryFactory,
+    _qfield: str,
+) -> None:
+    payload = factory("upd").model_dump()
+    fake = _install_fake_server(tmp_path, pre_seed=[(entity, payload)])
+    body_path = tmp_path / "body.json"
+    body_path.write_text(json.dumps(payload), encoding="utf-8")
+
+    result = runner.invoke(app, ["catalog", entity, "update", "upd", "--file", str(body_path)])
+    assert result.exit_code == 0, result.stderr
+    assert "upd" in result.stdout
+    put = [r for r in fake.captured_requests if r.method == "PUT"][-1]
+    assert put.headers["content-type"] == "application/json"
+
+
+# ---------------------------------------------------------------------------
+# delete (happy + structured payload + unknown 404)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(("entity", "factory", "_qfield"), ENTITIES)
+def test_delete_happy_path_table(
+    runner: CliRunner,
+    tmp_path: Path,
+    entity: str,
+    factory: EntryFactory,
+    _qfield: str,
+) -> None:
+    payload = factory("del").model_dump()
+    _install_fake_server(tmp_path, pre_seed=[(entity, payload)])
+
+    result = runner.invoke(app, ["catalog", entity, "delete", "del"])
+    assert result.exit_code == 0, result.stderr
+    singular = entity.rstrip("s")
+    assert f"Deleted {singular} 'del'." in result.stdout
+
+
+@pytest.mark.parametrize(("entity", "factory", "_qfield"), ENTITIES)
+def test_delete_json_format_structured_payload(
+    runner: CliRunner,
+    tmp_path: Path,
+    entity: str,
+    factory: EntryFactory,
+    _qfield: str,
+) -> None:
+    payload = factory("del-j").model_dump()
+    _install_fake_server(tmp_path, pre_seed=[(entity, payload)])
+
+    result = runner.invoke(app, ["--format", "json", "catalog", entity, "delete", "del-j"])
+    assert result.exit_code == 0, result.stderr
+    decoded = json.loads(result.stdout)
+    assert decoded == {"entity": entity, "id": "del-j", "status": "deleted"}
+
+
+@pytest.mark.parametrize(("entity", "factory", "_qfield"), ENTITIES)
+def test_delete_unknown_404(
+    runner: CliRunner,
+    tmp_path: Path,
+    entity: str,
+    factory: EntryFactory,
+    _qfield: str,
+) -> None:
+    _install_fake_server(tmp_path)
+    result = runner.invoke(app, ["catalog", entity, "delete", "ghost"])
+    assert result.exit_code == 1
+    assert "HTTP 404" in result.stderr
+
+
+# ---------------------------------------------------------------------------
+# Auto-auth inheritance (AC #11)
+# ---------------------------------------------------------------------------
+
+
+def test_list_inherits_bearer_auth_from_profile(runner: CliRunner, tmp_path: Path) -> None:
+    """AC #11 — a config with auth:, a pre-seeded cache → outbound Bearer."""
+    config_path = tmp_path / "config.yaml"
+    _write_auth_config(config_path, profile_name="acme-prod")
+    credentials_dir = tmp_path / "credentials"
+    save_token_cache(
+        "acme-prod",
+        TokenCacheEntry(
+            access_token="test-access-token",
+            refresh_token="rt",
+            expires_at=99_999_999_999,
+        ),
+        credentials_dir=credentials_dir,
+    )
+    # Verify the cache file was created with expected restrictive permissions.
+    cache_file = credentials_dir / "acme-prod.json"
+    assert cache_file.exists()
+    assert stat.S_IMODE(cache_file.stat().st_mode) == 0o600
+
+    main_module._CONFIG_PATH_OVERRIDE = config_path
+    main_module._CREDENTIALS_DIR_OVERRIDE = credentials_dir
+
+    captured_headers: list[httpx.Headers] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured_headers.append(request.headers.copy())
+        return httpx.Response(200, json=[])
+
+    transport = httpx.MockTransport(handler)
+
+    def factory(profile: Any, **kwargs: Any) -> httpx.Client:
+        from akgentic.infra.cli.http import build_http_client_with_auto_auth  # noqa: PLC0415
+
+        return build_http_client_with_auto_auth(profile, transport=transport, **kwargs)
+
+    main_module._HTTP_CLIENT_FACTORY_OVERRIDE = factory
+
+    result = runner.invoke(app, ["catalog", "templates", "list"])
+    assert result.exit_code == 0, result.stderr
+    assert captured_headers
+    assert captured_headers[-1].get("authorization") == "Bearer test-access-token"

--- a/tests/server/routes/test_admin_catalog.py
+++ b/tests/server/routes/test_admin_catalog.py
@@ -9,65 +9,83 @@ Covers every entity × every verb plus the ADR-022 §D2 error matrix:
 * Structured log line on every mutation; reads stay silent at INFO.
 
 All tests use real ``TierServices`` (YAML-backed catalogs, ``NoAuth``) via the
-top-level ``client`` fixture — no mocks.
+top-level ``client`` fixture — no mocks. Payloads are constructed as Pydantic
+models (no ``dict[str, Any]`` per AC #11 / Golden Rule #1); the one exception
+is the 422-malformed-body test, which uses a narrowly typed raw payload so the
+missing-field path can actually be exercised.
 """
 
 from __future__ import annotations
 
 import logging
+from collections.abc import Callable
 from pathlib import Path
-from typing import Any
 
 import pytest
+from akgentic.catalog.models import (
+    AgentEntry,
+    TeamEntry,
+    TemplateEntry,
+    ToolEntry,
+)
 from fastapi import APIRouter, FastAPI
 from fastapi.testclient import TestClient
+from pydantic import BaseModel
 
 # --- Payload factories (reused across parametrised tests) --------------------
 
 
-def _template_payload(tid: str = "admin-tpl") -> dict[str, Any]:
-    """A minimal valid TemplateEntry payload."""
-    return {"id": tid, "template": "Hello {name}, you are {role}."}
+def _template_payload(tid: str = "admin-tpl") -> TemplateEntry:
+    """A minimal valid TemplateEntry with placeholders ``name`` and ``role``."""
+    return TemplateEntry(id=tid, template="Hello {name}, you are {role}.")
 
 
-def _tool_payload(tid: str = "admin-tool") -> dict[str, Any]:
-    """A minimal valid ToolEntry payload."""
-    return {
-        "id": tid,
-        "tool_class": "akgentic.tool.search.SearchTool",
-        "tool": {"name": "search", "description": "Search the web"},
-    }
+def _tool_payload(tid: str = "admin-tool") -> ToolEntry:
+    """A minimal valid ToolEntry."""
+    return ToolEntry.model_validate(
+        {
+            "id": tid,
+            "tool_class": "akgentic.tool.search.SearchTool",
+            "tool": {"name": "search", "description": "Search the web"},
+        }
+    )
 
 
-def _agent_payload(tid: str = "admin-agent") -> dict[str, Any]:
-    """A minimal valid AgentEntry payload."""
-    return {
-        "id": tid,
-        "tool_ids": [],
-        "card": {
-            "role": "engineer",
-            "description": "admin-router test agent",
-            "skills": ["coding"],
-            "agent_class": "akgentic.agent.BaseAgent",
-            "config": {"name": "@Eng", "role": "Engineer"},
-            "routes_to": [],
-        },
-    }
+def _agent_payload(tid: str = "admin-agent") -> AgentEntry:
+    """A minimal valid AgentEntry."""
+    return AgentEntry.model_validate(
+        {
+            "id": tid,
+            "tool_ids": [],
+            "card": {
+                "role": "engineer",
+                "description": "admin-router test agent",
+                "skills": ["coding"],
+                "agent_class": "akgentic.agent.BaseAgent",
+                "config": {"name": "@Eng", "role": "Engineer"},
+                "routes_to": [],
+            },
+        }
+    )
 
 
-def _team_payload(tid: str = "admin-team") -> dict[str, Any]:
-    """A minimal valid TeamEntry payload referencing the seeded ``human-proxy``."""
-    return {
-        "id": tid,
-        "name": f"Admin Team {tid}",
-        "entry_point": "human-proxy",
-        "message_types": ["akgentic.core.messages.UserMessage"],
-        "members": [{"agent_id": "human-proxy"}],
-    }
+def _team_payload(tid: str = "admin-team") -> TeamEntry:
+    """A minimal valid TeamEntry referencing the seeded ``human-proxy``."""
+    return TeamEntry.model_validate(
+        {
+            "id": tid,
+            "name": f"Admin Team {tid}",
+            "entry_point": "human-proxy",
+            "message_types": ["akgentic.core.messages.UserMessage"],
+            "members": [{"agent_id": "human-proxy"}],
+        }
+    )
 
+
+EntryFactory = Callable[[str], BaseModel]
 
 # Each tuple: (entity_name, payload_factory, query_field_for_search_test)
-ENTITIES: list[tuple[str, Any, str]] = [
+ENTITIES: list[tuple[str, EntryFactory, str]] = [
     ("templates", _template_payload, "placeholder"),
     ("tools", _tool_payload, "name"),
     ("agents", _agent_payload, "description"),
@@ -75,9 +93,9 @@ ENTITIES: list[tuple[str, Any, str]] = [
 ]
 
 
-def _seed(client: TestClient, entity: str, payload: dict[str, Any]) -> None:
+def _seed(client: TestClient, entity: str, payload: BaseModel) -> None:
     """POST a payload to the admin router (idempotent: allow 201 or 409)."""
-    resp = client.post(f"/admin/catalog/{entity}", json=payload)
+    resp = client.post(f"/admin/catalog/{entity}", json=payload.model_dump())
     assert resp.status_code in (201, 409)
 
 
@@ -102,13 +120,9 @@ def test_registration_removal_eliminates_only_that_entity(skipped_entity: str) -
     each registered entity contributes exactly five (AC #9 updated spec).
     """
     from akgentic.catalog.models import (
-        AgentEntry,
         AgentQuery,
-        TeamEntry,
         TeamQuery,
-        TemplateEntry,
         TemplateQuery,
-        ToolEntry,
         ToolQuery,
     )
 
@@ -120,38 +134,39 @@ def test_registration_removal_eliminates_only_that_entity(skipped_entity: str) -
         _register_entity_routes,
     )
 
-    registrations: dict[str, dict[str, Any]] = {
-        "templates": {
-            "entity_name": "templates",
-            "get_catalog": _get_template_catalog,
-            "entry_model": TemplateEntry,
-            "query_from_q": lambda s: TemplateQuery(placeholder=s),
-        },
-        "tools": {
-            "entity_name": "tools",
-            "get_catalog": _get_tool_catalog,
-            "entry_model": ToolEntry,
-            "query_from_q": lambda s: ToolQuery(name=s),
-        },
-        "agents": {
-            "entity_name": "agents",
-            "get_catalog": _get_agent_catalog,
-            "entry_model": AgentEntry,
-            "query_from_q": lambda s: AgentQuery(description=s),
-        },
-        "teams": {
-            "entity_name": "teams",
-            "get_catalog": _get_team_catalog,
-            "entry_model": TeamEntry,
-            "query_from_q": lambda s: TeamQuery(name=s),
-        },
-    }
-
     partial_router = APIRouter(prefix="/admin/catalog")
-    for name, kwargs in registrations.items():
-        if name == skipped_entity:
-            continue
-        _register_entity_routes(partial_router, **kwargs)
+    if skipped_entity != "templates":
+        _register_entity_routes(
+            partial_router,
+            entity_name="templates",
+            get_catalog=_get_template_catalog,
+            entry_model=TemplateEntry,
+            query_from_q=lambda s: TemplateQuery(placeholder=s),
+        )
+    if skipped_entity != "tools":
+        _register_entity_routes(
+            partial_router,
+            entity_name="tools",
+            get_catalog=_get_tool_catalog,
+            entry_model=ToolEntry,
+            query_from_q=lambda s: ToolQuery(name=s),
+        )
+    if skipped_entity != "agents":
+        _register_entity_routes(
+            partial_router,
+            entity_name="agents",
+            get_catalog=_get_agent_catalog,
+            entry_model=AgentEntry,
+            query_from_q=lambda s: AgentQuery(description=s),
+        )
+    if skipped_entity != "teams":
+        _register_entity_routes(
+            partial_router,
+            entity_name="teams",
+            get_catalog=_get_team_catalog,
+            entry_model=TeamEntry,
+            query_from_q=lambda s: TeamQuery(name=s),
+        )
 
     app = FastAPI()
     app.include_router(partial_router)
@@ -179,7 +194,7 @@ def test_registration_removal_eliminates_only_that_entity(skipped_entity: str) -
 def test_list_happy_path(
     client: TestClient,
     entity: str,
-    payload_factory: Any,
+    payload_factory: EntryFactory,
     query_field: str,
 ) -> None:
     """GET /admin/catalog/{entity} returns a list (may include seeded entries)."""
@@ -196,13 +211,23 @@ def test_list_happy_path(
 def test_list_with_q_happy_path(
     client: TestClient,
     entity: str,
-    payload_factory: Any,
+    payload_factory: EntryFactory,
     query_field: str,
 ) -> None:
-    """GET /admin/catalog/{entity}?q=... returns filtered results via search."""
+    """GET /admin/catalog/{entity}?q=... returns filtered results via search.
+
+    Per-entity query semantics (from admin_catalog.py docstring):
+
+    * ``templates`` → ``TemplateQuery(placeholder=s)``: exact-match on a
+      placeholder NAME present in the template. Our template is
+      ``"Hello {name}, you are {role}."`` so ``q="name"`` matches; anything
+      else (e.g., ``"Hello"``) would not.
+    * ``tools``/``teams`` → ``ToolQuery(name=s)``/``TeamQuery(name=s)``:
+      substring match on ``name``.
+    * ``agents`` → ``AgentQuery(description=s)``: substring match on
+      ``description``.
+    """
     _seed(client, entity, payload_factory(f"q-{entity}"))
-    # Templates search on `placeholder`: our payload includes 'name' and 'role'.
-    # Tools/Teams search on `name`; Agents search on `description`.
     q_value = {
         "templates": "name",
         "tools": "search",
@@ -224,7 +249,7 @@ def test_list_with_q_happy_path(
 def test_get_happy_path(
     client: TestClient,
     entity: str,
-    payload_factory: Any,
+    payload_factory: EntryFactory,
     query_field: str,
 ) -> None:
     """GET /admin/catalog/{entity}/{id} returns the entry body."""
@@ -236,7 +261,7 @@ def test_get_happy_path(
 
 @pytest.mark.parametrize(("entity", "_factory", "_qfield"), ENTITIES)
 def test_get_unknown_returns_404_with_error_shape(
-    client: TestClient, entity: str, _factory: Any, _qfield: str
+    client: TestClient, entity: str, _factory: EntryFactory, _qfield: str
 ) -> None:
     """Unknown id → 404 via the global handler, with ErrorResponse shape."""
     resp = client.get(f"/admin/catalog/{entity}/does-not-exist")
@@ -254,12 +279,12 @@ def test_get_unknown_returns_404_with_error_shape(
 def test_create_happy_path(
     client: TestClient,
     entity: str,
-    payload_factory: Any,
+    payload_factory: EntryFactory,
     _qfield: str,
 ) -> None:
     """POST returns 201, echoes the entry, and subsequent GET retrieves it."""
     payload = payload_factory(f"create-{entity}")
-    resp = client.post(f"/admin/catalog/{entity}", json=payload)
+    resp = client.post(f"/admin/catalog/{entity}", json=payload.model_dump())
     assert resp.status_code == 201
     assert resp.json()["id"] == f"create-{entity}"
 
@@ -272,14 +297,14 @@ def test_create_happy_path(
 def test_create_duplicate_returns_409(
     client: TestClient,
     entity: str,
-    payload_factory: Any,
+    payload_factory: EntryFactory,
     _qfield: str,
 ) -> None:
     """Creating an entry with an already-used id → 409."""
     payload = payload_factory(f"dup-{entity}")
-    first = client.post(f"/admin/catalog/{entity}", json=payload)
+    first = client.post(f"/admin/catalog/{entity}", json=payload.model_dump())
     assert first.status_code == 201
-    second = client.post(f"/admin/catalog/{entity}", json=payload)
+    second = client.post(f"/admin/catalog/{entity}", json=payload.model_dump())
     assert second.status_code == 409
     body = second.json()
     assert set(body.keys()) == {"detail", "errors"}
@@ -287,13 +312,17 @@ def test_create_duplicate_returns_409(
 
 
 def test_create_malformed_body_returns_422(client: TestClient) -> None:
-    """Posting a TeamEntry missing the required ``entry_point`` → 422."""
-    bad_payload = {
+    """Posting a TeamEntry missing the required ``entry_point`` → 422.
+
+    This test uses a raw payload (narrow ``str | list[str]`` union) by design:
+    the whole point is to bypass the Pydantic model so the missing-field path
+    through FastAPI's default 422 handler is exercised.
+    """
+    bad_payload: dict[str, str | list[str]] = {
         "id": "malformed",
         "name": "Malformed",
         # entry_point missing
         "message_types": ["akgentic.core.messages.UserMessage"],
-        "members": [{"agent_id": "human-proxy"}],
     }
     resp = client.post("/admin/catalog/teams", json=bad_payload)
     assert resp.status_code == 422
@@ -306,14 +335,14 @@ def test_create_malformed_body_returns_422(client: TestClient) -> None:
 def test_update_happy_path(
     client: TestClient,
     entity: str,
-    payload_factory: Any,
+    payload_factory: EntryFactory,
     _qfield: str,
 ) -> None:
     """PUT replaces the entry; subsequent GET reflects the change."""
     eid = f"upd-{entity}"
     _seed(client, entity, payload_factory(eid))
 
-    updated = payload_factory(eid)
+    updated = payload_factory(eid).model_dump()
     # Tweak a descriptive field per entity so we can observe the change
     if entity == "templates":
         updated["template"] = "Updated {name}."
@@ -343,11 +372,14 @@ def test_update_happy_path(
 def test_update_unknown_returns_404(
     client: TestClient,
     entity: str,
-    payload_factory: Any,
+    payload_factory: EntryFactory,
     _qfield: str,
 ) -> None:
     """PUT on an unknown id → 404 via the global handler."""
-    resp = client.put(f"/admin/catalog/{entity}/unknown-id", json=payload_factory("unknown-id"))
+    resp = client.put(
+        f"/admin/catalog/{entity}/unknown-id",
+        json=payload_factory("unknown-id").model_dump(),
+    )
     assert resp.status_code == 404
 
 
@@ -355,7 +387,7 @@ def test_update_unknown_returns_404(
 def test_update_id_mismatch_returns_409(
     client: TestClient,
     entity: str,
-    payload_factory: Any,
+    payload_factory: EntryFactory,
     _qfield: str,
 ) -> None:
     """PUT with a path id that differs from the body id → 409."""
@@ -363,7 +395,7 @@ def test_update_id_mismatch_returns_409(
     _seed(client, entity, payload_factory(eid))
     # Body claims a different id than the URL path
     mismatched = payload_factory("different-id")
-    resp = client.put(f"/admin/catalog/{entity}/{eid}", json=mismatched)
+    resp = client.put(f"/admin/catalog/{entity}/{eid}", json=mismatched.model_dump())
     assert resp.status_code == 409
 
 
@@ -374,7 +406,7 @@ def test_update_id_mismatch_returns_409(
 def test_delete_happy_path(
     client: TestClient,
     entity: str,
-    payload_factory: Any,
+    payload_factory: EntryFactory,
     _qfield: str,
 ) -> None:
     """DELETE returns 204; subsequent GET returns 404."""
@@ -389,7 +421,7 @@ def test_delete_happy_path(
 
 @pytest.mark.parametrize(("entity", "_factory", "_qfield"), ENTITIES)
 def test_delete_unknown_returns_404(
-    client: TestClient, entity: str, _factory: Any, _qfield: str
+    client: TestClient, entity: str, _factory: EntryFactory, _qfield: str
 ) -> None:
     """DELETE of an unknown id → 404 via the global handler."""
     resp = client.delete(f"/admin/catalog/{entity}/does-not-exist")
@@ -406,10 +438,11 @@ def test_mutation_logging_emits_exactly_three_info_records(
     caplog.set_level(logging.INFO, logger="akgentic.infra.server.routes.admin_catalog")
 
     payload = _team_payload("log-team")
+    body = payload.model_dump()
 
-    resp = client.post("/admin/catalog/teams", json=payload)
+    resp = client.post("/admin/catalog/teams", json=body)
     assert resp.status_code == 201
-    resp = client.put("/admin/catalog/teams/log-team", json=payload)
+    resp = client.put("/admin/catalog/teams/log-team", json=body)
     assert resp.status_code == 200
     resp = client.delete("/admin/catalog/teams/log-team")
     assert resp.status_code == 204
@@ -420,12 +453,12 @@ def test_mutation_logging_emits_exactly_three_info_records(
         if r.name == "akgentic.infra.server.routes.admin_catalog" and r.levelname == "INFO"
     ]
     assert len(info_records) == 3
-    ops = [r.operation for r in info_records]  # type: ignore[attr-defined]
+    ops = [getattr(r, "operation") for r in info_records]
     assert ops == ["create", "update", "delete"]
     for r in info_records:
-        assert r.entity_type == "teams"  # type: ignore[attr-defined]
-        assert r.entity_id == "log-team"  # type: ignore[attr-defined]
-        assert r.principal_id == "anonymous"  # type: ignore[attr-defined]
+        assert getattr(r, "entity_type") == "teams"
+        assert getattr(r, "entity_id") == "log-team"
+        assert getattr(r, "principal_id") == "anonymous"
 
 
 def test_reads_do_not_emit_info_logs(client: TestClient, caplog: pytest.LogCaptureFixture) -> None:


### PR DESCRIPTION
## Summary

Implements story 23.2 — `ak catalog <entity> <verb>` CLI command group. Adds a single, generic-over-entity command module that exposes five CRUD verbs (`list`, `get`, `create`, `update`, `delete`) over the four catalog entities (`templates`, `tools`, `agents`, `teams`) against the admin-catalog router shipped by story 23.1. The CLI is a thin HTTP wire — server-side validation only, no parallel parsing in the client.

- New module `packages/akgentic-infra/src/akgentic/infra/cli/commands/catalog.py` — one `register(app)` entry point + a private `_register_entity_commands` helper applied four times. The only per-entity asymmetry is the `_COLUMNS_BY_ENTITY` constant.
- Extended `ApiClient` (`cli/client.py`) with five thin-wire methods (`admin_catalog_list|get|create|update|delete`) and a `_raw_request` helper for content-type-aware body posts.
- Wired `catalog_command.register(app)` into `cli/main.py` with exactly one new import line and one new register line alongside the existing `login` / `logout` registrations.
- Comprehensive test matrix: every entity x every verb (20 happy-path invocations), 404/409/422 error matrix, table/json/yaml format flag matrix, content-type inference rules (including `.txt` → no HTTP call), registration-count invariant, structural invariants, and auto-auth inheritance. 74 tests pass.

Closes #247

## Stacking

This PR is stacked on `feat/241-admin-catalog-router` (story 23.1). Merge order matters: 23.1 first, then this branch.

## Test results

- `pytest packages/akgentic-infra/tests/cli/commands/test_catalog.py` — 74 passed
- `pytest packages/akgentic-infra/tests/cli/` — 626 passed
- `mypy packages/akgentic-infra/src/` — clean (107 source files)
- `ruff check` + `ruff format --check` — clean
- Per-module coverage: `commands/catalog.py` 100 %, `cli/client.py` 93 %
