### PR TITLE
Close ADR-022 §D4 YAML-body gap + tighten CLI response typing

### DIFF
--- a/src/akgentic/infra/cli/client.py
+++ b/src/akgentic/infra/cli/client.py
@@ -3,13 +3,24 @@
 from __future__ import annotations
 
 import logging
-from typing import Any
+from typing import Any, cast
 
 import httpx
 from pydantic import BaseModel, model_validator
 
+from akgentic.catalog.models import AgentEntry, TeamEntry, TemplateEntry, ToolEntry
 from akgentic.core.messages.message import Message
 from akgentic.core.utils.deserializer import deserialize_object
+
+# Typed admin-catalog entry union (ADR-022 §D4 response side).
+CatalogEntry = TemplateEntry | ToolEntry | AgentEntry | TeamEntry
+
+_ENTITY_MODELS: dict[str, type[BaseModel]] = {
+    "templates": TemplateEntry,
+    "tools": ToolEntry,
+    "agents": AgentEntry,
+    "teams": TeamEntry,
+}
 
 _log = logging.getLogger(__name__)
 
@@ -103,6 +114,17 @@ class ApiError(Exception):
     def retryable(self) -> bool:
         """True for transient server errors and network issues."""
         return self.status_code >= 500 or self.status_code == 429 or self.status_code == 0
+
+
+def _require_json_object(body: object) -> dict[str, Any]:
+    """Guard: return ``body`` as a ``dict`` or raise :class:`ApiError`.
+
+    Replaces the previous bare ``assert isinstance(body, dict)`` so malformed
+    server responses still surface as an ``ApiError`` under ``python -O``.
+    """
+    if not isinstance(body, dict):
+        raise ApiError(0, "unexpected response shape: expected JSON object")
+    return dict(body)
 
 
 class ApiClient:
@@ -313,37 +335,38 @@ class ApiClient:
         self,
         entity: str,
         q: str | None = None,
-    ) -> list[dict[str, Any]]:
-        """GET /admin/catalog/<entity> → list of entries.
+    ) -> list[CatalogEntry]:
+        """GET /admin/catalog/<entity> → list of typed entries.
 
-        Returns the parsed JSON response body verbatim (``list[dict]``).
-        ``q`` is forwarded as ``?q=<text>`` when supplied.
+        ``q`` is forwarded as ``?q=<text>`` when supplied. Malformed responses
+        (non-list top-level) raise :class:`ApiError` — no silent empty-list
+        fallback.
         """
         params: dict[str, str] = {"q": q} if q is not None else {}
         resp = self._request("GET", f"/admin/catalog/{entity}", params=params or None)
         body = resp.json()
         if not isinstance(body, list):
-            return []
-        return list(body)
+            raise ApiError(0, "unexpected response shape: expected JSON array")
+        model = _ENTITY_MODELS[entity]
+        return [cast(CatalogEntry, model.model_validate(item)) for item in body]
 
-    def admin_catalog_get(self, entity: str, entry_id: str) -> dict[str, Any]:
-        """GET /admin/catalog/<entity>/<id> → single entry body."""
+    def admin_catalog_get(self, entity: str, entry_id: str) -> CatalogEntry:
+        """GET /admin/catalog/<entity>/<id> → typed entry."""
         resp = self._request("GET", f"/admin/catalog/{entity}/{entry_id}")
-        body = resp.json()
-        assert isinstance(body, dict)
-        return dict(body)
+        body = _require_json_object(resp.json())
+        return cast(CatalogEntry, _ENTITY_MODELS[entity].model_validate(body))
 
     def admin_catalog_create(
         self,
         entity: str,
         body: bytes,
         content_type: str,
-    ) -> dict[str, Any]:
-        """POST /admin/catalog/<entity> → created entry body.
+    ) -> CatalogEntry:
+        """POST /admin/catalog/<entity> → created typed entry.
 
         ``body`` is forwarded unchanged; ``content_type`` is one of
         ``application/json`` or ``application/yaml``. The server is the
-        validation point — the CLI does not parse the payload.
+        validation point — the CLI does not parse the outbound payload.
         """
         resp = self._raw_request(
             "POST",
@@ -351,9 +374,8 @@ class ApiClient:
             content=body,
             content_type=content_type,
         )
