### PR TITLE
chore: align version to 1.0.0-alpha.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "akgentic-infra"
-version = "0.1.0"
+version = "1.0.0-alpha.1"
 description = "Infrastructure backend: protocol abstractions and community-tier implementations for akgentic"
 readme = "README.md"
 requires-python = ">=3.12"


### PR DESCRIPTION
Aligns version to `1.0.0-alpha.1` to match akgentic-core and akgentic-team across the workspace.

Relates to #268