### PR TITLE
feat: server-side admin-catalog router (story 23.1)

### DIFF
--- a/src/akgentic/infra/server/app.py
+++ b/src/akgentic/infra/server/app.py
@@ -23,6 +23,7 @@ from akgentic.catalog.api.template_router import set_catalog as set_template_cat
 from akgentic.catalog.api.tool_router import set_catalog as set_tool_catalog
 from akgentic.infra.server.deps import TierServices
 from akgentic.infra.server.logging_config import configure_logging
+from akgentic.infra.server.routes.admin_catalog import router as admin_catalog_router
 from akgentic.infra.server.routes.frontend_adapter import load_frontend_adapter
 from akgentic.infra.server.routes.readiness import router as readiness_router
 from akgentic.infra.server.routes.teams import router as teams_router
@@ -189,6 +190,7 @@ def _mount_routes(app: FastAPI, settings: ServerSettings) -> None:
     app.include_router(ws_router)
     app.include_router(webhook_router)
     app.include_router(readiness_router)
+    app.include_router(admin_catalog_router)
 
     if settings.frontend_adapter:
         adapter = load_frontend_adapter(settings.frontend_adapter)

--- a/src/akgentic/infra/server/routes/admin_catalog.py
+++ b/src/akgentic/infra/server/routes/admin_catalog.py
@@ -1,0 +1,213 @@
+"""Admin catalog router — generic CRUD over templates, tools, agents, teams.
+
+Implements ADR-022 §D1 (five CRUD verbs per entity), §D2 (repository-exception
+→ HTTP-status mapping delegated to the global handlers registered by
+``akgentic.catalog.api._errors.add_exception_handlers``), and §D7 (structured
+INFO-level log line on every mutation; reads stay silent at INFO).
+
+One generic helper :func:`_register_entity_routes` is applied four times — once
+per entity — with per-entity Pydantic entry models and per-entity ``?q=``
+mappings. Adding a fifth entity is a one-line additional call.
+
+`?q=<s>` per-entity mapping (mirrors AC #6):
+
+* ``templates`` → ``TemplateQuery(placeholder=s)``
+* ``tools`` → ``ToolQuery(name=s)``
+* ``agents`` → ``AgentQuery(description=s)``
+* ``teams`` → ``TeamQuery(name=s)``
+
+The router relies entirely on middleware-level auth (ADR-022 §D3) — no
+``Depends(AuthStrategy)`` is attached to any route, and no RBAC role is
+introduced. The only auth contact is defensive, inside the mutation-log
+emitter, where ``services.auth.authenticate(request)`` feeds the
+``principal_id`` log field.
+"""
+
+import logging
+from collections.abc import Callable
+from typing import cast
+
+from fastapi import APIRouter, Depends, Request
+from pydantic import BaseModel
+
+from akgentic.catalog.models import (
+    AgentEntry,
+    AgentQuery,
+    EntryNotFoundError,
+    TeamEntry,
+    TeamQuery,
+    TemplateEntry,
+    TemplateQuery,
+    ToolEntry,
+    ToolQuery,
+)
+from akgentic.catalog.services import (
+    AgentCatalog,
+    TeamCatalog,
+    TemplateCatalog,
+    ToolCatalog,
+)
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/admin/catalog", tags=["admin-catalog"])
+
+
+# --- Per-entity dependency accessors (module-private) -------------------------
+
+
+def _get_template_catalog(request: Request) -> TemplateCatalog:
+    """Read the wired TemplateCatalog from ``app.state.services``."""
+    return cast(TemplateCatalog, request.app.state.services.template_catalog)
+
+
+def _get_tool_catalog(request: Request) -> ToolCatalog:
+    """Read the wired ToolCatalog from ``app.state.services``."""
+    return cast(ToolCatalog, request.app.state.services.tool_catalog)
+
+
+def _get_agent_catalog(request: Request) -> AgentCatalog:
+    """Read the wired AgentCatalog from ``app.state.services``."""
+    return cast(AgentCatalog, request.app.state.services.agent_catalog)
+
+
+def _get_team_catalog(request: Request) -> TeamCatalog:
+    """Read the wired TeamCatalog from ``app.state.services``."""
+    return cast(TeamCatalog, request.app.state.services.team_catalog)
+
+
+# --- Logging helper -----------------------------------------------------------
+
+
+def _emit_mutation_log(
+    request: Request, *, entity_name: str, entity_id: str, operation: str
+) -> None:
+    """Emit one structured INFO log line per mutation (create/update/delete).
+
+    The only field sourced from auth is ``principal_id``, resolved defensively
+    via the already-wired ``services.auth`` — no ``Depends(AuthStrategy)``
+    (ADR-022 §D3, middleware-level auth).
+    """
+    principal_id = request.app.state.services.auth.authenticate(request) or "anonymous"
+    logger.info(
+        "catalog admin mutation",
+        extra={
+            "principal_id": principal_id,
+            "entity_type": entity_name,
+            "entity_id": entity_id,
+            "operation": operation,
+        },
+    )
+
+
+# --- Generic route registration ----------------------------------------------
+
+
+def _register_entity_routes(
+    router: APIRouter,
+    *,
+    entity_name: str,
+    get_catalog: Callable[..., object],
+    entry_model: type[BaseModel],
+    query_from_q: Callable[[str], BaseModel],
+) -> None:
+    """Register the five CRUD verbs for one entity on ``router``.
+
+    Generic over entity: delegates to the passed-in ``get_catalog`` dependency
+    and to ``entry_model`` as request body / response type. Uses
+    ``query_from_q`` to translate the optional ``?q=<s>`` query parameter into
+    the entity's typed query model (per AC #6).
+
+    Mutation routes never wrap the catalog call in try/except — they let
+    ``CatalogValidationError`` (→ 409) and ``EntryNotFoundError`` (→ 404)
+    propagate to the global handlers registered in
+    ``akgentic.catalog.api._errors.add_exception_handlers``.
+    """
+    singular = entity_name.rstrip("s").title()
+    prefix = f"/{entity_name}"
+
+    @router.get(prefix, response_model=list[entry_model])  # type: ignore[valid-type]
+    def _list_entries(
+        q: str | None = None,
+        catalog: object = Depends(get_catalog),
+    ) -> list[BaseModel]:
+        if q is None:
+            return catalog.list()  # type: ignore[attr-defined, no-any-return]
+        return catalog.search(query_from_q(q))  # type: ignore[attr-defined, no-any-return]
+
+    @router.get(prefix + "/{entry_id}", response_model=entry_model)
+    def _get_entry(
+        entry_id: str,
+        catalog: object = Depends(get_catalog),
+    ) -> BaseModel:
+        result = catalog.get(entry_id)  # type: ignore[attr-defined]
+        if result is None:
+            raise EntryNotFoundError(f"{singular} id '{entry_id}' not found")
+        return cast(BaseModel, result)
+
+    @router.post(prefix, response_model=entry_model, status_code=201)
+    def _create_entry(
+        entry: entry_model,  # type: ignore[valid-type]
+        request: Request,
+        catalog: object = Depends(get_catalog),
+    ) -> BaseModel:
+        catalog.create(entry)  # type: ignore[attr-defined]
+        entry_id: str = entry.id  # type: ignore[attr-defined]
+        _emit_mutation_log(request, entity_name=entity_name, entity_id=entry_id, operation="create")
+        return cast(BaseModel, entry)
+
+    @router.put(prefix + "/{entry_id}", response_model=entry_model)
+    def _update_entry(
+        entry_id: str,
+        entry: entry_model,  # type: ignore[valid-type]
+        request: Request,
+        catalog: object = Depends(get_catalog),
+    ) -> BaseModel:
+        catalog.update(entry_id, entry)  # type: ignore[attr-defined]
+        _emit_mutation_log(request, entity_name=entity_name, entity_id=entry_id, operation="update")
+        return cast(BaseModel, entry)
+
+    @router.delete(prefix + "/{entry_id}", status_code=204)
+    def _delete_entry(
+        entry_id: str,
+        request: Request,
+        catalog: object = Depends(get_catalog),
+    ) -> None:
+        catalog.delete(entry_id)  # type: ignore[attr-defined]
+        _emit_mutation_log(request, entity_name=entity_name, entity_id=entry_id, operation="delete")
+
+
+# --- Four registration calls — one per entity -------------------------------
+
+
+_register_entity_routes(
+    router,
+    entity_name="templates",
+    get_catalog=_get_template_catalog,
+    entry_model=TemplateEntry,
+    query_from_q=lambda s: TemplateQuery(placeholder=s),
+)
+_register_entity_routes(
+    router,
+    entity_name="tools",
+    get_catalog=_get_tool_catalog,
+    entry_model=ToolEntry,
+    query_from_q=lambda s: ToolQuery(name=s),
+)
+_register_entity_routes(
+    router,
+    entity_name="agents",
+    get_catalog=_get_agent_catalog,
+    entry_model=AgentEntry,
+    query_from_q=lambda s: AgentQuery(description=s),
+)
+_register_entity_routes(
+    router,
+    entity_name="teams",
+    get_catalog=_get_team_catalog,
+    entry_model=TeamEntry,
+    query_from_q=lambda s: TeamQuery(name=s),
+)
+
+
+__all__ = ["router"]