-        data = resp.json()
-        assert isinstance(data, dict)
-        return dict(data)
+        data = _require_json_object(resp.json())
+        return cast(CatalogEntry, _ENTITY_MODELS[entity].model_validate(data))
 
     def admin_catalog_update(
         self,
@@ -361,17 +383,16 @@ class ApiClient:
         entry_id: str,
         body: bytes,
         content_type: str,
-    ) -> dict[str, Any]:
-        """PUT /admin/catalog/<entity>/<id> → updated entry body."""
+    ) -> CatalogEntry:
+        """PUT /admin/catalog/<entity>/<id> → updated typed entry."""
         resp = self._raw_request(
             "PUT",
             f"/admin/catalog/{entity}/{entry_id}",
             content=body,
             content_type=content_type,
         )
-        data = resp.json()
-        assert isinstance(data, dict)
-        return dict(data)
+        data = _require_json_object(resp.json())
+        return cast(CatalogEntry, _ENTITY_MODELS[entity].model_validate(data))
 
     def admin_catalog_delete(self, entity: str, entry_id: str) -> None:
         """DELETE /admin/catalog/<entity>/<id> — 204 on success."""

--- a/src/akgentic/infra/cli/commands/catalog.py
+++ b/src/akgentic/infra/cli/commands/catalog.py
@@ -34,6 +34,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Annotated
 
 import typer
+from pydantic import BaseModel
 
 from akgentic.infra.cli.client import ApiError
 from akgentic.infra.cli.formatters import OutputFormat, format_output
