### PR TITLE
feat(akgentic-infra): 22-1 add no-op on_stop_request to shared subscribers

### DIFF
--- a/src/akgentic/infra/adapters/shared/event_stream_subscriber.py
+++ b/src/akgentic/infra/adapters/shared/event_stream_subscriber.py
@@ -1,8 +1,8 @@
 """EventStreamSubscriber -- shared subscriber that routes orchestrator events to EventStream.
 
-Satisfies the ``EventSubscriber`` protocol from ``akgentic.core.orchestrator`` via
-structural subtyping. A single instance is shared across all teams; ``team_id`` is
-extracted from each ``Message`` to route events to the correct per-team stream.
+Implements the ``EventSubscriber`` protocol from ``akgentic.core.orchestrator``.
+A single instance is shared across all teams; ``team_id`` is extracted from each
+``Message`` to route events to the correct per-team stream.
 
 Threading model:
 - A ``threading.Lock`` protects ``_seen_teams`` for safe concurrent access from
@@ -16,6 +16,8 @@ import threading
 import uuid
 from typing import TYPE_CHECKING
 
+from akgentic.core.orchestrator import EventSubscriber
+
 if TYPE_CHECKING:
     from akgentic.core.messages import Message
     from akgentic.infra.protocols.event_stream import EventStream
@@ -23,7 +25,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-class EventStreamSubscriber:
+class EventStreamSubscriber(EventSubscriber):
     """Routes orchestrator events into the shared EventStream.
 
     Forwards each ``Message`` directly to the injected ``EventStream``.
@@ -57,6 +59,14 @@ class EventStreamSubscriber:
             self._seen_teams.add(team_id)
 
         self._event_stream.append(team_id, msg)
+
+    def on_stop_request(self) -> None:
+        """No-op — stop handling is bridged by ``TimerStopSubscriber`` in ``akgentic-team``.
+
+        The orchestrator's inactivity-timer handler calls this on every subscriber;
+        this shared subscriber has no per-team teardown to perform on that signal
+        (the per-team stream is removed in ``on_stop()`` once the team actually stops).
+        """
 
     def on_stop(self) -> None:
         """Remove streams for all tracked teams (best-effort cleanup)."""

--- a/src/akgentic/infra/adapters/shared/telemetry_subscriber.py
+++ b/src/akgentic/infra/adapters/shared/telemetry_subscriber.py
@@ -23,6 +23,8 @@ from typing import TYPE_CHECKING
 
 import logfire
 
+from akgentic.core.orchestrator import EventSubscriber
+
 if TYPE_CHECKING:
     from akgentic.core.messages import Message
 
@@ -46,12 +48,11 @@ class _FlushBarrier:
         self.event = threading.Event()
 
 
-class TelemetrySubscriber:
+class TelemetrySubscriber(EventSubscriber):
     """Traces orchestrator events via logfire on a background thread.
 
-    Satisfies the EventSubscriber protocol from akgentic.core.orchestrator
-    via structural subtyping. Thread-safe — designed as a shared, long-lived
-    subscriber across all teams.
+    Implements the EventSubscriber protocol from akgentic.core.orchestrator.
+    Thread-safe — designed as a shared, long-lived subscriber across all teams.
 
     ``on_message()`` extracts the small set of attributes it needs on the
     caller's thread, enqueues them, and returns immediately. Actual emission
@@ -91,6 +92,14 @@ class TelemetrySubscriber:
         msg_type = msg.__class__.__name__
         team_id = msg.team_id
         self._queue.put((sender, msg_type, team_id))
+
+    def on_stop_request(self) -> None:
+        """No-op — stop handling is bridged by ``TimerStopSubscriber`` in ``akgentic-team``.
+
+        The orchestrator's inactivity-timer handler calls this on every subscriber;
+        this shared telemetry subscriber has no per-team teardown to perform on that
+        signal (worker drain happens in ``on_stop()`` on actual shutdown).
+        """
 
     def on_stop(self) -> None:
         """Signal the worker to drain and exit.

--- a/tests/adapters/shared/test_event_stream_subscriber.py
+++ b/tests/adapters/shared/test_event_stream_subscriber.py
@@ -28,12 +28,23 @@ class TestEventStreamSubscriberProtocolCompliance:
         subscriber = EventStreamSubscriber(event_stream=LocalEventStream())
         assert callable(subscriber.on_stop)
 
