### PR TITLE
feat(akgentic-infra): 25-1 push list_teams user_id filter into EventStore

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "akgentic-infra"
-version = "1.2.0"
+version = "1.2.1"
 description = "Infrastructure backend: protocol abstractions and community-tier implementations for akgentic"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/akgentic/infra/server/services/team_service.py
+++ b/src/akgentic/infra/server/services/team_service.py
@@ -58,9 +58,14 @@ class TeamService:
         return process
 
     def list_teams(self, user_id: str) -> list[Process]:
-        """List all teams for a given user."""
-        all_teams = self._services.event_store.list_teams()
-        return [t for t in all_teams if t.user_id == user_id]
+        """List all teams for a given user.
+
+        Pushes the ``user_id`` filter into the EventStore rather than loading
+        every team into Python and filtering here. Per-request cost scales with
+        the requesting user's team count, not with total teams across all
+        users. See team-package ADR-16 / Epic 19 for the Protocol change.
+        """
+        return self._services.event_store.list_teams(user_id=user_id)
 
     def get_team(self, team_id: uuid.UUID) -> Process | None:
         """Get a single team by ID."""

--- a/tests/server/services/test_team_service.py
+++ b/tests/server/services/test_team_service.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import logging
 import uuid
+from unittest.mock import MagicMock
 
 import pytest
 from akgentic.catalog.models.errors import EntryNotFoundError
@@ -42,6 +43,48 @@ def test_list_teams_filters_by_user(team_service: TeamService) -> None:
     assert len(alice_teams) == 1
     assert len(bob_teams) == 1
     assert alice_teams[0].user_id == "alice"
+
+
+def test_list_teams_delegates_to_event_store_with_user_id(team_service: TeamService) -> None:
+    """TeamService.list_teams MUST push user_id down to event_store.list_teams,
+    not load all teams and filter in Python. Regression-guard for the team-side
+    ADR-16 / Epic 19 push-down: if a future refactor restores the in-memory
+    filter pattern, this test fails even though the behavioural contract
+    (users see only their own teams) still passes.
+    """
+    mock_event_store = MagicMock()
+    mock_event_store.list_teams.return_value = []
+    # Swap in the mock event_store on the wired TierServices container.
+    # SkipValidation on the field allows direct assignment without re-validation.
+    team_service._services.event_store = mock_event_store  # type: ignore[assignment]
+
+    result = team_service.list_teams(user_id="alice")
+
+    # The delegating call shape — exactly one call, user_id="alice" as kwarg.
+    mock_event_store.list_teams.assert_called_once_with(user_id="alice")
+    # The call must NOT be a no-arg call followed by an in-Python filter.
+    assert mock_event_store.list_teams.call_args.args == ()
+    assert mock_event_store.list_teams.call_args.kwargs == {"user_id": "alice"}
+    # And the returned list is the event store's return value verbatim
+    # (no intermediate Python comprehension repacking it).
+    assert result == []
+
+
+def test_list_teams_passes_empty_string_user_id_verbatim(team_service: TeamService) -> None:
+    """user_id="" is a literal value, NOT a "list everything" sentinel.
+
+    The empty string is passed through verbatim to event_store.list_teams; the
+    backend applies its literal-match filter and returns only teams whose
+    Process.user_id == "". This locks in the natural behaviour of the
+    one-line delegating call.
+    """
+    mock_event_store = MagicMock()
+    mock_event_store.list_teams.return_value = []
+    team_service._services.event_store = mock_event_store  # type: ignore[assignment]
+
+    team_service.list_teams(user_id="")
+
+    mock_event_store.list_teams.assert_called_once_with(user_id="")
 
 
 def test_get_team_found(team_service: TeamService) -> None:


### PR DESCRIPTION
## Summary

Push the `user_id` filter for `TeamService.list_teams` from Python down into the EventStore backend.

Before this change, every authenticated `GET /teams` request loaded every user's `Process` snapshot from the backend (full collection scan on Mongo, full rowset on Postgres, full directory walk on YAML) and discarded all but the requesting user's teams in Python. Per-request cost now scales with the requesting user's team count, not with total teams across all users.

The `EventStore` Protocol already accepts the optional `user_id` kwarg (delivered by the team-package Epic 19); every backend (YAML / Mongo / Postgres) implements the push-down. This PR closes the loop by making the `akgentic-infra` caller actually consume the new shape.

The public `TeamService.list_teams(user_id: str)` signature is intentionally preserved (NOT widened to `str | None`) — the optional shape on the Protocol exists only for the CLI's enumerate-everything use case; the server-side API always has an authenticated user.

## Changes

- `src/akgentic/infra/server/services/team_service.py` — replace the load-and-filter list comprehension with a one-line delegating call: `return self._services.event_store.list_teams(user_id=user_id)`. Docstring expanded to explain the push-down.
- `tests/server/services/test_team_service.py` — add `test_list_teams_delegates_to_event_store_with_user_id` (MagicMock-based delegation-contract test guarding against a silent regression to in-memory filtering) and `test_list_teams_passes_empty_string_user_id_verbatim` (locks in literal `user_id=""` semantics).

## Base branch

This PR targets `version-1.x` (NOT `master`) because the team-package Epic 19 has only landed on `version-1.x`.

## References

- Story: `_bmad-output/akgentic-infra/stories/25-1-team-service-list-teams-event-store-push-down.md`
- Parent epic: `_bmad-output/akgentic-infra/epics/epic-25-adr-team-16-list-teams-user-id-caller-migration.md`
- Team-side ADR: `_bmad-output/akgentic-team/decisions/adr-16-event-store-list-teams-user-id-filter.md`
- Team-side epic (prerequisite, merged in `version-1.x`): `_bmad-output/akgentic-team/epics/epic-19-adr-16-list-teams-user-id-filter.md`

Relates to #273
