### PR TITLE
fix: webhook returns 400 (not 500) on malformed body

### DIFF
--- a/src/akgentic/infra/server/routes/webhook.py
+++ b/src/akgentic/infra/server/routes/webhook.py
@@ -65,7 +65,10 @@ async def webhook(
     else:
         logger.warning("Unsupported content type: %s", content_type)
         raise HTTPException(status_code=415, detail="Unsupported content type")
-    message = await parser.parse(payload)
+    try:
+        message = await parser.parse(payload)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
 
     if message.team_id is not None:
         # Reply flow

--- a/tests/adapters/shared/test_telegram_integration.py
+++ b/tests/adapters/shared/test_telegram_integration.py
@@ -187,14 +187,12 @@ class TestWebhookWithTelegramParser:
         resp = client.post("/webhook/unknown", json={"text": "hello"})
         assert resp.status_code == 404
 
-    def test_invalid_telegram_payload_raises(self) -> None:
-        """Payload without 'message' key → parser raises ValueError.
-
-        The webhook route does not catch parser errors — they propagate
-        as 500. This is existing model behavior (not a bug introduced
-        by the Telegram classes).
+    def test_invalid_telegram_payload_returns_400(self) -> None:
+        """Payload without 'message' key → parser raises ValueError,
+        surfaced as HTTP 400 (client sent a malformed body — not a 5xx).
         """
         app, _, _ = self._make_app()
         client = TestClient(app, raise_server_exceptions=False)
         resp = client.post("/webhook/telegram", json={"update_id": 1})
-        assert resp.status_code == 500
+        assert resp.status_code == 400
+        assert "message" in resp.json()["detail"].lower()

--- a/tests/server/routes/test_webhook_route.py
+++ b/tests/server/routes/test_webhook_route.py
@@ -360,3 +360,23 @@ class TestWebhookUnsupportedContentType:
 
         assert resp.status_code == 415
         assert "Unsupported content type" in resp.json()["detail"]
+
+
+class TestWebhookMalformedPayload:
+    """Parser-raised ValueError should surface as 400, not 500."""
+
+    def test_parser_value_error_returns_400(self, tmp_path: Path) -> None:
+        class RaisingParser(StubParser):
+            async def parse(self, payload: dict[str, JsonValue]) -> ChannelMessage:
+                del payload
+                raise ValueError("payload missing required field 'message'")
+
+        parser = RaisingParser()
+        ingestion = StubIngestion()
+        registry = YamlChannelRegistry(tmp_path / "registry.yaml")
+        client = TestClient(_build_app(parser, ingestion, registry))
+
+        resp = client.post("/webhook/test-channel", json={"update_id": 1})
+
+        assert resp.status_code == 400
+        assert "payload missing required field 'message'" in resp.json()["detail"]


### PR DESCRIPTION
## Summary

- Wrap the channel-parser `parse()` call in the webhook route with a `try/except ValueError` so a malformed inbound body returns **HTTP 400** with the error detail instead of surfacing as a generic 500.
- Add unit test covering the 400 branch; `webhook.py` is now at 100% line coverage.

## Test plan

- [x] `uv run pytest packages/akgentic-infra/tests/server/routes/test_webhook_route.py` — 12 pass
- [x] Manual curl to webhook with malformed Telegram payload returns HTTP 400, not 500

Fixes #261