### PR TITLE
fix(akgentic-infra): resolve mypy and ruff errors

### DIFF
--- a/src/akgentic/infra/server/routes/frontend_adapter/angular_v1/router.py
+++ b/src/akgentic/infra/server/routes/frontend_adapter/angular_v1/router.py
@@ -70,9 +70,10 @@ def get_team_service(request: Request) -> TeamService:
 def _to_v1_process_context(process: Process) -> V1ProcessContext:
     """Convert a V2 Process to a V1ProcessContext."""
     entry_point = process.team_card.entry_point
+    team_name = process.team_card.name or process.catalog_namespace or str(process.team_id)
     return V1ProcessContext(
         id=str(process.team_id),
-        type=process.team_card.name,
+        type=team_name,
         status=process.status.value,
         created_at=process.created_at.isoformat(),
         updated_at=process.updated_at.isoformat(),
@@ -82,7 +83,7 @@ def _to_v1_process_context(process: Process) -> V1ProcessContext:
             role=entry_point.card.role,
         ),
         running=process.status == TeamStatus.RUNNING,
-        config_name=process.team_card.name,
+        config_name=team_name,
         user_id=process.user_id,
         user_email=process.user_email,
     )

--- a/src/akgentic/infra/worker/routes/teams.py
+++ b/src/akgentic/infra/worker/routes/teams.py
@@ -51,9 +51,10 @@ def get_services(request: Request) -> WorkerServices:
 
 def _process_to_response(process: Process) -> TeamResponse:
     """Convert a Process model to a TeamResponse."""
+    team_name = process.team_card.name or process.catalog_namespace or str(process.team_id)
     return TeamResponse(
         team_id=process.team_id,
-        name=process.team_card.name,
+        name=team_name,
         status=process.status.value,
         user_id=process.user_id,
         created_at=process.created_at,

--- a/tests/adapters/community/test_local_worker_handle.py
+++ b/tests/adapters/community/test_local_worker_handle.py
@@ -12,7 +12,7 @@ from akgentic.infra.protocols.worker_handle import WorkerHandle
 
 
 def _make_adapter() -> tuple[LocalWorkerHandle, MagicMock, MagicMock]:
-    """Create a LocalWorkerHandle with mock dependencies, return adapter, team_manager, actor_system."""
+    """Create a LocalWorkerHandle with mock deps; return adapter, team_manager, actor_system."""
     team_manager = MagicMock()
     service_registry = MagicMock()
     actor_system = MagicMock()

--- a/tests/cli/test_tui_commands.py
+++ b/tests/cli/test_tui_commands.py
@@ -266,7 +266,7 @@ async def test_message_send_calls_api() -> None:
 
 @pytest.mark.asyncio
 async def test_message_send_dispatches_without_local_widget() -> None:
-    """Non-slash text sends via API and does NOT mount a local UserMessage widget (12.9 AC #1, #3)."""
+    """Non-slash text sends via API, does NOT mount a local UserMessage widget (12.9 AC #1, #3)."""
     client = _mock_client()
     app = _make_app(client=client)
     async with app.run_test(size=(100, 30)) as pilot:

--- a/tests/integration/test_repl_e2e.py
+++ b/tests/integration/test_repl_e2e.py
@@ -109,12 +109,9 @@ def _cleanup_team(server_url: str, team_id: str) -> None:
         api.close()
 
 
-async def _wait_for_ws_event(
-    conn: ConnectionManager | WsClient,
-    timeout: float = POLL_TIMEOUT_S,
-) -> object:
-    """Wait for a single WebSocket event with timeout."""
-    return await asyncio.wait_for(conn.receive_event(), timeout=timeout)
+async def _wait_for_ws_event(conn: ConnectionManager | WsClient) -> object:
+    """Wait for a single WebSocket event, bounded by ``POLL_TIMEOUT_S``."""
+    return await asyncio.wait_for(conn.receive_event(), timeout=POLL_TIMEOUT_S)
 
 
 def _poll_events_have_content(server_url: str, team_id: str) -> bool:
@@ -491,7 +488,7 @@ class TestCommandsOnStoppedTeam:
         """CS1: /info on a stopped team → returns info."""
         team_id = _create_team(smoke_server)
         _stop_team(smoke_server, team_id)
-        time.sleep(0.3)
+        await asyncio.sleep(0.3)
         try:
             session = _make_session(smoke_server, team_id)
             await _info_handler("", session)
@@ -508,7 +505,7 @@ class TestCommandsOnStoppedTeam:
         """CS2: /events on a stopped team → returns persisted events."""
         team_id = _create_team(smoke_server)
         _stop_team(smoke_server, team_id)
-        time.sleep(0.3)
+        await asyncio.sleep(0.3)
         try:
             session = _make_session(smoke_server, team_id)
             await _events_handler("", session)
@@ -525,7 +522,7 @@ class TestCommandsOnStoppedTeam:
         """CS3: Send message to stopped team → error."""
         team_id = _create_team(smoke_server)
         _stop_team(smoke_server, team_id)
-        time.sleep(0.3)
+        await asyncio.sleep(0.3)
         try:
             session = _make_session(smoke_server, team_id)
 

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -46,7 +46,7 @@ def test_infra_all_includes_adapters() -> None:
 
 
 def test_infra_all_includes_server_models() -> None:
-    """akgentic.infra.__all__ includes ServerSettings, CommunitySettings, TierServices, CommunityServices."""
+    """akgentic.infra.__all__ exposes the server settings and tier-services symbols."""
     from akgentic import infra
 
     assert "ServerSettings" in infra.__all__


### PR DESCRIPTION
## Summary
Clears all outstanding mypy and ruff errors in `akgentic-infra`.

### mypy (3 errors) — `fix:`
`TeamCard.name` is typed `str | None`, but `TeamResponse.name` and `V1ProcessContext.type`/`config_name` require `str`. The three call sites now use the same fallback chain `server/routes/teams.py` already applies: `team_card.name or catalog_namespace or str(team_id)`.

### ruff (7 errors) — `test:`
- **E501** — reflowed three over-length docstrings.
- **ASYNC251** — three `async` test methods called blocking `time.sleep`; replaced with `await asyncio.sleep`.
- **ASYNC109** — dropped the `timeout` parameter from the `async` `_wait_for_ws_event` helper (both callers used the default) and inlined the `POLL_TIMEOUT_S` constant.

## Verification
- ruff: clean (src + tests)
- mypy: clean (109 source files)
- 255 server/worker tests passing; integration suite collects cleanly

Closes #279