+    def test_has_on_stop_request_method(self) -> None:
+        """Story 22.1 AC1: subscriber exposes on_stop_request for timer-driven shutdown."""
+        subscriber = EventStreamSubscriber(event_stream=LocalEventStream())
+        assert callable(subscriber.on_stop_request)
+
     def test_on_message_signature_matches_protocol(self) -> None:
         sig = inspect.signature(EventStreamSubscriber.on_message)
         assert "msg" in sig.parameters
 
     def test_on_stop_signature_matches_protocol(self) -> None:
         sig = inspect.signature(EventStreamSubscriber.on_stop)
+        params = [p for p in sig.parameters if p != "self"]
+        assert len(params) == 0
+
+    def test_on_stop_request_signature_matches_protocol(self) -> None:
+        """Story 22.1 AC1: on_stop_request takes no parameters beyond self and returns None."""
+        sig = inspect.signature(EventStreamSubscriber.on_stop_request)
         params = [p for p in sig.parameters if p != "self"]
         assert len(params) == 0
 
@@ -144,3 +155,40 @@ class TestOnStop:
         # Should not raise even though remove() throws
         subscriber.on_stop()
         mock_stream.remove.assert_called_once_with(team_id)
+
+
+class TestOnStopRequest:
+    """Story 22.1 AC4: on_stop_request is a no-op — never raises, never mutates state."""
+
+    def test_on_stop_request_returns_none_and_does_not_raise(self) -> None:
+        """Direct invocation returns None without raising."""
+        stream = LocalEventStream()
+        subscriber = EventStreamSubscriber(event_stream=stream)
+
+        result = subscriber.on_stop_request()
+
+        assert result is None
+
+    def test_on_stop_request_does_not_touch_event_stream(self) -> None:
+        """No-op contract: on_stop_request must not append, remove, or read from the stream."""
+        mock_stream = MagicMock()
+        subscriber = EventStreamSubscriber(event_stream=mock_stream)
+
+        subscriber.on_stop_request()
+
+        # No methods on the stream should have been called.
+        mock_stream.append.assert_not_called()
+        mock_stream.remove.assert_not_called()
+        mock_stream.read_from.assert_not_called()
+
+    def test_on_stop_request_does_not_mutate_seen_teams(self) -> None:
+        """State invariant: on_stop_request leaves _seen_teams untouched."""
+        stream = LocalEventStream()
+        subscriber = EventStreamSubscriber(event_stream=stream)
+        team_id = uuid.uuid4()
+        subscriber.on_message(_make_message(team_id=team_id))
+        before = set(subscriber._seen_teams)
+
+        subscriber.on_stop_request()
+
+        assert subscriber._seen_teams == before

--- a/tests/adapters/shared/test_telemetry_subscriber.py
+++ b/tests/adapters/shared/test_telemetry_subscriber.py
@@ -22,6 +22,12 @@ class TestTelemetrySubscriberProtocolCompliance:
         subscriber = TelemetrySubscriber()
         assert callable(subscriber.on_stop)
 
+    def test_has_on_stop_request_method(self) -> None:
+        """Story 22.1 AC2: subscriber exposes on_stop_request for timer-driven shutdown."""
+        subscriber = TelemetrySubscriber()
+        assert callable(subscriber.on_stop_request)
+        subscriber.on_stop()
+
     def test_on_message_signature_matches_protocol(self) -> None:
         """on_message has msg parameter matching EventSubscriber."""
         sig = inspect.signature(TelemetrySubscriber.on_message)
@@ -30,6 +36,12 @@ class TestTelemetrySubscriberProtocolCompliance:
     def test_on_stop_signature_matches_protocol(self) -> None:
         """on_stop has no parameters beyond self."""
         sig = inspect.signature(TelemetrySubscriber.on_stop)
+        params = [p for p in sig.parameters if p != "self"]
+        assert len(params) == 0
+
+    def test_on_stop_request_signature_matches_protocol(self) -> None:
+        """Story 22.1 AC2: on_stop_request takes no parameters beyond self."""
+        sig = inspect.signature(TelemetrySubscriber.on_stop_request)
         params = [p for p in sig.parameters if p != "self"]
         assert len(params) == 0
 
@@ -68,9 +80,7 @@ class TestTelemetrySubscriberAsyncWorker:
         msg = MagicMock()
         msg.__class__.__name__ = "StartMessage"
 
-        with patch(
-            "akgentic.infra.adapters.shared.telemetry_subscriber.logfire"
-        ) as mock_lf:
+        with patch("akgentic.infra.adapters.shared.telemetry_subscriber.logfire") as mock_lf:
             mock_lf.info.side_effect = lambda *a, **kw: time.sleep(2)
 
             start = time.perf_counter()
