### PR TITLE
feat(akgentic-infra): 26-1 define request-user identity seam and wire team routes

### DIFF
--- a/src/akgentic/infra/server/auth.py
+++ b/src/akgentic/infra/server/auth.py
@@ -1,0 +1,28 @@
+"""Request-user identity seam for tier-agnostic server routes (ADR-023)."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, Field
+
+
+class RequestUser(BaseModel):
+    """The authenticated principal for a server request, tier-agnostic.
+
+    Deployment tiers adapt their own auth identity into this shape.
+    Community supplies the anonymous default. Routes never see a
+    tier-specific identity type.
+    """
+
+    user_id: str
+    email: str = ""
+    roles: list[str] = Field(default_factory=list)
+
+
+def get_request_user() -> RequestUser:
+    """Resolve the authenticated principal for the current request.
+
+    Default (community tier): an anonymous principal. Department and
+    enterprise OVERRIDE this dependency via ``app.dependency_overrides``
+    so the same routes resolve a real authenticated identity.
+    """
+    return RequestUser(user_id="anonymous")

--- a/src/akgentic/infra/server/routes/teams.py
+++ b/src/akgentic/infra/server/routes/teams.py
@@ -9,6 +9,7 @@ from typing import NoReturn, cast
 from fastapi import APIRouter, Depends, HTTPException, Request
 
 from akgentic.catalog.models.errors import EntryNotFoundError
+from akgentic.infra.server.auth import RequestUser, get_request_user
 from akgentic.infra.server.models import (
     CreateTeamRequest,
     EventListResponse,
@@ -46,16 +47,16 @@ def _process_to_response(process: Process) -> TeamResponse:
 @router.post("", status_code=201, response_model=TeamResponse)
 def create_team(
     body: CreateTeamRequest,
+    user: RequestUser = Depends(get_request_user),
     service: TeamService = Depends(get_team_service),
 ) -> TeamResponse:
     """Create a new team from a catalog entry."""
     logger.info("POST /teams — catalog_entry=%s", body.catalog_entry_id)
     try:
-        # Community-tier hardcoded identity. Department/enterprise tiers must
-        # replace with authenticated user identity from auth middleware.
         process = service.create_team(
             catalog_entry_id=body.catalog_entry_id,
-            user_id="anonymous",
+            user_id=user.user_id,
+            user_email=user.email,
         )
     except EntryNotFoundError:
         logger.warning("Team creation failed: catalog entry %s not found", body.catalog_entry_id)
@@ -65,12 +66,12 @@ def create_team(
 
 @router.get("", response_model=TeamListResponse)
 def list_teams(
+    user: RequestUser = Depends(get_request_user),
     service: TeamService = Depends(get_team_service),
 ) -> TeamListResponse:
     """List all teams for the current user."""
     logger.debug("GET /teams")
-    # Community-tier hardcoded identity (see create_team comment above).
-    processes = service.list_teams(user_id="anonymous")
+    processes = service.list_teams(user_id=user.user_id)
     return TeamListResponse(teams=[_process_to_response(p) for p in processes])
 
 

--- a/tests/server/routes/test_team_routes.py
+++ b/tests/server/routes/test_team_routes.py
@@ -3,9 +3,13 @@
 from __future__ import annotations
 
 import uuid
+from collections.abc import Generator
 
 import pytest
+from fastapi import FastAPI
 from fastapi.testclient import TestClient
+
+from akgentic.infra.server.auth import RequestUser, get_request_user
 
 
 def test_create_team_success(client: TestClient) -> None:
@@ -75,3 +79,44 @@ def test_delete_team_not_found(client: TestClient) -> None:
     """DELETE /teams/{id} returns 404 for unknown team."""
     resp = client.delete(f"/teams/{uuid.uuid4()}")
     assert resp.status_code == 404
+
+
+# --- RequestUser identity seam (ADR-023 Story 26.1) ---
+
+
+def test_create_team_default_identity_anonymous(client: TestClient) -> None:
+    """With no override, POST /teams persists user_id == 'anonymous' (AC #5)."""
+    resp = client.post("/teams/", json={"catalog_entry_id": "test-team"})
+    assert resp.status_code == 201
+    assert resp.json()["user_id"] == "anonymous"
+
+
+@pytest.fixture()
+def overridden_user_client(app: FastAPI) -> Generator[TestClient, None, None]:
+    """TestClient with get_request_user overridden to a fixed identity."""
+    app.dependency_overrides[get_request_user] = lambda: RequestUser(
+        user_id="alice", email="alice@example.com"
+    )
+    yield TestClient(app)
+    app.dependency_overrides.clear()
+
+
+def test_create_team_uses_overridden_identity(
+    overridden_user_client: TestClient,
+) -> None:
+    """When get_request_user is overridden, POST /teams persists that user_id (AC #6)."""
+    resp = overridden_user_client.post("/teams/", json={"catalog_entry_id": "test-team"})
+    assert resp.status_code == 201
+    assert resp.json()["user_id"] == "alice"
+
+
+def test_list_teams_filters_by_overridden_identity(
+    overridden_user_client: TestClient,
+) -> None:
+    """Under the override, GET /teams returns only the overridden user's teams (AC #6)."""
+    overridden_user_client.post("/teams/", json={"catalog_entry_id": "test-team"})
+    resp = overridden_user_client.get("/teams/")
+    assert resp.status_code == 200
+    teams = resp.json()["teams"]
+    assert len(teams) == 1
+    assert teams[0]["user_id"] == "alice"


### PR DESCRIPTION
## Summary

Story 26.1 (ADR-023, Epic 26) — introduce a tier-agnostic **request-user identity seam** so the
team routes resolve the request's authenticated principal through a single typed FastAPI
dependency, instead of hardcoding `"anonymous"` in each handler.

### What the seam does

- **New `server/auth.py`** — defines `RequestUser` (a Pydantic `BaseModel`: `user_id: str`,
  `email: str = ""`, `roles: list[str] = Field(default_factory=list)`) and the
  `get_request_user()` dependency returning the documented community-tier `RequestUser(user_id="anonymous")`
  default. Imports `BaseModel`/`Field` from `pydantic` only — no department/enterprise identity types.
- **`server/routes/teams.py`** — `POST /teams` and `GET /teams` now declare
  `user: RequestUser = Depends(get_request_user)`. The hardcoded `user_id="anonymous"` literals and
  their "Community-tier hardcoded identity" inline comments are removed. `create_team` forwards
  `user.user_id` and `user.email`; `list_teams` forwards `user.user_id`.
- Department and enterprise tiers (Stories 26.2 / 26.3, separate repos) override this single
  dependency via `app.dependency_overrides` — no per-tier route duplication.

### Acceptance Criteria covered

- AC #1, #2, #7, #8 — `RequestUser` model shape, community `"anonymous"` default, no tier-specific
  identity import; `"anonymous"` now appears only inside `get_request_user`.
- AC #3, #4 — both routes wired to `Depends(get_request_user)`, literals + comments removed.
- AC #5, #6 — community default and overridden-identity behaviour verified by route tests; an
  `overridden_user_client` fixture sets and tears down `app.dependency_overrides`.
- AC #9 — `mypy --strict`, `ruff check`, full `pytest` suite, and the 90% coverage gate all pass.

## Verification (local)

- `ruff check` on changed files — clean.
- `mypy --strict` on `auth.py` + `routes/teams.py` — no issues.
- `pytest packages/akgentic-infra/tests/` (unit, excluding integration/e2e) — **1413 passed,
  14 skipped, coverage 90.71%** (above the 90% submodule gate). `routes/teams.py` at 99% line coverage.

## Known issue — pre-existing CI defect

The `version-1.x` GitHub Actions workflow has a **pre-existing, structural CI-config defect**: the
"Override akgentic-infra submodule with current branch" step fails with
`No such file or directory ... /packages/akgentic-infra` **before** mypy/ruff/pytest ever run. All
5 prior `version-1.x` CI runs failed identically — this pre-dates issue #281 and is **not** caused
by this PR. Local verification (mypy/ruff/pytest, all green) is the gate for this story per
user approval. Fixing the CI workflow is a separate concern, tracked independently, and out of
scope for Story 26.1.

## Scope guard

All changes are confined to `packages/akgentic-infra/` — three files: `server/auth.py` (new),
`server/routes/teams.py`, `tests/server/routes/test_team_routes.py`. No cross-submodule edits;
no import of department/enterprise identity types.

Relates to #281
