### PR TITLE
feat(akgentic-infra): 7-4 skip CORS middleware when origins list is empty

### DIFF
--- a/src/akgentic/infra/server/app.py
+++ b/src/akgentic/infra/server/app.py
@@ -145,7 +145,13 @@ def _build_app(
 
 
 def _add_cors(app: FastAPI, cors_origins: list[str]) -> None:
-    """Add CORS middleware to the application."""
+    """Add CORS middleware to the application.
+
+    When *cors_origins* is empty the middleware is **not** registered at all,
+    allowing an external gateway (e.g. Azure App Service) to manage CORS.
+    """
+    if not cors_origins:
+        return
     app.add_middleware(
         CORSMiddleware,
         allow_origins=cors_origins,

--- a/src/akgentic/infra/server/settings.py
+++ b/src/akgentic/infra/server/settings.py
@@ -53,9 +53,11 @@ class ServerSettings(BaseSettings):
     )
     # Community-tier permissive default. Department/enterprise tiers must
     # override with explicit origins in their environment configuration.
+    # Set to [] to disable the CORS middleware entirely — useful when an
+    # external gateway (e.g. Azure App Service) manages CORS.
     cors_origins: list[str] = Field(
         default=["*"],
-        description="Allowed CORS origins for the HTTP server",
+        description="Allowed CORS origins for the HTTP server (empty list disables middleware)",
     )
     shutdown_drain_timeout: int = Field(
         default=30,


### PR DESCRIPTION
## Summary

- `_add_cors()` in `server/app.py` returns early when `cors_origins` is empty — no `CORSMiddleware` registered on the FastAPI app.
- `ServerSettings.cors_origins` field description updated to document the empty-list semantics: "empty list disables middleware".
- Inline comment added explaining the Azure App Service / reverse-proxy use case.

## Context

When deploying behind Azure App Service (or any reverse-proxy with built-in CORS), having `CORSMiddleware` registered — even with an empty origins list — intercepts preflight `OPTIONS` requests and can strip or conflict with the gateway's own CORS headers. Skipping middleware registration entirely lets the platform manage CORS without interference.

Env var usage: `AKGENTIC_CORS_ORIGINS='[]'` disables middleware. Any non-empty list (including the default `["*"]`) registers middleware as before — no behavioural change for existing deployments.

Relates to Epic 7 (Tier-Agnostic Refactoring, ADR-003).
Closes #256.