--- a/tests/server/routes/test_admin_catalog.py
+++ b/tests/server/routes/test_admin_catalog.py
@@ -1,0 +1,465 @@
+"""Tests for the admin-catalog router at /admin/catalog/<entity>.
+
+Covers every entity × every verb plus the ADR-022 §D2 error matrix:
+
+* ``404`` — ``EntryNotFoundError`` → via global handler
+* ``409`` — ``CatalogValidationError`` → via global handler
+* ``422`` — Pydantic validation error → via FastAPI's default handler
+* ``201`` on create, ``204`` on delete, ``200`` default
+* Structured log line on every mutation; reads stay silent at INFO.
+
+All tests use real ``TierServices`` (YAML-backed catalogs, ``NoAuth``) via the
+top-level ``client`` fixture — no mocks.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Any
+
+import pytest
+from fastapi import APIRouter, FastAPI
+from fastapi.testclient import TestClient
+
+# --- Payload factories (reused across parametrised tests) --------------------
+
+
+def _template_payload(tid: str = "admin-tpl") -> dict[str, Any]:
+    """A minimal valid TemplateEntry payload."""
+    return {"id": tid, "template": "Hello {name}, you are {role}."}
+
+
+def _tool_payload(tid: str = "admin-tool") -> dict[str, Any]:
+    """A minimal valid ToolEntry payload."""
+    return {
+        "id": tid,
+        "tool_class": "akgentic.tool.search.SearchTool",
+        "tool": {"name": "search", "description": "Search the web"},
+    }
+
+
+def _agent_payload(tid: str = "admin-agent") -> dict[str, Any]:
+    """A minimal valid AgentEntry payload."""
+    return {
+        "id": tid,
+        "tool_ids": [],
+        "card": {
+            "role": "engineer",
+            "description": "admin-router test agent",
+            "skills": ["coding"],
+            "agent_class": "akgentic.agent.BaseAgent",
+            "config": {"name": "@Eng", "role": "Engineer"},
+            "routes_to": [],
+        },
+    }
+
+
+def _team_payload(tid: str = "admin-team") -> dict[str, Any]:
+    """A minimal valid TeamEntry payload referencing the seeded ``human-proxy``."""
+    return {
+        "id": tid,
+        "name": f"Admin Team {tid}",
+        "entry_point": "human-proxy",
+        "message_types": ["akgentic.core.messages.UserMessage"],
+        "members": [{"agent_id": "human-proxy"}],
+    }
+
+
+# Each tuple: (entity_name, payload_factory, query_field_for_search_test)
+ENTITIES: list[tuple[str, Any, str]] = [
+    ("templates", _template_payload, "placeholder"),
+    ("tools", _tool_payload, "name"),
+    ("agents", _agent_payload, "description"),
+    ("teams", _team_payload, "name"),
+]
+
+
+def _seed(client: TestClient, entity: str, payload: dict[str, Any]) -> None:
+    """POST a payload to the admin router (idempotent: allow 201 or 409)."""
+    resp = client.post(f"/admin/catalog/{entity}", json=payload)
+    assert resp.status_code in (201, 409)
+
+
+# --- Registration-count & mount --------------------------------------------
+
+
+def test_all_four_entities_mounted(app: FastAPI) -> None:
+    """All four entities register the five expected prefixes each."""
+    paths = {r.path for r in app.routes if r.path.startswith("/admin/catalog/")}
+    for entity in ("templates", "tools", "agents", "teams"):
+        assert f"/admin/catalog/{entity}" in paths
+        assert f"/admin/catalog/{entity}/{{entry_id}}" in paths
+
+
+@pytest.mark.parametrize("skipped_entity", ["templates", "tools", "agents", "teams"])
+def test_registration_removal_eliminates_only_that_entity(skipped_entity: str) -> None:
+    """Skipping one entity registration eliminates only that entity's routes.
+
+    Parametrised over every entity in turn: build a fresh router + fresh app,
+    register the three non-skipped entities via ``_register_entity_routes``,
+    mount, and assert the skipped entity's prefix contributes zero routes while
+    each registered entity contributes exactly five (AC #9 updated spec).
+    """
+    from akgentic.catalog.models import (
+        AgentEntry,
+        AgentQuery,
+        TeamEntry,
+        TeamQuery,
+        TemplateEntry,
+        TemplateQuery,
+        ToolEntry,
+        ToolQuery,
+    )
+
+    from akgentic.infra.server.routes.admin_catalog import (
+        _get_agent_catalog,
+        _get_team_catalog,
+        _get_template_catalog,
+        _get_tool_catalog,
+        _register_entity_routes,
+    )
+
+    registrations: dict[str, dict[str, Any]] = {
+        "templates": {
+            "entity_name": "templates",
+            "get_catalog": _get_template_catalog,
+            "entry_model": TemplateEntry,
+            "query_from_q": lambda s: TemplateQuery(placeholder=s),
+        },
+        "tools": {
+            "entity_name": "tools",
+            "get_catalog": _get_tool_catalog,
+            "entry_model": ToolEntry,
+            "query_from_q": lambda s: ToolQuery(name=s),
+        },
+        "agents": {
+            "entity_name": "agents",
+            "get_catalog": _get_agent_catalog,
+            "entry_model": AgentEntry,
+            "query_from_q": lambda s: AgentQuery(description=s),
+        },
+        "teams": {
+            "entity_name": "teams",
+            "get_catalog": _get_team_catalog,
+            "entry_model": TeamEntry,
+            "query_from_q": lambda s: TeamQuery(name=s),
+        },
+    }
+
+    partial_router = APIRouter(prefix="/admin/catalog")
+    for name, kwargs in registrations.items():
+        if name == skipped_entity:
+            continue
+        _register_entity_routes(partial_router, **kwargs)
+
+    app = FastAPI()
+    app.include_router(partial_router)
+
+    skipped_paths = sorted(
+        {r.path for r in app.routes if r.path.startswith(f"/admin/catalog/{skipped_entity}")}
+    )
+    assert skipped_paths == []
+
+    for other in ("templates", "tools", "agents", "teams"):
+        if other == skipped_entity:
+            continue
+        other_routes = [r for r in app.routes if r.path.startswith(f"/admin/catalog/{other}")]
+        # Five verbs per entity: list, get, create, update, delete
+        assert len(other_routes) == 5, (
+            f"expected 5 routes for {other}, got {len(other_routes)}: "
+            f"{[r.path for r in other_routes]}"
+        )
+
+
+# --- List (happy + ?q=) ------------------------------------------------------
+
+
+@pytest.mark.parametrize(("entity", "payload_factory", "query_field"), ENTITIES)
+def test_list_happy_path(
+    client: TestClient,
+    entity: str,
+    payload_factory: Any,
+    query_field: str,
+) -> None:
+    """GET /admin/catalog/{entity} returns a list (may include seeded entries)."""
+    _seed(client, entity, payload_factory(f"list-{entity}"))
+    resp = client.get(f"/admin/catalog/{entity}")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert isinstance(body, list)
+    ids = [e["id"] for e in body]
+    assert f"list-{entity}" in ids
+
+
+@pytest.mark.parametrize(("entity", "payload_factory", "query_field"), ENTITIES)
+def test_list_with_q_happy_path(
+    client: TestClient,
+    entity: str,
+    payload_factory: Any,
+    query_field: str,
+) -> None:
+    """GET /admin/catalog/{entity}?q=... returns filtered results via search."""
+    _seed(client, entity, payload_factory(f"q-{entity}"))
+    # Templates search on `placeholder`: our payload includes 'name' and 'role'.
+    # Tools/Teams search on `name`; Agents search on `description`.
+    q_value = {
+        "templates": "name",
+        "tools": "search",
+        "agents": "admin-router",
+        "teams": f"Admin Team q-{entity}",
+    }[entity]
+    resp = client.get(f"/admin/catalog/{entity}", params={"q": q_value})
+    assert resp.status_code == 200
+    body = resp.json()
+    assert isinstance(body, list)
+    ids = [e["id"] for e in body]
+    assert f"q-{entity}" in ids
+
+
+# --- Get ---------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(("entity", "payload_factory", "query_field"), ENTITIES)
+def test_get_happy_path(
+    client: TestClient,
+    entity: str,
+    payload_factory: Any,
+    query_field: str,
+) -> None:
+    """GET /admin/catalog/{entity}/{id} returns the entry body."""
+    _seed(client, entity, payload_factory(f"get-{entity}"))
+    resp = client.get(f"/admin/catalog/{entity}/get-{entity}")
+    assert resp.status_code == 200
+    assert resp.json()["id"] == f"get-{entity}"
+
+
+@pytest.mark.parametrize(("entity", "_factory", "_qfield"), ENTITIES)
+def test_get_unknown_returns_404_with_error_shape(
+    client: TestClient, entity: str, _factory: Any, _qfield: str
+) -> None:
+    """Unknown id → 404 via the global handler, with ErrorResponse shape."""
+    resp = client.get(f"/admin/catalog/{entity}/does-not-exist")
+    assert resp.status_code == 404
+    body = resp.json()
+    # Global handler: {"detail": "...", "errors": [...]}
+    assert set(body.keys()) == {"detail", "errors"}
+    assert "not found" in body["detail"].lower()
+
+
+# --- Create ------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(("entity", "payload_factory", "_qfield"), ENTITIES)
+def test_create_happy_path(
+    client: TestClient,
+    entity: str,
+    payload_factory: Any,
+    _qfield: str,
+) -> None:
+    """POST returns 201, echoes the entry, and subsequent GET retrieves it."""
+    payload = payload_factory(f"create-{entity}")
+    resp = client.post(f"/admin/catalog/{entity}", json=payload)
+    assert resp.status_code == 201
+    assert resp.json()["id"] == f"create-{entity}"
+
+    resp = client.get(f"/admin/catalog/{entity}/create-{entity}")
+    assert resp.status_code == 200
+    assert resp.json()["id"] == f"create-{entity}"
+
+
+@pytest.mark.parametrize(("entity", "payload_factory", "_qfield"), ENTITIES)
+def test_create_duplicate_returns_409(
+    client: TestClient,
+    entity: str,
+    payload_factory: Any,
+    _qfield: str,
+) -> None:
+    """Creating an entry with an already-used id → 409."""
+    payload = payload_factory(f"dup-{entity}")
+    first = client.post(f"/admin/catalog/{entity}", json=payload)
+    assert first.status_code == 201
+    second = client.post(f"/admin/catalog/{entity}", json=payload)
+    assert second.status_code == 409
+    body = second.json()
+    assert set(body.keys()) == {"detail", "errors"}
+    assert f"dup-{entity}" in body["detail"]
+
+
+def test_create_malformed_body_returns_422(client: TestClient) -> None:
+    """Posting a TeamEntry missing the required ``entry_point`` → 422."""
+    bad_payload = {
+        "id": "malformed",
+        "name": "Malformed",
+        # entry_point missing
+        "message_types": ["akgentic.core.messages.UserMessage"],
+        "members": [{"agent_id": "human-proxy"}],
+    }
+    resp = client.post("/admin/catalog/teams", json=bad_payload)
+    assert resp.status_code == 422
+
+
+# --- Update ------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(("entity", "payload_factory", "_qfield"), ENTITIES)
+def test_update_happy_path(
+    client: TestClient,
+    entity: str,
+    payload_factory: Any,
+    _qfield: str,
+) -> None:
+    """PUT replaces the entry; subsequent GET reflects the change."""
+    eid = f"upd-{entity}"
+    _seed(client, entity, payload_factory(eid))
+
+    updated = payload_factory(eid)
+    # Tweak a descriptive field per entity so we can observe the change
+    if entity == "templates":
+        updated["template"] = "Updated {name}."
+    elif entity == "tools":
+        updated["tool"]["description"] = "updated-description"
+    elif entity == "agents":
+        updated["card"]["description"] = "updated-description"
+    elif entity == "teams":
+        updated["description"] = "updated-description"
+
+    resp = client.put(f"/admin/catalog/{entity}/{eid}", json=updated)
+    assert resp.status_code == 200
+    assert resp.json()["id"] == eid
+
+    got = client.get(f"/admin/catalog/{entity}/{eid}").json()
+    if entity == "templates":
+        assert got["template"].startswith("Updated")
+    elif entity == "tools":
+        assert got["tool"]["description"] == "updated-description"
+    elif entity == "agents":
+        assert got["card"]["description"] == "updated-description"
+    elif entity == "teams":
+        assert got["description"] == "updated-description"
+
+
+@pytest.mark.parametrize(("entity", "payload_factory", "_qfield"), ENTITIES)
+def test_update_unknown_returns_404(
+    client: TestClient,
+    entity: str,
+    payload_factory: Any,
+    _qfield: str,
+) -> None:
+    """PUT on an unknown id → 404 via the global handler."""
+    resp = client.put(f"/admin/catalog/{entity}/unknown-id", json=payload_factory("unknown-id"))
+    assert resp.status_code == 404
+
+
+@pytest.mark.parametrize(("entity", "payload_factory", "_qfield"), ENTITIES)
+def test_update_id_mismatch_returns_409(
+    client: TestClient,
+    entity: str,
+    payload_factory: Any,
+    _qfield: str,
+) -> None:
+    """PUT with a path id that differs from the body id → 409."""
+    eid = f"mis-{entity}"
+    _seed(client, entity, payload_factory(eid))
+    # Body claims a different id than the URL path
+    mismatched = payload_factory("different-id")
+    resp = client.put(f"/admin/catalog/{entity}/{eid}", json=mismatched)
+    assert resp.status_code == 409
+
+
+# --- Delete ------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(("entity", "payload_factory", "_qfield"), ENTITIES)
+def test_delete_happy_path(
+    client: TestClient,
+    entity: str,
+    payload_factory: Any,
+    _qfield: str,
+) -> None:
+    """DELETE returns 204; subsequent GET returns 404."""
+    eid = f"del-{entity}"
+    _seed(client, entity, payload_factory(eid))
+    resp = client.delete(f"/admin/catalog/{entity}/{eid}")
+    assert resp.status_code == 204
+
+    resp = client.get(f"/admin/catalog/{entity}/{eid}")
+    assert resp.status_code == 404
+
+
+@pytest.mark.parametrize(("entity", "_factory", "_qfield"), ENTITIES)
+def test_delete_unknown_returns_404(
+    client: TestClient, entity: str, _factory: Any, _qfield: str
+) -> None:
+    """DELETE of an unknown id → 404 via the global handler."""
+    resp = client.delete(f"/admin/catalog/{entity}/does-not-exist")
+    assert resp.status_code == 404
+
+
+# --- Structured mutation logging --------------------------------------------
+
+
+def test_mutation_logging_emits_exactly_three_info_records(
+    client: TestClient, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Create/Update/Delete → exactly three INFO records with structured extras."""
+    caplog.set_level(logging.INFO, logger="akgentic.infra.server.routes.admin_catalog")
+
+    payload = _team_payload("log-team")
+
+    resp = client.post("/admin/catalog/teams", json=payload)
+    assert resp.status_code == 201
+    resp = client.put("/admin/catalog/teams/log-team", json=payload)
+    assert resp.status_code == 200
+    resp = client.delete("/admin/catalog/teams/log-team")
+    assert resp.status_code == 204
+
+    info_records = [
+        r
+        for r in caplog.records
+        if r.name == "akgentic.infra.server.routes.admin_catalog" and r.levelname == "INFO"
+    ]
+    assert len(info_records) == 3
+    ops = [r.operation for r in info_records]  # type: ignore[attr-defined]
+    assert ops == ["create", "update", "delete"]
+    for r in info_records:
+        assert r.entity_type == "teams"  # type: ignore[attr-defined]
+        assert r.entity_id == "log-team"  # type: ignore[attr-defined]
+        assert r.principal_id == "anonymous"  # type: ignore[attr-defined]
+
+
+def test_reads_do_not_emit_info_logs(client: TestClient, caplog: pytest.LogCaptureFixture) -> None:
+    """GET list + GET by id emit zero INFO records from the admin_catalog logger."""
+    caplog.set_level(logging.INFO, logger="akgentic.infra.server.routes.admin_catalog")
+
+    # Seed one entry so the GET-by-id path hits 200, not 404
+    _seed(client, "teams", _team_payload("silent-team"))
+    caplog.clear()
+
+    resp = client.get("/admin/catalog/teams")
+    assert resp.status_code == 200
+    resp = client.get("/admin/catalog/teams/silent-team")
+    assert resp.status_code == 200
+
+    info_records = [
+        r
+        for r in caplog.records
+        if r.name == "akgentic.infra.server.routes.admin_catalog" and r.levelname == "INFO"
+    ]
+    assert info_records == []
+
+
+# --- Auth boundary (AC #7b) -------------------------------------------------
+
+
+def test_admin_catalog_module_does_not_import_auth_protocol() -> None:
+    """Module source does NOT reference ``akgentic.infra.protocols.auth``.
+
+    Textual check (AC #9 updated spec) — covers both ``from X import ...`` and
+    plain ``import X`` with a single substring match, avoiding the blind spot
+    of an ``ast.ImportFrom``-only walk.
+    """
+    import akgentic.infra.server.routes.admin_catalog as m
+
+    src = Path(m.__file__).read_text()
+    assert "akgentic.infra.protocols.auth" not in src


### PR DESCRIPTION
## Story 23.1 — Server-Side Admin-Catalog Router

Expose REST surface over catalog CRUD for `templates`, `tools`, `agents`, `teams` under `/admin/catalog/{entity}` in `akgentic-infra`. Generic factory registered four times, five CRUD verbs per entity, using the existing `{Template|Tool|Agent|Team}Entry` Pydantic models. Error mapping via the existing catalog exception handler.

Implements ADR-022 §D1–D3.

Relates to #241