@@ -90,9 +100,7 @@ class TestTelemetrySubscriberAsyncWorker:
         msg.sender.name = "orchestrator"
         msg.team_id = "team-xyz"
 
-        with patch(
-            "akgentic.infra.adapters.shared.telemetry_subscriber.logfire"
-        ) as mock_lf:
+        with patch("akgentic.infra.adapters.shared.telemetry_subscriber.logfire") as mock_lf:
             subscriber.on_message(msg)
             assert subscriber._flush(timeout=5.0), "worker did not drain in time"
 
@@ -111,9 +119,7 @@ class TestTelemetrySubscriberAsyncWorker:
         msg = MagicMock()
         msg.__class__.__name__ = "StartMessage"
 
-        with patch(
-            "akgentic.infra.adapters.shared.telemetry_subscriber.logfire"
-        ) as mock_lf:
+        with patch("akgentic.infra.adapters.shared.telemetry_subscriber.logfire") as mock_lf:
             for _ in range(10):
                 subscriber.on_message(msg)
             assert subscriber._flush(timeout=5.0)
@@ -137,4 +143,51 @@ class TestTelemetrySubscriberAsyncWorker:
         elapsed = time.perf_counter() - start
 
         assert elapsed < 5.0, f"on_stop took {elapsed:.2f} s"
+        assert not subscriber._worker.is_alive()
+
+
+class TestOnStopRequest:
+    """Story 22.1 AC4: on_stop_request is a no-op — never raises, never enqueues."""
+
+    def test_on_stop_request_returns_none_and_does_not_raise(self) -> None:
+        """Direct invocation returns None without raising."""
+        subscriber = TelemetrySubscriber()
+        try:
+            result = subscriber.on_stop_request()
+            assert result is None
+        finally:
+            subscriber.on_stop()
+
+    def test_on_stop_request_does_not_enqueue_on_worker(self) -> None:
+        """Queue invariant: on_stop_request must NOT enqueue a telemetry record.
+
+        Emission belongs on_message; a stop-request signal is metadata from
+        the orchestrator and is not a trace event itself.
+        """
+        subscriber = TelemetrySubscriber()
+        try:
+            qsize_before = subscriber._queue.qsize()
+
+            subscriber.on_stop_request()
+            # Allow worker a tiny window to drain anything unexpected.
+            assert subscriber._flush(timeout=5.0)
+
+            with patch("akgentic.infra.adapters.shared.telemetry_subscriber.logfire") as mock_lf:
+                # Re-flush after patching so any pending emission would surface.
+                assert subscriber._flush(timeout=5.0)
+                mock_lf.info.assert_not_called()
+
+            # Queue size is unchanged (ignoring barrier sentinels which are drained
+            # by _flush before we observe).
+            assert subscriber._queue.qsize() == qsize_before
+        finally:
+            subscriber.on_stop()
+
+    def test_on_stop_request_before_on_stop_then_stop_still_works(self) -> None:
+        """Idempotent: calling on_stop_request then on_stop still shuts the worker down."""
+        subscriber = TelemetrySubscriber()
+
+        subscriber.on_stop_request()
+        subscriber.on_stop()
+
         assert not subscriber._worker.is_alive()


### PR DESCRIPTION
## Summary

- Add no-op `on_stop_request(self) -> None` to the two shared adapter subscribers (`EventStreamSubscriber`, `TelemetrySubscriber`), making both explicitly implement the `EventSubscriber` protocol from `akgentic.core.orchestrator`.
- Docstrings updated from "satisfies protocol via structural subtyping" to "implements protocol".
- New unit tests cover protocol compliance (method presence + signature) and behavioural no-op guarantees (returns `None`, does not raise, does not touch the event stream / does not enqueue on the telemetry worker).
- Closes the `akgentic-infra` slice of the cross-submodule timer-stop delegation rollout.

## Context

Upstream `akgentic-core` story 3-6 (PR #55) added `on_stop_request()` to the `EventSubscriber` protocol with a no-op default and reworked the orchestrator's inactivity-timer handler to call `_notify_subscribers("on_stop_request")`. Shared subscribers in this submodule must expose the method so the orchestrator stops logging per-subscriber "failed on_stop_request" errors on every timer-driven shutdown.

Real teardown is bridged by `TimerStopSubscriber` in `akgentic-team` (merged in PR #90). Shared subscribers in `akgentic-infra` intentionally stay no-op on `on_stop_request` — per-team teardown happens in `on_stop()` when the team actually stops.

Relates to akgentic-team epic-17 (cross-submodule timer-stop delegation).
Closes #254.