@@ -94,10 +95,24 @@ def _read_body(
     return body, content_type
 
 
+def _to_dict_or_list(data: object) -> object:
+    """Pre-convert typed Pydantic entries to dicts for the formatter.
+
+    The ``format_output`` formatter projects by string key (``row.get(col)``),
+    so typed ``CatalogEntry`` values must be converted to dicts first. This
+    preserves the formatter's public contract without rewriting it.
+    """
+    if isinstance(data, BaseModel):
+        return data.model_dump()
+    if isinstance(data, list):
+        return [item.model_dump() if isinstance(item, BaseModel) else item for item in data]
+    return data
+
+
 def _render_entity(data: object, entity_name: str, fmt: OutputFormat) -> None:
     """Render a single entity body or a list of entity bodies."""
     columns = _COLUMNS_BY_ENTITY[entity_name]
-    typer.echo(format_output(data, fmt, columns))
+    typer.echo(format_output(_to_dict_or_list(data), fmt, columns))
 
 
 def _current_state() -> _State:

--- a/src/akgentic/infra/server/routes/admin_catalog.py
+++ b/src/akgentic/infra/server/routes/admin_catalog.py
@@ -24,12 +24,14 @@ emitter, where ``services.auth.authenticate(request)`` feeds the
 """
 
 import builtins
+import json
 import logging
 from collections.abc import Callable
 from typing import Generic, Protocol, TypeVar, cast
 
-from fastapi import APIRouter, Depends, Request
-from pydantic import BaseModel
+import yaml
+from fastapi import APIRouter, Depends, HTTPException, Request
+from pydantic import BaseModel, ValidationError
 
 from akgentic.catalog.models import (
     AgentEntry,
@@ -121,6 +123,52 @@ def _emit_mutation_log(
     )
 
 
+# --- Request-body parsing (ADR-022 §D4: JSON + YAML single validation point) --
+
+_YAML_CONTENT_TYPES = frozenset({"application/yaml", "application/x-yaml"})
+
+
+async def _parse_entry_body(request: Request, entry_model: type[BaseModel]) -> BaseModel:
+    """Parse the request body into ``entry_model`` based on ``Content-Type``.
+
+    Accepts ``application/json`` (or missing header) and
+    ``application/yaml`` / ``application/x-yaml``. Content-type parameters
+    (``; charset=utf-8``) are tolerated — split on ``;``, strip, lower-case the
+    head.
+
+    Invalid YAML raises ``HTTPException(422, "invalid YAML body: ...")``.
+    Unsupported content types raise ``HTTPException(415, ...)``. Pydantic
+    ``ValidationError`` on ``entry_model.model_validate`` is mapped to a 422
+    ``HTTPException`` (mirrors FastAPI's default body-binding behaviour now
+    that the explicit body parameter has been replaced with raw-request
+    dispatch).
+    """
+    raw_ct = request.headers.get("content-type", "application/json")
+    content_type = raw_ct.split(";")[0].strip().lower()
+    raw = await request.body()
+
+    if content_type == "application/json" or content_type == "":
+        parsed: object = json.loads(raw) if raw else {}
+    elif content_type in _YAML_CONTENT_TYPES:
+        try:
+            parsed = yaml.safe_load(raw) if raw else {}
+        except yaml.YAMLError as exc:
+            raise HTTPException(status_code=422, detail=f"invalid YAML body: {exc}") from exc
+    else:
+        raise HTTPException(
+            status_code=415,
+            detail=(
+                f"unsupported Content-Type: {content_type!r}; "
+                "expected application/json or application/yaml"
+            ),
+        )
+
+    try:
+        return entry_model.model_validate(parsed)
+    except ValidationError as exc:
+        raise HTTPException(status_code=422, detail=exc.errors()) from exc
+
+
 # --- Generic route registration ----------------------------------------------
 
 
@@ -174,26 +222,26 @@ def _register_entity_routes(  # noqa: UP047
         return result
 
     @router.post(prefix, response_model=entry_model, status_code=201)
-    def _create_entry(
-        entry: entry_model,  # type: ignore[valid-type]
+    async def _create_entry(
         request: Request,
         catalog: _CatalogProto[EntryT, QueryT] = Depends(get_catalog),
     ) -> EntryT:
+        entry = cast(EntryT, await _parse_entry_body(request, entry_model))
         catalog.create(entry)
         entry_id = cast(str, getattr(entry, "id"))  # noqa: B009
         _emit_mutation_log(request, entity_name=entity_name, entity_id=entry_id, operation="create")
-        return cast(EntryT, entry)
+        return entry
 
     @router.put(prefix + "/{entry_id}", response_model=entry_model)
-    def _update_entry(
+    async def _update_entry(
         entry_id: str,
-        entry: entry_model,  # type: ignore[valid-type]
         request: Request,
         catalog: _CatalogProto[EntryT, QueryT] = Depends(get_catalog),
     ) -> EntryT:
+        entry = cast(EntryT, await _parse_entry_body(request, entry_model))
         catalog.update(entry_id, entry)
         _emit_mutation_log(request, entity_name=entity_name, entity_id=entry_id, operation="update")
-        return cast(EntryT, entry)
+        return entry
 
     @router.delete(prefix + "/{entry_id}", status_code=204)
     def _delete_entry(

--- a/tests/server/routes/test_admin_catalog.py
+++ b/tests/server/routes/test_admin_catalog.py
@@ -21,7 +21,9 @@ import logging
 from collections.abc import Callable
 from pathlib import Path
 
+import httpx
 import pytest
+import yaml
 from akgentic.catalog.models import (
     AgentEntry,
     TeamEntry,
@@ -496,3 +498,136 @@ def test_admin_catalog_module_does_not_import_auth_protocol() -> None:
 
     src = Path(m.__file__).read_text()
     assert "akgentic.infra.protocols.auth" not in src
+
+
+# --- YAML request-body support (ADR-022 §D4) --------------------------------
+
+
+def _post_yaml_resp(
+    client: TestClient, entity: str, body_dict: dict[str, object]
+) -> httpx.Response:
+    return client.post(
+        f"/admin/catalog/{entity}",
+        content=yaml.safe_dump(body_dict).encode(),
+        headers={"Content-Type": "application/yaml"},
+    )
+
+
+def _put_yaml_resp(
+    client: TestClient, entity: str, entry_id: str, body_dict: dict[str, object]
+) -> httpx.Response:
+    return client.put(
+        f"/admin/catalog/{entity}/{entry_id}",
+        content=yaml.safe_dump(body_dict).encode(),
+        headers={"Content-Type": "application/yaml"},
+    )
+
+
+@pytest.mark.parametrize(("entity", "payload_factory", "_qfield"), ENTITIES)
+def test_yaml_post_happy_path(
+    client: TestClient,
+    entity: str,
+    payload_factory: EntryFactory,
+    _qfield: str,
+) -> None:
+    """POST application/yaml → 201; subsequent GET returns the posted entry."""
+    payload = payload_factory(f"yaml-post-{entity}").model_dump()
+    resp = _post_yaml_resp(client, entity, payload)
+    assert resp.status_code == 201, resp.text
+    got = client.get(f"/admin/catalog/{entity}/yaml-post-{entity}")
+    assert got.status_code == 200
+    # Round-trip: posted dict equals the stored entry (operator-owned fields)
+    assert got.json() == payload
+
+
+@pytest.mark.parametrize(("entity", "payload_factory", "_qfield"), ENTITIES)
+def test_yaml_put_happy_path(
+    client: TestClient,
+    entity: str,
+    payload_factory: EntryFactory,
+    _qfield: str,
+) -> None:
+    """PUT application/yaml → 200; GET reflects the mutated field."""
+    eid = f"yaml-put-{entity}"
+    _seed(client, entity, payload_factory(eid))
+    updated = payload_factory(eid).model_dump()
+    if entity == "templates":
+        updated["template"] = "Updated {name} via YAML."
+    elif entity == "tools":
+        updated["tool"]["description"] = "updated-via-yaml"
+    elif entity == "agents":
+        updated["card"]["description"] = "updated-via-yaml"
+    elif entity == "teams":
+        updated["description"] = "updated-via-yaml"
+
+    resp = _put_yaml_resp(client, entity, eid, updated)
+    assert resp.status_code == 200, resp.text
+
+    got = client.get(f"/admin/catalog/{entity}/{eid}").json()
+    if entity == "templates":
+        assert "YAML" in got["template"]
+    elif entity == "tools":
+        assert got["tool"]["description"] == "updated-via-yaml"
+    elif entity == "agents":
+        assert got["card"]["description"] == "updated-via-yaml"
+    elif entity == "teams":
+        assert got["description"] == "updated-via-yaml"
+
+
+def test_yaml_post_malformed_returns_422(client: TestClient) -> None:
+    """Malformed YAML body on POST → 422 with ``invalid YAML body:`` prefix."""
+    resp = client.post(
+        "/admin/catalog/templates",
+        content=b"{unclosed: [\n",
+        headers={"Content-Type": "application/yaml"},
+    )
+    assert resp.status_code == 422
+    body = resp.json()
+    assert body["detail"].startswith("invalid YAML body: ")
+
+
+def test_yaml_put_malformed_returns_422(client: TestClient) -> None:
+    """Malformed YAML body on PUT → 422 with ``invalid YAML body:`` prefix."""
+    _seed(client, "templates", _template_payload("put-malformed"))
+    resp = client.put(
+        "/admin/catalog/templates/put-malformed",
+        content=b"{unclosed: [\n",
+        headers={"Content-Type": "application/yaml"},
+    )
+    assert resp.status_code == 422
+    body = resp.json()
+    assert body["detail"].startswith("invalid YAML body: ")
+
+
+def test_post_unsupported_content_type_returns_415(client: TestClient) -> None:
+    """POST with ``text/plain`` → 415 with ``unsupported Content-Type:`` prefix."""
+    resp = client.post(
+        "/admin/catalog/templates",
+        content=b"plain body",
+        headers={"Content-Type": "text/plain"},
+    )
+    assert resp.status_code == 415
+    body = resp.json()
+    assert body["detail"].startswith("unsupported Content-Type: ")
+
+
+def test_yaml_post_with_charset_parameter_accepted(client: TestClient) -> None:
+    """``application/yaml; charset=utf-8`` is treated as ``application/yaml``."""
+    payload = _template_payload("yaml-charset").model_dump()
+    resp = client.post(
+        "/admin/catalog/templates",
+        content=yaml.safe_dump(payload).encode(),
+        headers={"Content-Type": "application/yaml; charset=utf-8"},
+    )
+    assert resp.status_code == 201, resp.text
+
+
+def test_yaml_x_yaml_alias_accepted(client: TestClient) -> None:
+    """``application/x-yaml`` alias is accepted on POST."""
+    payload = _template_payload("yaml-alias").model_dump()
+    resp = client.post(
+        "/admin/catalog/templates",
+        content=yaml.safe_dump(payload).encode(),
+        headers={"Content-Type": "application/x-yaml"},
+    )
+    assert resp.status_code == 201, resp.text


### PR DESCRIPTION
## Summary

Close the ADR-022 §D4 YAML-body gap on the admin-catalog router and tighten CLI response typing per Golden Rule #1.

- Server: `_parse_entry_body` helper on `admin_catalog.py` dispatches on `Content-Type`, accepting `application/json`, `application/yaml`, and `application/x-yaml` (tolerates `; charset=...` parameters). Invalid YAML returns 422 with `invalid YAML body: ...`; unsupported Content-Type returns 415; Pydantic `ValidationError` is mapped to 422 with `detail=exc.errors()` (necessary now that the Pydantic body parameter is gone — FastAPI no longer auto-emits the 422).
- `_create_entry` and `_update_entry` converted to `async def` (required for `await request.body()`); response side unchanged.
- CLI client: `CatalogEntry` union, `_ENTITY_MODELS` dispatch, `_require_json_object` guard; `admin_catalog_{get,list,create,update}` now return typed Pydantic entries. `reload_channels` preserved verbatim per Story 23.3's documented narrow exception.
- CLI commands: `_to_dict_or_list` bridge keeps the existing `format_output` dict-projection contract.
- Tests: 11 new server-side tests (4 YAML-POST happy + 4 YAML-PUT happy + 2 malformed-YAML → 422 + 1 unsupported-Content-Type → 415, plus charset-parameter and `x-yaml` alias assertions).

Closes #251
Relates to epic 23
