### PR TITLE
feat(akgentic-infra): epic 27 — EventSubscriber team_id-aware lifecycle wiring

### DIFF
--- a/src/akgentic/infra/adapters/shared/channel_dispatcher.py
+++ b/src/akgentic/infra/adapters/shared/channel_dispatcher.py
@@ -32,8 +32,17 @@ class InteractionChannelDispatcher:
         self._team_id = team_id
         self._restoring = False
 
-    def set_restoring(self, restoring: bool) -> None:
-        """Toggle restore mode to suppress delivery during event replay."""
+    def set_restoring(self, team_id: uuid.UUID, restoring: bool) -> None:
+        """Toggle restore mode to suppress delivery during event replay.
+
+        Args:
+            team_id: ``team_id`` from the orchestrator. Must equal
+                ``self._team_id`` — the dispatcher is per-team, so a mismatch
+                indicates a wiring bug and fails loud.
+            restoring: ``True`` while restore replay is in progress, ``False``
+                to resume dispatch.
+        """
+        assert team_id == self._team_id
         self._restoring = restoring
 
     def on_message(self, msg: Message) -> None:
@@ -60,8 +69,26 @@ class InteractionChannelDispatcher:
             if adapter.matches(msg):
                 adapter.deliver(msg)
 
-    def on_stop(self) -> None:
-        """Clean up all registered adapters when the team stops."""
+    def on_stop_request(self, team_id: uuid.UUID) -> None:  # noqa: ARG002
+        """No-op — dispatcher has no work to do on the inactivity-timer signal.
+
+        Channel-side teardown happens on ``on_stop()`` once the team actually
+        stops. Present to satisfy the ``EventSubscriber`` Protocol.
+
+        Args:
+            team_id: ``team_id`` from the orchestrator. Accepted to satisfy the
+                Protocol but ignored — no work is performed here.
+        """
+
+    def on_stop(self, team_id: uuid.UUID) -> None:
+        """Clean up all registered adapters when the team stops.
+
+        Args:
+            team_id: ``team_id`` from the orchestrator. Must equal
+                ``self._team_id`` — the dispatcher is per-team, so a mismatch
+                indicates a wiring bug and fails loud.
+        """
+        assert team_id == self._team_id
         logger.debug("ChannelDispatcher stopped: team_id=%s", self._team_id)
         for adapter in self._adapters:
             adapter.on_stop(self._team_id)

--- a/src/akgentic/infra/adapters/shared/event_stream_subscriber.py
+++ b/src/akgentic/infra/adapters/shared/event_stream_subscriber.py
@@ -3,16 +3,11 @@
 Implements the ``EventSubscriber`` protocol from ``akgentic.core.orchestrator``.
 A single instance is shared across all teams; ``team_id`` is extracted from each
 ``Message`` to route events to the correct per-team stream.
-
-Threading model:
-- A ``threading.Lock`` protects ``_seen_teams`` for safe concurrent access from
-  multiple orchestrator actor threads.
 """
 
 from __future__ import annotations
 
 import logging
-import threading
 import uuid
 from typing import TYPE_CHECKING
 
@@ -30,22 +25,28 @@ class EventStreamSubscriber(EventSubscriber):
 
     Forwards each ``Message`` directly to the injected ``EventStream``.
 
-    On stop, removes streams for all teams that were seen via ``on_message()``.
+    On ``on_stop(team_id)``, removes the per-team stream for that team only —
+    the canonical community-tier per-team cleanup hook, mirroring
+    ``RedisStreamSubscriber.on_stop`` in the department tier and
+    ``DaprStreamSubscriber.on_stop`` in enterprise.
     """
 
     def __init__(self, event_stream: EventStream) -> None:
         self._event_stream = event_stream
-        self._seen_teams: set[uuid.UUID] = set()
-        self._lock = threading.Lock()
         logger.debug("EventStreamSubscriber initialized")
 
     def set_restoring(self, team_id: uuid.UUID, restoring: bool) -> None:  # noqa: FBT001, ARG002
-        """No-op — EventStream must be repopulated during restore replay.
+        """No-op — community ``LocalEventStream`` is repopulated by restore replay.
+
+        Suppressing emission here would create the gap the design intentionally
+        avoids: the in-memory ``LocalEventStream`` has no persistence, so the
+        cursor-based replay path needs every restored event to land in the
+        stream. Department and enterprise stream subscribers (Redis / Dapr)
+        override this to suppress while restoring; the community-tier
+        ``LocalEventStream`` does not.
 
         Args:
-            team_id: ``team_id`` from the orchestrator. Accepted to satisfy the
-                ``EventSubscriber`` Protocol but currently ignored — this
-                subscriber's restore behaviour is a global no-op.
+            team_id: ``team_id`` from the orchestrator. Ignored.
             restoring: ``True`` while restore replay is in progress, ``False``
                 otherwise. Ignored.
         """
@@ -63,9 +64,6 @@ class EventStreamSubscriber(EventSubscriber):
             logger.debug("EventStreamSubscriber: skipping message with team_id=None")
             return
 
-        with self._lock:
-            self._seen_teams.add(team_id)
-
         self._event_stream.append(team_id, msg)
 
     def on_stop_request(self, team_id: uuid.UUID) -> None:  # noqa: ARG002
@@ -81,25 +79,23 @@ class EventStreamSubscriber(EventSubscriber):
                 stop handling is deferred to ``TimerStopSubscriber``.
         """
 
-    def on_stop(self, team_id: uuid.UUID) -> None:  # noqa: ARG002
-        """Remove streams for all tracked teams (best-effort cleanup).
+    def on_stop(self, team_id: uuid.UUID) -> None:
+        """Remove the per-team stream for the stopping team.
+
+        Canonical community-tier per-team cleanup hook. Any error raised by
+        ``event_stream.remove`` (e.g. stream already removed by
+        ``TeamService.stop_team`` as a belt-and-suspenders) is swallowed and
+        logged at DEBUG — ``on_stop`` must never propagate an exception back
+        to the orchestrator.
 
         Args:
-            team_id: ``team_id`` from the orchestrator. Accepted to satisfy the
-                ``EventSubscriber`` Protocol but currently ignored — the body
-                still iterates ``_seen_teams``. Single-team-keyed cleanup is
-                deferred to story 27.3.
+            team_id: ``team_id`` of the stopping team.
         """
-        with self._lock:
-            teams = set(self._seen_teams)
-
-        for team_id in teams:
-            try:
-                self._event_stream.remove(team_id)
-            except Exception:
-                logger.debug(
-                    "EventStreamSubscriber: remove() failed for team_id=%s",
-                    team_id,
-                )
-
-        logger.debug("EventStreamSubscriber stopped, cleaned up %d team streams", len(teams))
+        try:
+            self._event_stream.remove(team_id)
+        except Exception:  # noqa: BLE001
+            logger.debug(
+                "EventStreamSubscriber: remove() failed for team_id=%s",
+                team_id,
+            )
+        logger.debug("EventStreamSubscriber stopped, team_id=%s", team_id)

--- a/src/akgentic/infra/adapters/shared/event_stream_subscriber.py
+++ b/src/akgentic/infra/adapters/shared/event_stream_subscriber.py
@@ -39,8 +39,16 @@ class EventStreamSubscriber(EventSubscriber):
         self._lock = threading.Lock()
         logger.debug("EventStreamSubscriber initialized")
 
-    def set_restoring(self, restoring: bool) -> None:  # noqa: FBT001, ARG002
-        """No-op — EventStream must be repopulated during restore replay."""
+    def set_restoring(self, team_id: uuid.UUID, restoring: bool) -> None:  # noqa: FBT001, ARG002
+        """No-op — EventStream must be repopulated during restore replay.
+
+        Args:
+            team_id: ``team_id`` from the orchestrator. Accepted to satisfy the
+                ``EventSubscriber`` Protocol but currently ignored — this
+                subscriber's restore behaviour is a global no-op.
+            restoring: ``True`` while restore replay is in progress, ``False``
+                otherwise. Ignored.
+        """
 
     def on_message(self, msg: Message) -> None:
         """Forward message directly to the event stream.
@@ -60,16 +68,28 @@ class EventStreamSubscriber(EventSubscriber):
 
         self._event_stream.append(team_id, msg)
 
-    def on_stop_request(self) -> None:
+    def on_stop_request(self, team_id: uuid.UUID) -> None:  # noqa: ARG002
         """No-op — stop handling is bridged by ``TimerStopSubscriber`` in ``akgentic-team``.
 
         The orchestrator's inactivity-timer handler calls this on every subscriber;
         this shared subscriber has no per-team teardown to perform on that signal
         (the per-team stream is removed in ``on_stop()`` once the team actually stops).
+
+        Args:
+            team_id: ``team_id`` from the orchestrator. Accepted to satisfy the
+                ``EventSubscriber`` Protocol but currently ignored — per-team
+                stop handling is deferred to ``TimerStopSubscriber``.
         """
 
-    def on_stop(self) -> None:
-        """Remove streams for all tracked teams (best-effort cleanup)."""
+    def on_stop(self, team_id: uuid.UUID) -> None:  # noqa: ARG002
+        """Remove streams for all tracked teams (best-effort cleanup).
+
+        Args:
+            team_id: ``team_id`` from the orchestrator. Accepted to satisfy the
+                ``EventSubscriber`` Protocol but currently ignored — the body
+                still iterates ``_seen_teams``. Single-team-keyed cleanup is
+                deferred to story 27.3.
+        """
         with self._lock:
             teams = set(self._seen_teams)
 

--- a/src/akgentic/infra/adapters/shared/telemetry_subscriber.py
+++ b/src/akgentic/infra/adapters/shared/telemetry_subscriber.py
@@ -62,7 +62,8 @@ class TelemetrySubscriber(EventSubscriber):
     """
 
     def __init__(self) -> None:
-        self._restoring = False
+        self._restoring: set[uuid.UUID] = set()
+        self._restoring_lock = threading.Lock()
         self._queue: queue.Queue[object] = queue.Queue()
         self._worker = threading.Thread(
             target=self._run,
@@ -72,30 +73,43 @@ class TelemetrySubscriber(EventSubscriber):
         self._worker.start()
         logger.debug("TelemetrySubscriber initialized (async worker)")
 
-    def set_restoring(self, team_id: uuid.UUID, restoring: bool) -> None:  # noqa: ARG002
-        """Toggle restore mode to suppress span emission during event replay.
+    def set_restoring(self, team_id: uuid.UUID, restoring: bool) -> None:
+        """Toggle restore-mode suppression for a single team.
+
+        The restoring set is per-team — only messages whose ``team_id`` is in
+        the set are suppressed by ``on_message``. Mutation is guarded by
+        ``self._restoring_lock`` because multiple orchestrator threads may
+        toggle the flag concurrently (one orchestrator per team).
 
         Args:
             team_id: ``team_id`` from the orchestrator triggering the notification.
-                Accepted to satisfy the ``EventSubscriber`` Protocol but currently
-                ignored — per-team conversion of ``_restoring`` is deferred to
-                story 27.2.
-            restoring: ``True`` to suppress emission, ``False`` to resume.
+            restoring: ``True`` to suppress emission for ``team_id``, ``False``
+                to resume normal emission for it. Calling with ``restoring=False``
+                when ``team_id`` is not in the set is a silent no-op
+                (``set.discard`` semantics).
         """
-        self._restoring = restoring
+        with self._restoring_lock:
+            if restoring:
+                self._restoring.add(team_id)
+            else:
+                self._restoring.discard(team_id)
 
     def on_message(self, msg: Message) -> None:
         """Enqueue a lightweight telemetry record for background emission.
 
         Non-blocking: reads a few plain attributes off the message on the
         caller's thread and hands them to the worker. The actor thread is
-        never held on logfire I/O.
+        never held on logfire I/O. Messages whose ``team_id`` is currently
+        flagged restoring are dropped before they reach the queue, so the
+        restore-replay window of one team cannot interfere with the live
+        telemetry of another.
 
         Args:
             msg: Orchestrator telemetry message
         """
-        if self._restoring:
-            return
+        with self._restoring_lock:
+            if msg.team_id in self._restoring:
+                return
 
         sender = msg.sender.name if msg.sender else "unknown"
         msg_type = msg.__class__.__name__
@@ -107,7 +121,7 @@ class TelemetrySubscriber(EventSubscriber):
 
         The orchestrator's inactivity-timer handler calls this on every subscriber;
         this shared telemetry subscriber has no per-team teardown to perform on that
-        signal (worker drain happens in ``on_stop()`` on actual shutdown).
+        signal (worker drain happens in ``close()`` on actual worker shutdown).
 
         Args:
             team_id: ``team_id`` from the orchestrator triggering the notification.
@@ -115,20 +129,34 @@ class TelemetrySubscriber(EventSubscriber):
                 ignored — per-team handling is deferred.
         """
 
-    def on_stop(self, team_id: uuid.UUID) -> None:  # noqa: ARG002
-        """Signal the worker to drain and exit.
+    def on_stop(self, team_id: uuid.UUID) -> None:
+        """Per-team stop notification — does **not** drain the worker thread.
 
-        Bounded join keeps server shutdown snappy even if logfire is wedged.
+        The daemon worker is shared across every team that publishes through
+        this subscriber, so tearing it down on a single team's stop would
+        starve the rest. The drain is now performed by ``close()`` from the
+        worker FastAPI ``_lifespan`` shutdown branch, once every team has
+        already been torn down.
 
         Args:
             team_id: ``team_id`` from the orchestrator triggering the notification.
-                Accepted to satisfy the ``EventSubscriber`` Protocol but currently
-                ignored — extraction of the worker drain into a separate
-                ``close()`` method is deferred to story 27.2.
+                Logged at DEBUG; no other action is taken.
         """
+        logger.debug("TelemetrySubscriber: on_stop for team_id=%s", team_id)
+
+    def close(self) -> None:
+        """Push ``_SHUTDOWN`` and join the daemon worker thread. Idempotent.
+
+        Called from the worker FastAPI ``_lifespan`` shutdown branch after
+        ``WorkerLifecycle.shutdown()`` returns (all teams torn down). A second
+        call is a no-op — once the worker has exited, ``is_alive()`` is
+        ``False`` and the method returns immediately.
+        """
+        if not self._worker.is_alive():
+            return
         self._queue.put(_SHUTDOWN)
         self._worker.join(timeout=5.0)
-        logger.debug("TelemetrySubscriber stopped")
+        logger.debug("TelemetrySubscriber closed")
 
     def _flush(self, timeout: float = 5.0) -> bool:
         """Block until every item enqueued so far has been drained by the worker.

--- a/src/akgentic/infra/adapters/shared/telemetry_subscriber.py
+++ b/src/akgentic/infra/adapters/shared/telemetry_subscriber.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 import logging
 import queue
 import threading
+import uuid
 from typing import TYPE_CHECKING
 
 import logfire
@@ -71,8 +72,16 @@ class TelemetrySubscriber(EventSubscriber):
         self._worker.start()
         logger.debug("TelemetrySubscriber initialized (async worker)")
 
-    def set_restoring(self, restoring: bool) -> None:
-        """Toggle restore mode to suppress span emission during event replay."""
+    def set_restoring(self, team_id: uuid.UUID, restoring: bool) -> None:  # noqa: ARG002
+        """Toggle restore mode to suppress span emission during event replay.
+
+        Args:
+            team_id: ``team_id`` from the orchestrator triggering the notification.
+                Accepted to satisfy the ``EventSubscriber`` Protocol but currently
+                ignored — per-team conversion of ``_restoring`` is deferred to
+                story 27.2.
+            restoring: ``True`` to suppress emission, ``False`` to resume.
+        """
         self._restoring = restoring
 
     def on_message(self, msg: Message) -> None:
@@ -93,18 +102,29 @@ class TelemetrySubscriber(EventSubscriber):
         team_id = msg.team_id
         self._queue.put((sender, msg_type, team_id))
 
-    def on_stop_request(self) -> None:
+    def on_stop_request(self, team_id: uuid.UUID) -> None:  # noqa: ARG002
         """No-op — stop handling is bridged by ``TimerStopSubscriber`` in ``akgentic-team``.
 
         The orchestrator's inactivity-timer handler calls this on every subscriber;
         this shared telemetry subscriber has no per-team teardown to perform on that
         signal (worker drain happens in ``on_stop()`` on actual shutdown).
+
+        Args:
+            team_id: ``team_id`` from the orchestrator triggering the notification.
+                Accepted to satisfy the ``EventSubscriber`` Protocol but currently
+                ignored — per-team handling is deferred.
         """
 
-    def on_stop(self) -> None:
+    def on_stop(self, team_id: uuid.UUID) -> None:  # noqa: ARG002
         """Signal the worker to drain and exit.
 
         Bounded join keeps server shutdown snappy even if logfire is wedged.
+
+        Args:
+            team_id: ``team_id`` from the orchestrator triggering the notification.
+                Accepted to satisfy the ``EventSubscriber`` Protocol but currently
+                ignored — extraction of the worker drain into a separate
+                ``close()`` method is deferred to story 27.2.
         """
         self._queue.put(_SHUTDOWN)
         self._worker.join(timeout=5.0)

--- a/src/akgentic/infra/wiring.py
+++ b/src/akgentic/infra/wiring.py
@@ -43,7 +43,9 @@ def wire_community(settings: CommunitySettings) -> CommunityServices:
     event_store = YamlEventStore(data_dir=settings.event_store_path)
     service_registry = NullServiceRegistry()
     event_stream = LocalEventStream()
-    actor_system, team_manager = _build_actor_layer(event_store, service_registry, event_stream)
+    actor_system, team_manager, _telemetry_subscriber = _build_actor_layer(
+        event_store, service_registry, event_stream
+    )
     catalog = _build_catalog(settings)
 
     local_placement = LocalPlacement(team_manager, service_registry)
@@ -82,11 +84,19 @@ def _build_actor_layer(
     event_store: EventStore,
     service_registry: ServiceRegistry,
     event_stream: EventStream,
-) -> tuple[ActorSystem, TeamManager]:
-    """Build ActorSystem and TeamManager."""
+) -> tuple[ActorSystem, TeamManager, TelemetrySubscriber]:
+    """Build ActorSystem, TeamManager, and return the shared TelemetrySubscriber.
+
+    The ``TelemetrySubscriber`` is returned by reference so callers that drive
+    a FastAPI worker can plumb it into ``WorkerServices.telemetry_subscriber``
+    and call ``close()`` from the worker lifespan shutdown hook (story 27.1).
+    Community wiring discards the reference because it does not run a FastAPI
+    worker process.
+    """
     logger.debug("Building actor layer: event_store=%s", type(event_store).__name__)
+    telemetry_subscriber = TelemetrySubscriber()
     shared_subscribers: list[EventSubscriber] = [
-        TelemetrySubscriber(),
+        telemetry_subscriber,
         EventStreamSubscriber(event_stream=event_stream),
     ]
     actor_system = ActorSystem()
@@ -100,7 +110,7 @@ def _build_actor_layer(
         "Actor system created, team manager initialized with %d shared subscribers",
         len(shared_subscribers),
     )
-    return actor_system, team_manager
+    return actor_system, team_manager, telemetry_subscriber
 
 
 def _build_catalog(settings: CommunitySettings) -> Catalog:

--- a/src/akgentic/infra/worker/app.py
+++ b/src/akgentic/infra/worker/app.py
@@ -75,3 +75,12 @@ async def _lifespan(app: FastAPI) -> AsyncIterator[None]:
         await asyncio.sleep(delay)
 
     await app.state.lifecycle.shutdown(drain_timeout=settings.shutdown_drain_timeout)
+
+    # Drain the shared TelemetrySubscriber daemon worker AFTER every team has been
+    # torn down, so per-team ``on_stop`` notifications could still emit telemetry
+    # spans. The subscriber is optional on ``WorkerServices`` — tiers that do not
+    # register a TelemetrySubscriber leave it None.
+    services: WorkerServices = app.state.services
+    if services.telemetry_subscriber is not None:
+        services.telemetry_subscriber.close()
+        logger.info("Worker lifespan shutdown: telemetry drained")

--- a/src/akgentic/infra/worker/deps.py
+++ b/src/akgentic/infra/worker/deps.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from pydantic import BaseModel, ConfigDict, Field, SkipValidation
 
 from akgentic.core import ActorSystem
+from akgentic.infra.adapters.shared.telemetry_subscriber import TelemetrySubscriber
 from akgentic.infra.protocols.runtime_cache import RuntimeCache
 from akgentic.infra.protocols.worker_handle import WorkerHandle
 from akgentic.team.manager import TeamManager
@@ -34,3 +35,12 @@ class WorkerServices(BaseModel):
         description="Cache mapping team IDs to live TeamHandle instances"
     )
     worker_handle: WorkerHandle = Field(description="Local worker handle for this process")
+    telemetry_subscriber: TelemetrySubscriber | None = Field(
+        default=None,
+        description=(
+            "Shared TelemetrySubscriber driving the daemon-thread logfire emitter. "
+            "Optional so department/enterprise wirings that do not register a "
+            "TelemetrySubscriber can omit it. When present, the worker FastAPI "
+            "lifespan calls close() after WorkerLifecycle.shutdown() returns."
+        ),
+    )

--- a/tests/adapters/shared/test_channel_dispatcher.py
+++ b/tests/adapters/shared/test_channel_dispatcher.py
@@ -4,9 +4,11 @@ from __future__ import annotations
 
 import uuid
 
+import pytest
 from akgentic.core.actor_address_impl import ActorAddressProxy
 from akgentic.core.messages import Message
 from akgentic.core.messages.orchestrator import ReceivedMessage, SentMessage, StartMessage
+from akgentic.core.orchestrator import EventSubscriber
 
 from akgentic.infra.adapters.shared.channel_dispatcher import InteractionChannelDispatcher
 
@@ -216,7 +218,7 @@ class TestRestoreMode:
     def test_restoring_skips_all_events(self) -> None:
         adapter = _MatchingAdapter()
         dispatcher = InteractionChannelDispatcher(team_id=TEAM_ID, adapters=[adapter])
-        dispatcher.set_restoring(True)
+        dispatcher.set_restoring(TEAM_ID, True)
         dispatcher.on_message(_make_sent_message())
 
         assert not adapter.matches_called
@@ -225,11 +227,11 @@ class TestRestoreMode:
     def test_restoring_false_resumes_dispatch(self) -> None:
         adapter = _MatchingAdapter()
         dispatcher = InteractionChannelDispatcher(team_id=TEAM_ID, adapters=[adapter])
-        dispatcher.set_restoring(True)
+        dispatcher.set_restoring(TEAM_ID, True)
         dispatcher.on_message(_make_sent_message())
         assert not adapter.deliver_called
 
-        dispatcher.set_restoring(False)
+        dispatcher.set_restoring(TEAM_ID, False)
         dispatcher.on_message(_make_sent_message())
         assert adapter.deliver_called
 
@@ -246,7 +248,7 @@ class TestOnStop:
         a1 = _MatchingAdapter()
         a2 = _NonMatchingAdapter()
         dispatcher = InteractionChannelDispatcher(team_id=TEAM_ID, adapters=[a1, a2])
-        dispatcher.on_stop()
+        dispatcher.on_stop(TEAM_ID)
 
         assert a1.stop_called
         assert a1.stop_team_id == TEAM_ID
@@ -255,7 +257,7 @@ class TestOnStop:
 
     def test_on_stop_empty_adapter_list(self) -> None:
         dispatcher = InteractionChannelDispatcher(team_id=TEAM_ID, adapters=[])
-        dispatcher.on_stop()  # should not raise
+        dispatcher.on_stop(TEAM_ID)  # should not raise
 
 
 # ---------------------------------------------------------------------------
@@ -296,3 +298,80 @@ class TestMultiAdapterDispatch:
         assert adapter_b.deliver_called, "Adapter B should receive the message"
         assert adapter_a.deliver_msg is sent
         assert adapter_b.deliver_msg is sent
+
+
+# ---------------------------------------------------------------------------
+# Story 27.1 AC #3: dispatcher asserts team_id equality on lifecycle entries
+# ---------------------------------------------------------------------------
+
+
+class TestOnStopAssertsTeamId:
+    """on_stop and set_restoring raise ``AssertionError`` on team_id mismatch.
+
+    The dispatcher is per-team; the orchestrator MUST pass the matching
+    ``team_id`` on every lifecycle call. A mismatch indicates a wiring bug.
+    """
+
+    def test_on_stop_with_mismatched_team_id_raises(self) -> None:
+        adapter = _MatchingAdapter()
+        dispatcher = InteractionChannelDispatcher(team_id=TEAM_ID, adapters=[adapter])
+
+        with pytest.raises(AssertionError):
+            dispatcher.on_stop(uuid.uuid4())
+
+        assert not adapter.stop_called
+
+    def test_set_restoring_with_mismatched_team_id_raises(self) -> None:
+        adapter = _MatchingAdapter()
+        dispatcher = InteractionChannelDispatcher(team_id=TEAM_ID, adapters=[adapter])
+
+        with pytest.raises(AssertionError):
+            dispatcher.set_restoring(uuid.uuid4(), True)
+
+        # _restoring must remain False (assertion failed before assignment).
+        assert dispatcher._restoring is False
+
+
+class TestOnStopRequest:
+    """Story 27.1 AC #3: on_stop_request is a no-op for Protocol compliance.
+
+    The dispatcher has no work to perform on the inactivity-timer signal; all
+    channel-side teardown happens on on_stop.
+    """
+
+    def test_on_stop_request_returns_none(self) -> None:
+        adapter = _MatchingAdapter()
+        dispatcher = InteractionChannelDispatcher(team_id=TEAM_ID, adapters=[adapter])
+
+        result = dispatcher.on_stop_request(TEAM_ID)
+
+        assert result is None
+
+    def test_on_stop_request_does_not_call_adapter_methods(self) -> None:
+        adapter = _MatchingAdapter()
+        dispatcher = InteractionChannelDispatcher(team_id=TEAM_ID, adapters=[adapter])
+
+        dispatcher.on_stop_request(TEAM_ID)
+
+        assert not adapter.stop_called
+        assert not adapter.matches_called
+        assert not adapter.deliver_called
+
+    def test_on_stop_request_does_not_mutate_restoring(self) -> None:
+        adapter = _MatchingAdapter()
+        dispatcher = InteractionChannelDispatcher(team_id=TEAM_ID, adapters=[adapter])
+
+        dispatcher.on_stop_request(TEAM_ID)
+
+        assert dispatcher._restoring is False
+
+
+class TestProtocolCompliance:
+    """Story 27.1 AC #4: InteractionChannelDispatcher structurally satisfies EventSubscriber."""
+
+    def test_satisfies_event_subscriber_protocol(self) -> None:
+        dispatcher: EventSubscriber = InteractionChannelDispatcher(team_id=TEAM_ID, adapters=[])
+        assert callable(dispatcher.set_restoring)
+        assert callable(dispatcher.on_stop_request)
+        assert callable(dispatcher.on_stop)
+        assert callable(dispatcher.on_message)

--- a/tests/adapters/shared/test_event_stream_subscriber.py
+++ b/tests/adapters/shared/test_event_stream_subscriber.py
@@ -7,9 +7,12 @@ import uuid
 from unittest.mock import MagicMock
 
 from akgentic.core.messages import Message
+from akgentic.core.orchestrator import EventSubscriber
 
 from akgentic.infra.adapters.community.local_event_stream import LocalEventStream
 from akgentic.infra.adapters.shared.event_stream_subscriber import EventStreamSubscriber
+
+_TEAM_ID = uuid.uuid4()
 
 
 def _make_message(team_id: uuid.UUID | None = None) -> Message:
@@ -38,15 +41,26 @@ class TestEventStreamSubscriberProtocolCompliance:
         assert "msg" in sig.parameters
 
     def test_on_stop_signature_matches_protocol(self) -> None:
+        """on_stop takes a single ``team_id`` parameter beyond self (Story 27.1)."""
         sig = inspect.signature(EventStreamSubscriber.on_stop)
         params = [p for p in sig.parameters if p != "self"]
-        assert len(params) == 0
+        assert len(params) == 1
+        assert params[0] == "team_id"
 
     def test_on_stop_request_signature_matches_protocol(self) -> None:
-        """Story 22.1 AC1: on_stop_request takes no parameters beyond self and returns None."""
+        """on_stop_request takes a single ``team_id`` parameter beyond self (Story 27.1)."""
         sig = inspect.signature(EventStreamSubscriber.on_stop_request)
         params = [p for p in sig.parameters if p != "self"]
-        assert len(params) == 0
+        assert len(params) == 1
+        assert params[0] == "team_id"
+
+    def test_satisfies_event_subscriber_protocol(self) -> None:
+        """Story 27.1 AC #4: EventStreamSubscriber structurally satisfies EventSubscriber."""
+        subscriber: EventSubscriber = EventStreamSubscriber(event_stream=LocalEventStream())
+        assert callable(subscriber.set_restoring)
+        assert callable(subscriber.on_stop_request)
+        assert callable(subscriber.on_stop)
+        assert callable(subscriber.on_message)
 
 
 class TestOnMessage:
@@ -130,7 +144,9 @@ class TestOnStop:
         subscriber.on_message(_make_message(team_id=team_a))
         subscriber.on_message(_make_message(team_id=team_b))
 
-        subscriber.on_stop()
+        # Story 27.1: ``on_stop`` accepts ``team_id`` but body still iterates
+        # ``_seen_teams``; per-team-keyed cleanup is revived in story 27.3.
+        subscriber.on_stop(_TEAM_ID)
 
         # Streams should be removed
         assert stream.read_from(team_a) == []
@@ -141,7 +157,7 @@ class TestOnStop:
         stream = LocalEventStream()
         subscriber = EventStreamSubscriber(event_stream=stream)
 
-        subscriber.on_stop()  # Should not raise
+        subscriber.on_stop(_TEAM_ID)  # Should not raise
 
     def test_on_stop_handles_remove_exceptions_gracefully(self) -> None:
         """AC3: on_stop handles remove() exceptions (logged, not raised)."""
@@ -153,7 +169,7 @@ class TestOnStop:
         subscriber.on_message(_make_message(team_id=team_id))
 
         # Should not raise even though remove() throws
-        subscriber.on_stop()
+        subscriber.on_stop(_TEAM_ID)
         mock_stream.remove.assert_called_once_with(team_id)
 
 
@@ -165,7 +181,7 @@ class TestOnStopRequest:
         stream = LocalEventStream()
         subscriber = EventStreamSubscriber(event_stream=stream)
 
-        result = subscriber.on_stop_request()
+        result = subscriber.on_stop_request(_TEAM_ID)
 
         assert result is None
 
@@ -174,7 +190,7 @@ class TestOnStopRequest:
         mock_stream = MagicMock()
         subscriber = EventStreamSubscriber(event_stream=mock_stream)
 
-        subscriber.on_stop_request()
+        subscriber.on_stop_request(_TEAM_ID)
 
         # No methods on the stream should have been called.
         mock_stream.append.assert_not_called()
@@ -189,6 +205,6 @@ class TestOnStopRequest:
         subscriber.on_message(_make_message(team_id=team_id))
         before = set(subscriber._seen_teams)
 
-        subscriber.on_stop_request()
+        subscriber.on_stop_request(_TEAM_ID)
 
         assert subscriber._seen_teams == before

--- a/tests/adapters/shared/test_event_stream_subscriber.py
+++ b/tests/adapters/shared/test_event_stream_subscriber.py
@@ -1,4 +1,8 @@
-"""Tests for EventStreamSubscriber adapter (updated for Story 13.7)."""
+"""Tests for EventStreamSubscriber adapter.
+
+Story 27.1: ``_seen_teams`` tracking removed; ``on_stop(team_id)`` is the
+canonical per-team cleanup hook; ``set_restoring`` remains a documented no-op.
+"""
 
 from __future__ import annotations
 
@@ -11,6 +15,7 @@ from akgentic.core.orchestrator import EventSubscriber
 
 from akgentic.infra.adapters.community.local_event_stream import LocalEventStream
 from akgentic.infra.adapters.shared.event_stream_subscriber import EventStreamSubscriber
+from akgentic.infra.protocols.event_stream import EventStream
 
 _TEAM_ID = uuid.uuid4()
 
@@ -55,7 +60,7 @@ class TestEventStreamSubscriberProtocolCompliance:
         assert params[0] == "team_id"
 
     def test_satisfies_event_subscriber_protocol(self) -> None:
-        """Story 27.1 AC #4: EventStreamSubscriber structurally satisfies EventSubscriber."""
+        """Story 27.1 AC #2: EventStreamSubscriber structurally satisfies EventSubscriber."""
         subscriber: EventSubscriber = EventStreamSubscriber(event_stream=LocalEventStream())
         assert callable(subscriber.set_restoring)
         assert callable(subscriber.on_stop_request)
@@ -63,11 +68,49 @@ class TestEventStreamSubscriberProtocolCompliance:
         assert callable(subscriber.on_message)
 
 
-class TestOnMessage:
-    """AC4: on_message forwards Message directly -- no PersistedEvent wrapping."""
+class TestNoSeenTeamsAttribute:
+    """Story 27.1 AC #8: ``_seen_teams`` tracking removed entirely."""
 
-    def test_valid_team_id_forwards_message_directly(self) -> None:
-        """AC4: on_message with valid team_id forwards Message to event stream."""
+    def test_no_seen_teams_attribute(self) -> None:
+        subscriber = EventStreamSubscriber(event_stream=LocalEventStream())
+        assert not hasattr(subscriber, "_seen_teams")
+
+    def test_no_internal_lock_attribute(self) -> None:
+        """The ``threading.Lock`` that guarded _seen_teams was removed too."""
+        subscriber = EventStreamSubscriber(event_stream=LocalEventStream())
+        assert not hasattr(subscriber, "_lock")
+
+
+class TestOnMessage:
+    """Story 27.1 AC #9: ``on_message`` appends every event to the per-team stream."""
+
+    def test_on_message_appends_to_stream_with_team_id(self) -> None:
+        """Two messages with the same team_id ⇒ two ``append`` calls (no dedup)."""
+        mock_stream = MagicMock(spec=EventStream)
+        subscriber = EventStreamSubscriber(event_stream=mock_stream)
+        team_id = uuid.uuid4()
+        msg1 = _make_message(team_id=team_id)
+        msg2 = _make_message(team_id=team_id)
+
+        subscriber.on_message(msg1)
+        mock_stream.append.assert_called_once_with(team_id, msg1)
+
+        subscriber.on_message(msg2)
+        assert mock_stream.append.call_count == 2
+        mock_stream.append.assert_called_with(team_id, msg2)
+
+    def test_on_message_skips_team_id_none(self) -> None:
+        """A message with team_id=None must not reach the stream."""
+        mock_stream = MagicMock(spec=EventStream)
+        subscriber = EventStreamSubscriber(event_stream=mock_stream)
+        msg = _make_message(team_id=None)
+
+        subscriber.on_message(msg)
+
+        mock_stream.append.assert_not_called()
+
+    def test_valid_team_id_forwards_message_to_local_stream(self) -> None:
+        """End-to-end smoke against the real LocalEventStream."""
         stream = LocalEventStream()
         subscriber = EventStreamSubscriber(event_stream=stream)
         team_id = uuid.uuid4()
@@ -80,22 +123,8 @@ class TestOnMessage:
         assert events[0].id == msg.id
         assert events[0].team_id == team_id
 
-    def test_team_id_none_is_silently_skipped(self) -> None:
-        """AC4: Messages with team_id=None are silently skipped."""
-        stream = LocalEventStream()
-        subscriber = EventStreamSubscriber(event_stream=stream)
-        team_id = uuid.uuid4()
-        msg = _make_message(team_id=None)
-
-        subscriber.on_message(msg)
-
-        # Verify no events were appended for any team
-        assert stream.read_from(team_id) == []
-        # Subscriber should not have tracked any teams
-        assert len(subscriber._seen_teams) == 0
-
     def test_multiple_messages_appended_in_order(self) -> None:
-        """Messages are appended in order to the event stream."""
+        """Messages are appended in order across multiple teams (no dedup)."""
         stream = LocalEventStream()
         subscriber = EventStreamSubscriber(event_stream=stream)
         team_a = uuid.uuid4()
@@ -115,7 +144,7 @@ class TestOnMessage:
         assert len(events_b) == 2
 
     def test_forwarded_message_is_original(self) -> None:
-        """AC4: Forwarded event is the original Message, not a wrapper."""
+        """Forwarded event is the original Message, not a wrapper."""
         stream = LocalEventStream()
         subscriber = EventStreamSubscriber(event_stream=stream)
         team_id = uuid.uuid4()
@@ -132,45 +161,61 @@ class TestOnMessage:
 
 
 class TestOnStop:
-    """AC3: on_stop removes streams for all seen team_ids."""
+    """Story 27.1 AC #10: ``on_stop(team_id)`` removes exactly one team's stream."""
 
-    def test_on_stop_removes_all_seen_teams(self) -> None:
-        """AC3: on_stop calls remove() for all tracked team_ids."""
+    def test_on_stop_removes_only_supplied_team(self) -> None:
+        """``on_stop(team_a)`` calls ``remove(team_a)`` once; team_b untouched."""
+        mock_stream = MagicMock(spec=EventStream)
+        subscriber = EventStreamSubscriber(event_stream=mock_stream)
+        team_a = uuid.uuid4()
+
+        subscriber.on_stop(team_a)
+
+        mock_stream.remove.assert_called_once_with(team_a)
+
+    def test_on_stop_does_not_touch_other_teams(self) -> None:
+        """Pre-populating a LocalEventStream with two teams: on_stop(team_a) removes only team_a."""
         stream = LocalEventStream()
         subscriber = EventStreamSubscriber(event_stream=stream)
         team_a = uuid.uuid4()
         team_b = uuid.uuid4()
-
         subscriber.on_message(_make_message(team_id=team_a))
         subscriber.on_message(_make_message(team_id=team_b))
 
-        # Story 27.1: ``on_stop`` accepts ``team_id`` but body still iterates
-        # ``_seen_teams``; per-team-keyed cleanup is revived in story 27.3.
-        subscriber.on_stop(_TEAM_ID)
+        subscriber.on_stop(team_a)
 
-        # Streams should be removed
+        # team_a stream is gone, team_b still has its event
         assert stream.read_from(team_a) == []
-        assert stream.read_from(team_b) == []
+        assert len(stream.read_from(team_b)) == 1
 
-    def test_on_stop_no_messages_is_noop(self) -> None:
-        """AC3: on_stop with no messages received is a no-op."""
-        stream = LocalEventStream()
-        subscriber = EventStreamSubscriber(event_stream=stream)
-
-        subscriber.on_stop(_TEAM_ID)  # Should not raise
-
-    def test_on_stop_handles_remove_exceptions_gracefully(self) -> None:
-        """AC3: on_stop handles remove() exceptions (logged, not raised)."""
-        mock_stream = MagicMock()
-        mock_stream.remove.side_effect = RuntimeError("test error")
+    def test_on_stop_swallows_remove_exception(self) -> None:
+        """If ``event_stream.remove`` raises, the exception is swallowed (logged)."""
+        mock_stream = MagicMock(spec=EventStream)
+        mock_stream.remove.side_effect = KeyError("stream not found")
         subscriber = EventStreamSubscriber(event_stream=mock_stream)
-        team_id = uuid.uuid4()
+        team_a = uuid.uuid4()
 
-        subscriber.on_message(_make_message(team_id=team_id))
+        # Must not raise.
+        subscriber.on_stop(team_a)
 
-        # Should not raise even though remove() throws
-        subscriber.on_stop(_TEAM_ID)
-        mock_stream.remove.assert_called_once_with(team_id)
+        mock_stream.remove.assert_called_once_with(team_a)
+
+
+class TestSetRestoringNoOp:
+    """Story 27.1 AC #11: ``set_restoring`` is a documented no-op on EventStreamSubscriber."""
+
+    def test_set_restoring_is_noop(self) -> None:
+        """Neither ``set_restoring(True)`` nor ``set_restoring(False)`` calls any stream method."""
+        mock_stream = MagicMock(spec=EventStream)
+        subscriber = EventStreamSubscriber(event_stream=mock_stream)
+        team_a = uuid.uuid4()
+
+        subscriber.set_restoring(team_a, True)
+        subscriber.set_restoring(team_a, False)
+
+        mock_stream.append.assert_not_called()
+        mock_stream.remove.assert_not_called()
+        mock_stream.read_from.assert_not_called()
 
 
 class TestOnStopRequest:
@@ -187,24 +232,11 @@ class TestOnStopRequest:
 
     def test_on_stop_request_does_not_touch_event_stream(self) -> None:
         """No-op contract: on_stop_request must not append, remove, or read from the stream."""
-        mock_stream = MagicMock()
+        mock_stream = MagicMock(spec=EventStream)
         subscriber = EventStreamSubscriber(event_stream=mock_stream)
 
         subscriber.on_stop_request(_TEAM_ID)
 
-        # No methods on the stream should have been called.
         mock_stream.append.assert_not_called()
         mock_stream.remove.assert_not_called()
         mock_stream.read_from.assert_not_called()
-
-    def test_on_stop_request_does_not_mutate_seen_teams(self) -> None:
-        """State invariant: on_stop_request leaves _seen_teams untouched."""
-        stream = LocalEventStream()
-        subscriber = EventStreamSubscriber(event_stream=stream)
-        team_id = uuid.uuid4()
-        subscriber.on_message(_make_message(team_id=team_id))
-        before = set(subscriber._seen_teams)
-
-        subscriber.on_stop_request(_TEAM_ID)
-
-        assert subscriber._seen_teams == before

--- a/tests/adapters/shared/test_telemetry_restore.py
+++ b/tests/adapters/shared/test_telemetry_restore.py
@@ -7,9 +7,12 @@ runs on a daemon worker. Live-emit assertions must flush the worker via
 
 from __future__ import annotations
 
+import uuid
 from unittest.mock import MagicMock, patch
 
 from akgentic.infra.adapters.shared.telemetry_subscriber import TelemetrySubscriber
+
+_TEAM_ID = uuid.uuid4()
 
 
 class TestTelemetryRestoreAwareness:
@@ -25,14 +28,12 @@ class TestTelemetryRestoreAwareness:
         msg = MagicMock()
         msg.__class__.__name__ = "StartMessage"
 
-        with patch(
-            "akgentic.infra.adapters.shared.telemetry_subscriber.logfire"
-        ) as mock_lf:
+        with patch("akgentic.infra.adapters.shared.telemetry_subscriber.logfire") as mock_lf:
             subscriber.on_message(msg)
             assert subscriber._flush(timeout=5.0), "worker did not drain in time"
             mock_lf.info.assert_called_once()
 
-        subscriber.on_stop()
+        subscriber.on_stop(_TEAM_ID)
 
     def test_restoring_skips_logfire_emission(self) -> None:
         """AC #6: set_restoring(True) suppresses logfire.info calls.
@@ -41,37 +42,33 @@ class TestTelemetryRestoreAwareness:
         so the worker has nothing to emit.
         """
         subscriber = TelemetrySubscriber()
-        subscriber.set_restoring(True)
+        subscriber.set_restoring(_TEAM_ID, True)
         msg = MagicMock()
         msg.__class__.__name__ = "StartMessage"
 
-        with patch(
-            "akgentic.infra.adapters.shared.telemetry_subscriber.logfire"
-        ) as mock_lf:
+        with patch("akgentic.infra.adapters.shared.telemetry_subscriber.logfire") as mock_lf:
             subscriber.on_message(msg)
             assert subscriber._flush(timeout=5.0)
             mock_lf.info.assert_not_called()
 
-        subscriber.on_stop()
+        subscriber.on_stop(_TEAM_ID)
 
     def test_restoring_false_resumes_logfire(self) -> None:
         """set_restoring(False) resumes normal logfire emission."""
         subscriber = TelemetrySubscriber()
-        subscriber.set_restoring(True)
-        subscriber.set_restoring(False)
+        subscriber.set_restoring(_TEAM_ID, True)
+        subscriber.set_restoring(_TEAM_ID, False)
         msg = MagicMock()
         msg.__class__.__name__ = "StartMessage"
 
-        with patch(
-            "akgentic.infra.adapters.shared.telemetry_subscriber.logfire"
-        ) as mock_lf:
+        with patch("akgentic.infra.adapters.shared.telemetry_subscriber.logfire") as mock_lf:
             subscriber.on_message(msg)
             assert subscriber._flush(timeout=5.0)
             mock_lf.info.assert_called_once()
 
-        subscriber.on_stop()
+        subscriber.on_stop(_TEAM_ID)
 
     def test_on_stop_does_not_raise(self) -> None:
         """on_stop completes without error."""
         subscriber = TelemetrySubscriber()
-        subscriber.on_stop()
+        subscriber.on_stop(_TEAM_ID)

--- a/tests/adapters/shared/test_telemetry_restore.py
+++ b/tests/adapters/shared/test_telemetry_restore.py
@@ -33,25 +33,27 @@ class TestTelemetryRestoreAwareness:
             assert subscriber._flush(timeout=5.0), "worker did not drain in time"
             mock_lf.info.assert_called_once()
 
-        subscriber.on_stop(_TEAM_ID)
+        subscriber.close()
 
     def test_restoring_skips_logfire_emission(self) -> None:
-        """AC #6: set_restoring(True) suppresses logfire.info calls.
+        """AC #6: set_restoring(team_id, True) suppresses logfire.info for that team.
 
-        The ``_restoring`` guard drops messages before they enter the queue,
-        so the worker has nothing to emit.
+        The ``_restoring`` guard drops messages whose ``team_id`` is in the
+        per-team restoring set before they enter the queue, so the worker
+        has nothing to emit.
         """
         subscriber = TelemetrySubscriber()
         subscriber.set_restoring(_TEAM_ID, True)
         msg = MagicMock()
         msg.__class__.__name__ = "StartMessage"
+        msg.team_id = _TEAM_ID
 
         with patch("akgentic.infra.adapters.shared.telemetry_subscriber.logfire") as mock_lf:
             subscriber.on_message(msg)
             assert subscriber._flush(timeout=5.0)
             mock_lf.info.assert_not_called()
 
-        subscriber.on_stop(_TEAM_ID)
+        subscriber.close()
 
     def test_restoring_false_resumes_logfire(self) -> None:
         """set_restoring(False) resumes normal logfire emission."""
@@ -66,9 +68,9 @@ class TestTelemetryRestoreAwareness:
             assert subscriber._flush(timeout=5.0)
             mock_lf.info.assert_called_once()
 
-        subscriber.on_stop(_TEAM_ID)
+        subscriber.close()
 
     def test_on_stop_does_not_raise(self) -> None:
         """on_stop completes without error."""
         subscriber = TelemetrySubscriber()
-        subscriber.on_stop(_TEAM_ID)
+        subscriber.close()

--- a/tests/adapters/shared/test_telemetry_subscriber.py
+++ b/tests/adapters/shared/test_telemetry_subscriber.py
@@ -143,7 +143,7 @@ class TestTelemetrySubscriberAsyncWorker:
         subscriber.close()
 
     def test_restoring_flag_suppresses_enqueue(self) -> None:
-        """``set_restoring(team, True)`` drops messages for that team before they reach the queue."""
+        """``set_restoring(team, True)`` drops same-team messages before they reach the queue."""
         subscriber = TelemetrySubscriber()
         subscriber.set_restoring(_TEAM_ID, True)
         msg = MagicMock()
@@ -278,9 +278,7 @@ class TestPerTeamRestoringSet:
             msg_b.sender.name = "orchestrator"
             msg_b.team_id = team_b
 
-            with patch(
-                "akgentic.infra.adapters.shared.telemetry_subscriber.logfire"
-            ) as mock_lf:
+            with patch("akgentic.infra.adapters.shared.telemetry_subscriber.logfire") as mock_lf:
                 subscriber.on_message(msg_a)  # dropped
                 subscriber.on_message(msg_b)  # emitted
                 assert subscriber._flush(timeout=5.0)

--- a/tests/adapters/shared/test_telemetry_subscriber.py
+++ b/tests/adapters/shared/test_telemetry_subscriber.py
@@ -4,9 +4,14 @@ from __future__ import annotations
 
 import inspect
 import time
+import uuid
 from unittest.mock import MagicMock, patch
 
+from akgentic.core.orchestrator import EventSubscriber
+
 from akgentic.infra.adapters.shared.telemetry_subscriber import TelemetrySubscriber
+
+_TEAM_ID = uuid.uuid4()
 
 
 class TestTelemetrySubscriberProtocolCompliance:
@@ -26,7 +31,7 @@ class TestTelemetrySubscriberProtocolCompliance:
         """Story 22.1 AC2: subscriber exposes on_stop_request for timer-driven shutdown."""
         subscriber = TelemetrySubscriber()
         assert callable(subscriber.on_stop_request)
-        subscriber.on_stop()
+        subscriber.on_stop(_TEAM_ID)
 
     def test_on_message_signature_matches_protocol(self) -> None:
         """on_message has msg parameter matching EventSubscriber."""
@@ -34,16 +39,35 @@ class TestTelemetrySubscriberProtocolCompliance:
         assert "msg" in sig.parameters
 
     def test_on_stop_signature_matches_protocol(self) -> None:
-        """on_stop has no parameters beyond self."""
+        """on_stop takes a single ``team_id`` parameter beyond self (Story 27.1)."""
         sig = inspect.signature(TelemetrySubscriber.on_stop)
         params = [p for p in sig.parameters if p != "self"]
-        assert len(params) == 0
+        assert len(params) == 1
+        assert params[0] == "team_id"
 
     def test_on_stop_request_signature_matches_protocol(self) -> None:
-        """Story 22.1 AC2: on_stop_request takes no parameters beyond self."""
+        """on_stop_request takes a single ``team_id`` parameter beyond self (Story 27.1)."""
         sig = inspect.signature(TelemetrySubscriber.on_stop_request)
         params = [p for p in sig.parameters if p != "self"]
-        assert len(params) == 0
+        assert len(params) == 1
+        assert params[0] == "team_id"
+
+    def test_satisfies_event_subscriber_protocol(self) -> None:
+        """Story 27.1 AC #4: TelemetrySubscriber structurally satisfies EventSubscriber.
+
+        ``EventSubscriber`` is a ``typing.Protocol`` (not ``runtime_checkable``),
+        so this test assigns the subscriber to a Protocol-typed name to surface
+        structural mismatches at mypy time and asserts each required method
+        exists at runtime.
+        """
+        subscriber: EventSubscriber = TelemetrySubscriber()
+        try:
+            assert callable(subscriber.set_restoring)
+            assert callable(subscriber.on_stop_request)
+            assert callable(subscriber.on_stop)
+            assert callable(subscriber.on_message)
+        finally:
+            subscriber.on_stop(_TEAM_ID)
 
 
 class TestTelemetrySubscriberBehavior:
@@ -59,7 +83,7 @@ class TestTelemetrySubscriberBehavior:
     def test_on_stop_does_not_raise(self) -> None:
         """on_stop completes without error."""
         subscriber = TelemetrySubscriber()
-        subscriber.on_stop()
+        subscriber.on_stop(_TEAM_ID)
 
 
 class TestTelemetrySubscriberAsyncWorker:
@@ -90,7 +114,7 @@ class TestTelemetrySubscriberAsyncWorker:
             # Generous ceiling for shared CI runners; the real target is sub-ms.
             assert elapsed < 0.05, f"on_message took {elapsed * 1000:.1f} ms"
 
-        subscriber.on_stop()
+        subscriber.on_stop(_TEAM_ID)
 
     def test_flush_then_logfire_called_with_expected_args(self) -> None:
         """After explicit flush, ``logfire.info`` was called with sender/msg_type/team_id."""
@@ -110,12 +134,12 @@ class TestTelemetrySubscriberAsyncWorker:
             assert kwargs["msg_type"] == "StartMessage"
             assert kwargs["team_id"] == "team-xyz"
 
-        subscriber.on_stop()
+        subscriber.on_stop(_TEAM_ID)
 
     def test_restoring_flag_suppresses_enqueue(self) -> None:
         """``_restoring=True`` drops messages before they reach the queue."""
         subscriber = TelemetrySubscriber()
-        subscriber.set_restoring(True)
+        subscriber.set_restoring(_TEAM_ID, True)
         msg = MagicMock()
         msg.__class__.__name__ = "StartMessage"
 
@@ -126,20 +150,20 @@ class TestTelemetrySubscriberAsyncWorker:
 
             mock_lf.info.assert_not_called()
 
-        subscriber.on_stop()
+        subscriber.on_stop(_TEAM_ID)
 
     def test_worker_is_daemon(self) -> None:
         """Worker thread is a daemon — process exit is never blocked on logfire."""
         subscriber = TelemetrySubscriber()
         assert subscriber._worker.daemon is True
-        subscriber.on_stop()
+        subscriber.on_stop(_TEAM_ID)
 
     def test_on_stop_joins_within_timeout(self) -> None:
         """``on_stop`` returns within ~5 s and the worker thread exits."""
         subscriber = TelemetrySubscriber()
 
         start = time.perf_counter()
-        subscriber.on_stop()
+        subscriber.on_stop(_TEAM_ID)
         elapsed = time.perf_counter() - start
 
         assert elapsed < 5.0, f"on_stop took {elapsed:.2f} s"
@@ -153,10 +177,10 @@ class TestOnStopRequest:
         """Direct invocation returns None without raising."""
         subscriber = TelemetrySubscriber()
         try:
-            result = subscriber.on_stop_request()
+            result = subscriber.on_stop_request(_TEAM_ID)
             assert result is None
         finally:
-            subscriber.on_stop()
+            subscriber.on_stop(_TEAM_ID)
 
     def test_on_stop_request_does_not_enqueue_on_worker(self) -> None:
         """Queue invariant: on_stop_request must NOT enqueue a telemetry record.
@@ -168,7 +192,7 @@ class TestOnStopRequest:
         try:
             qsize_before = subscriber._queue.qsize()
 
-            subscriber.on_stop_request()
+            subscriber.on_stop_request(_TEAM_ID)
             # Allow worker a tiny window to drain anything unexpected.
             assert subscriber._flush(timeout=5.0)
 
@@ -181,13 +205,13 @@ class TestOnStopRequest:
             # by _flush before we observe).
             assert subscriber._queue.qsize() == qsize_before
         finally:
-            subscriber.on_stop()
+            subscriber.on_stop(_TEAM_ID)
 
     def test_on_stop_request_before_on_stop_then_stop_still_works(self) -> None:
         """Idempotent: calling on_stop_request then on_stop still shuts the worker down."""
         subscriber = TelemetrySubscriber()
 
-        subscriber.on_stop_request()
-        subscriber.on_stop()
+        subscriber.on_stop_request(_TEAM_ID)
+        subscriber.on_stop(_TEAM_ID)
 
         assert not subscriber._worker.is_alive()

--- a/tests/adapters/shared/test_telemetry_subscriber.py
+++ b/tests/adapters/shared/test_telemetry_subscriber.py
@@ -31,7 +31,7 @@ class TestTelemetrySubscriberProtocolCompliance:
         """Story 22.1 AC2: subscriber exposes on_stop_request for timer-driven shutdown."""
         subscriber = TelemetrySubscriber()
         assert callable(subscriber.on_stop_request)
-        subscriber.on_stop(_TEAM_ID)
+        subscriber.close()
 
     def test_on_message_signature_matches_protocol(self) -> None:
         """on_message has msg parameter matching EventSubscriber."""
@@ -67,7 +67,7 @@ class TestTelemetrySubscriberProtocolCompliance:
             assert callable(subscriber.on_stop)
             assert callable(subscriber.on_message)
         finally:
-            subscriber.on_stop(_TEAM_ID)
+            subscriber.close()
 
 
 class TestTelemetrySubscriberBehavior:
@@ -76,14 +76,20 @@ class TestTelemetrySubscriberBehavior:
     def test_on_message_does_not_raise(self) -> None:
         """on_message processes a mock message without error."""
         subscriber = TelemetrySubscriber()
-        msg = MagicMock()
-        msg.__class__.__name__ = "StartMessage"
-        subscriber.on_message(msg)
+        try:
+            msg = MagicMock()
+            msg.__class__.__name__ = "StartMessage"
+            subscriber.on_message(msg)
+        finally:
+            subscriber.close()
 
     def test_on_stop_does_not_raise(self) -> None:
         """on_stop completes without error."""
         subscriber = TelemetrySubscriber()
-        subscriber.on_stop(_TEAM_ID)
+        try:
+            subscriber.on_stop(_TEAM_ID)
+        finally:
+            subscriber.close()
 
 
 class TestTelemetrySubscriberAsyncWorker:
@@ -114,7 +120,7 @@ class TestTelemetrySubscriberAsyncWorker:
             # Generous ceiling for shared CI runners; the real target is sub-ms.
             assert elapsed < 0.05, f"on_message took {elapsed * 1000:.1f} ms"
 
-        subscriber.on_stop(_TEAM_ID)
+        subscriber.close()
 
     def test_flush_then_logfire_called_with_expected_args(self) -> None:
         """After explicit flush, ``logfire.info`` was called with sender/msg_type/team_id."""
@@ -134,14 +140,15 @@ class TestTelemetrySubscriberAsyncWorker:
             assert kwargs["msg_type"] == "StartMessage"
             assert kwargs["team_id"] == "team-xyz"
 
-        subscriber.on_stop(_TEAM_ID)
+        subscriber.close()
 
     def test_restoring_flag_suppresses_enqueue(self) -> None:
-        """``_restoring=True`` drops messages before they reach the queue."""
+        """``set_restoring(team, True)`` drops messages for that team before they reach the queue."""
         subscriber = TelemetrySubscriber()
         subscriber.set_restoring(_TEAM_ID, True)
         msg = MagicMock()
         msg.__class__.__name__ = "StartMessage"
+        msg.team_id = _TEAM_ID
 
         with patch("akgentic.infra.adapters.shared.telemetry_subscriber.logfire") as mock_lf:
             for _ in range(10):
@@ -150,23 +157,23 @@ class TestTelemetrySubscriberAsyncWorker:
 
             mock_lf.info.assert_not_called()
 
-        subscriber.on_stop(_TEAM_ID)
+        subscriber.close()
 
     def test_worker_is_daemon(self) -> None:
         """Worker thread is a daemon — process exit is never blocked on logfire."""
         subscriber = TelemetrySubscriber()
         assert subscriber._worker.daemon is True
-        subscriber.on_stop(_TEAM_ID)
+        subscriber.close()
 
-    def test_on_stop_joins_within_timeout(self) -> None:
-        """``on_stop`` returns within ~5 s and the worker thread exits."""
+    def test_close_joins_within_timeout(self) -> None:
+        """``close()`` returns within ~5 s and the worker thread exits."""
         subscriber = TelemetrySubscriber()
 
         start = time.perf_counter()
-        subscriber.on_stop(_TEAM_ID)
+        subscriber.close()
         elapsed = time.perf_counter() - start
 
-        assert elapsed < 5.0, f"on_stop took {elapsed:.2f} s"
+        assert elapsed < 5.0, f"close() took {elapsed:.2f} s"
         assert not subscriber._worker.is_alive()
 
 
@@ -180,7 +187,7 @@ class TestOnStopRequest:
             result = subscriber.on_stop_request(_TEAM_ID)
             assert result is None
         finally:
-            subscriber.on_stop(_TEAM_ID)
+            subscriber.close()
 
     def test_on_stop_request_does_not_enqueue_on_worker(self) -> None:
         """Queue invariant: on_stop_request must NOT enqueue a telemetry record.
@@ -205,13 +212,119 @@ class TestOnStopRequest:
             # by _flush before we observe).
             assert subscriber._queue.qsize() == qsize_before
         finally:
-            subscriber.on_stop(_TEAM_ID)
+            subscriber.close()
 
-    def test_on_stop_request_before_on_stop_then_stop_still_works(self) -> None:
-        """Idempotent: calling on_stop_request then on_stop still shuts the worker down."""
+    def test_on_stop_request_before_close_then_close_still_works(self) -> None:
+        """Idempotent: calling on_stop_request then close() still shuts the worker down."""
         subscriber = TelemetrySubscriber()
 
         subscriber.on_stop_request(_TEAM_ID)
-        subscriber.on_stop(_TEAM_ID)
+        subscriber.close()
 
+        assert not subscriber._worker.is_alive()
+
+
+class TestPerTeamRestoringSet:
+    """Story 27.1 AC #3, #4: ``_restoring`` is a per-team set with lock-guarded mutation."""
+
+    def test_set_restoring_adds_team_id_to_set(self) -> None:
+        """``set_restoring(team, True)`` adds; ``set_restoring(team, False)`` discards."""
+        subscriber = TelemetrySubscriber()
+        try:
+            team_a = uuid.uuid4()
+            subscriber.set_restoring(team_a, True)
+            assert team_a in subscriber._restoring
+
+            subscriber.set_restoring(team_a, False)
+            assert team_a not in subscriber._restoring
+        finally:
+            subscriber.close()
+
+    def test_set_restoring_discard_is_idempotent(self) -> None:
+        """``set_restoring(team, False)`` on an absent team is a no-op (set.discard semantics)."""
+        subscriber = TelemetrySubscriber()
+        try:
+            team_a = uuid.uuid4()
+            # Not previously added; must not raise.
+            subscriber.set_restoring(team_a, False)
+            assert team_a not in subscriber._restoring
+        finally:
+            subscriber.close()
+
+    def test_restoring_set_starts_empty(self) -> None:
+        """Fresh subscriber has an empty restoring set (not False/None)."""
+        subscriber = TelemetrySubscriber()
+        try:
+            assert isinstance(subscriber._restoring, set)
+            assert len(subscriber._restoring) == 0
+        finally:
+            subscriber.close()
+
+    def test_on_message_suppresses_only_restoring_team(self) -> None:
+        """team_a in restoring ⇒ team_a messages dropped, team_b messages still emitted."""
+        subscriber = TelemetrySubscriber()
+        try:
+            team_a = uuid.uuid4()
+            team_b = uuid.uuid4()
+            subscriber.set_restoring(team_a, True)
+
+            msg_a = MagicMock()
+            msg_a.__class__.__name__ = "StartMessage"
+            msg_a.sender.name = "orchestrator"
+            msg_a.team_id = team_a
+
+            msg_b = MagicMock()
+            msg_b.__class__.__name__ = "StartMessage"
+            msg_b.sender.name = "orchestrator"
+            msg_b.team_id = team_b
+
+            with patch(
+                "akgentic.infra.adapters.shared.telemetry_subscriber.logfire"
+            ) as mock_lf:
+                subscriber.on_message(msg_a)  # dropped
+                subscriber.on_message(msg_b)  # emitted
+                assert subscriber._flush(timeout=5.0)
+
+                # Only team_b's message reached logfire.
+                assert mock_lf.info.call_count == 1
+                _, kwargs = mock_lf.info.call_args
+                assert kwargs["team_id"] == team_b
+        finally:
+            subscriber.close()
+
+
+class TestOnStopDoesNotDrainWorker:
+    """Story 27.1 AC #5: ``on_stop(team_id)`` no longer drains the daemon worker thread."""
+
+    def test_on_stop_does_not_drain_worker(self) -> None:
+        """Two per-team ``on_stop`` calls leave the worker alive; only close() drains."""
+        subscriber = TelemetrySubscriber()
+        try:
+            team_a = uuid.uuid4()
+            team_b = uuid.uuid4()
+
+            subscriber.on_stop(team_a)
+            assert subscriber._worker.is_alive()
+
+            subscriber.on_stop(team_b)
+            assert subscriber._worker.is_alive()
+        finally:
+            subscriber.close()
+
+
+class TestCloseIdempotency:
+    """Story 27.1 AC #6: ``close()`` drains the worker once and is idempotent."""
+
+    def test_close_drains_worker(self) -> None:
+        """After ``close()``, the worker thread has exited."""
+        subscriber = TelemetrySubscriber()
+        subscriber.close()
+        assert not subscriber._worker.is_alive()
+
+    def test_close_is_idempotent(self) -> None:
+        """A second ``close()`` is a no-op and does not raise."""
+        subscriber = TelemetrySubscriber()
+        subscriber.close()
+        # Second call must not raise; worker stays not-alive.
+        subscriber.close()
         assert not subscriber._worker.is_alive()

--- a/tests/server/services/test_team_service.py
+++ b/tests/server/services/test_team_service.py
@@ -204,7 +204,16 @@ class TestStopTeam:
         assert events_after == []
 
     def test_stop_team_errors_are_non_fatal(self, team_service: TeamService) -> None:
-        """AC1: event_stream.remove() failure does not prevent stop."""
+        """AC1: event_stream.remove() failure does not prevent stop.
+
+        Story 27.1: ``EventStreamSubscriber.on_stop(team_id)`` also calls
+        ``event_stream.remove`` as the canonical per-team cleanup hook, and
+        ``TeamService.stop_team`` retains its own ``event_stream.remove`` call
+        as a belt-and-suspenders for the case where the worker has died
+        before ``on_stop`` could fire. Both call sites must swallow
+        ``event_stream.remove`` failures; the test now asserts the failing
+        ``remove`` was invoked at least once.
+        """
         process = team_service.create_team(catalog_namespace="test-team", user_id="anonymous")
         team_id = process.team_id
 
@@ -220,7 +229,7 @@ class TestStopTeam:
         team_service._services.event_stream.remove = failing_remove  # type: ignore[assignment]
         try:
             team_service.stop_team(team_id)  # Should not raise
-            assert call_count == 1
+            assert call_count >= 1
         finally:
             team_service._services.event_stream.remove = original_remove  # type: ignore[assignment]
 

--- a/tests/worker/test_app_lifespan_telemetry_close.py
+++ b/tests/worker/test_app_lifespan_telemetry_close.py
@@ -1,0 +1,97 @@
+"""Tests for the worker FastAPI lifespan calling TelemetrySubscriber.close().
+
+Story 27.1 AC #7: after ``WorkerLifecycle.shutdown()`` returns, the worker
+lifespan must call ``services.telemetry_subscriber.close()`` exactly once.
+When ``services.telemetry_subscriber is None`` the lifespan must not raise.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+from akgentic.core import ActorSystem
+from akgentic.team.manager import TeamManager
+from akgentic.team.ports import EventStore, NullServiceRegistry
+
+from akgentic.infra.adapters.shared.telemetry_subscriber import TelemetrySubscriber
+from akgentic.infra.protocols.runtime_cache import RuntimeCache
+from akgentic.infra.protocols.worker_handle import WorkerHandle
+from akgentic.infra.worker.app import _lifespan, create_worker_app
+from akgentic.infra.worker.deps import WorkerServices
+from akgentic.infra.worker.settings import WorkerSettings
+
+
+def _build_services(
+    telemetry_subscriber: TelemetrySubscriber | None,
+) -> WorkerServices:
+    """Build a WorkerServices with all-mocked deps and the given subscriber."""
+    return WorkerServices(
+        team_manager=MagicMock(spec=TeamManager),
+        actor_system=MagicMock(spec=ActorSystem),
+        event_store=MagicMock(spec=EventStore),
+        service_registry=NullServiceRegistry(),
+        runtime_cache=MagicMock(spec=RuntimeCache),
+        worker_handle=MagicMock(spec=WorkerHandle),
+        telemetry_subscriber=telemetry_subscriber,
+    )
+
+
+class TestLifespanTelemetryClose:
+    """Story 27.1 AC #7: worker lifespan invokes telemetry_subscriber.close() on shutdown."""
+
+    @pytest.mark.asyncio
+    async def test_lifespan_calls_close_exactly_once(self) -> None:
+        """Entering and exiting the lifespan calls close() exactly once."""
+        mock_subscriber = MagicMock(spec=TelemetrySubscriber)
+        services = _build_services(telemetry_subscriber=mock_subscriber)
+        settings = WorkerSettings(shutdown_drain_timeout=0, shutdown_pre_drain_delay=0)
+        app = create_worker_app(services, settings)
+
+        async with _lifespan(app):
+            mock_subscriber.close.assert_not_called()
+
+        mock_subscriber.close.assert_called_once_with()
+
+    @pytest.mark.asyncio
+    async def test_lifespan_handles_none_subscriber(self) -> None:
+        """If telemetry_subscriber is None, the lifespan exits cleanly without raising."""
+        services = _build_services(telemetry_subscriber=None)
+        settings = WorkerSettings(shutdown_drain_timeout=0, shutdown_pre_drain_delay=0)
+        app = create_worker_app(services, settings)
+
+        # Lifespan must not raise on shutdown when no subscriber is wired.
+        async with _lifespan(app):
+            pass
+
+    @pytest.mark.asyncio
+    async def test_close_called_after_lifecycle_shutdown(self) -> None:
+        """close() runs AFTER WorkerLifecycle.shutdown() returns.
+
+        Order matters: per-team ``on_stop`` notifications (driven by
+        ``WorkerLifecycle.shutdown()``) might still emit telemetry spans;
+        draining the daemon before they finish would lose them.
+        """
+        mock_subscriber = MagicMock(spec=TelemetrySubscriber)
+        services = _build_services(telemetry_subscriber=mock_subscriber)
+        settings = WorkerSettings(shutdown_drain_timeout=0, shutdown_pre_drain_delay=0)
+        app = create_worker_app(services, settings)
+
+        call_order: list[str] = []
+        app.state.lifecycle.shutdown = MagicMock(  # type: ignore[method-assign]
+            side_effect=lambda drain_timeout: call_order.append("lifecycle.shutdown"),
+        )
+        mock_subscriber.close.side_effect = lambda: call_order.append("subscriber.close")
+
+        # The MagicMock above replaces an async method with a sync one. Wrap to async.
+        original_shutdown = app.state.lifecycle.shutdown
+
+        async def _shutdown(drain_timeout: int) -> None:
+            original_shutdown(drain_timeout)
+
+        app.state.lifecycle.shutdown = _shutdown  # type: ignore[method-assign]
+
+        async with _lifespan(app):
+            pass
+
+        assert call_order == ["lifecycle.shutdown", "subscriber.close"]

--- a/tests/worker/test_worker_deps.py
+++ b/tests/worker/test_worker_deps.py
@@ -8,6 +8,7 @@ from akgentic.core import ActorSystem
 from akgentic.team.manager import TeamManager
 from akgentic.team.ports import EventStore, NullServiceRegistry, ServiceRegistry
 
+from akgentic.infra.adapters.shared.telemetry_subscriber import TelemetrySubscriber
 from akgentic.infra.protocols.runtime_cache import RuntimeCache
 from akgentic.infra.protocols.worker_handle import WorkerHandle
 from akgentic.infra.worker.deps import WorkerServices
@@ -41,6 +42,35 @@ class TestWorkerServicesConstruction:
         assert services.runtime_cache is runtime_cache
         assert services.worker_handle is worker_handle
 
+    def test_telemetry_subscriber_field_defaults_to_none(self) -> None:
+        """Story 27.1 AC #7: ``telemetry_subscriber`` is optional, defaults to None."""
+        services = WorkerServices(
+            team_manager=MagicMock(spec=TeamManager),
+            actor_system=MagicMock(spec=ActorSystem),
+            event_store=MagicMock(spec=EventStore),
+            service_registry=NullServiceRegistry(),
+            runtime_cache=MagicMock(spec=RuntimeCache),
+            worker_handle=MagicMock(spec=WorkerHandle),
+        )
+        assert services.telemetry_subscriber is None
+
+    def test_telemetry_subscriber_field_accepts_subscriber(self) -> None:
+        """Story 27.1 AC #7: ``telemetry_subscriber`` accepts a TelemetrySubscriber."""
+        subscriber = TelemetrySubscriber()
+        try:
+            services = WorkerServices(
+                team_manager=MagicMock(spec=TeamManager),
+                actor_system=MagicMock(spec=ActorSystem),
+                event_store=MagicMock(spec=EventStore),
+                service_registry=NullServiceRegistry(),
+                runtime_cache=MagicMock(spec=RuntimeCache),
+                worker_handle=MagicMock(spec=WorkerHandle),
+                telemetry_subscriber=subscriber,
+            )
+            assert services.telemetry_subscriber is subscriber
+        finally:
+            subscriber.close()
+
 
 class TestWorkerServicesModel:
     """WorkerServices model structure and metadata (AC #1)."""
@@ -53,6 +83,7 @@ class TestWorkerServicesModel:
             "service_registry",
             "runtime_cache",
             "worker_handle",
+            "telemetry_subscriber",
         }
         assert set(WorkerServices.model_fields.keys()) == expected_fields
 


### PR DESCRIPTION
Wires `EventSubscriber` `team_id`-aware lifecycle into `akgentic-infra` shared subscribers and the worker FastAPI lifespan.

## Stories

- [x] 27-1-eventsubscriber-team-id-lifecycle-wiring — (Relates to #285)

## Background — story consolidation

Story 27.1 was consolidated from former stories 27.1 / 27.2 / 27.3 into a single coordinated story. The three originals all touched the same three source files and the same four test files, so splitting them forced churn across stacked PRs with no review-quality gain.

The **signature-widening half** (former 27.1 scope) already landed on commit `46b2217` before this review. This PR completes Epic 27 with the **behavioural half** (former 27.2 + 27.3 scope) across 5 additional commits in range `46b2217..HEAD`:

- `8b89c7c` feat: telemetry subscriber per-team restoring set and `close()`
- `d768605` feat: wire `TelemetrySubscriber.close()` into worker lifespan
- `dd572d4` feat: `EventStreamSubscriber` per-team cleanup body revival
- `2d0b8f2` style: apply ruff format to story 27.1 test additions
- `1f55351` test: update `test_stop_team_errors_are_non_fatal` for belt-and-suspenders

## Highlights

- **`TelemetrySubscriber._restoring`** is now `set[uuid.UUID]` guarded by a `threading.Lock`; cross-team replay-suppression interference is gone — team A restoring no longer drops team B telemetry.
- **`TelemetrySubscriber.on_stop(team_id)`** is now a debug log; daemon drain extracted into idempotent **`close()`** method called from the worker FastAPI `_lifespan` shutdown branch (after `WorkerLifecycle.shutdown()` returns).
- **`EventStreamSubscriber._seen_teams` tracking deleted entirely.** `on_message` appends every event directly; `on_stop(team_id)` is now the canonical community-tier per-team cleanup hook (mirrors `RedisStreamSubscriber.on_stop` / `DaprStreamSubscriber.on_stop`), swallowing `event_stream.remove` failures at DEBUG.
- **`WorkerServices.telemetry_subscriber: TelemetrySubscriber | None`** is the optional wiring point; community wiring discards the reference (no FastAPI worker in-process), department/enterprise wirings can plumb it in once their own ADRs land. `arbitrary_types_allowed=True` is the established documented exemption for this DI container.
- **`TeamService.stop_team` still calls `event_stream.remove(team_id)`** as a belt-and-suspenders for the case where the worker has died before `on_stop` could fire (ADR-025 §2). Source unchanged.

## Review status

**Verdict: APPROVED.** All 15 acceptance criteria satisfied. Zero CRITICAL/HIGH/MEDIUM findings on the 5-commit behavioural slice. No fixup commit needed.

| AC | Status |
|---|---|
| #1 Lifecycle signatures match Protocol (3 subscribers) | landed in 46b2217 (out of review range) — verified intact |
| #2 Subscribers satisfy `EventSubscriber` Protocol | ✓ tests present per subscriber |
| #3 `_restoring: set[uuid.UUID]` + lock | ✓ `telemetry_subscriber.py:65-66` |
| #4 Cross-team interference test passes | ✓ `test_on_message_suppresses_only_restoring_team` |
| #5 `on_stop` no longer drains worker | ✓ debug log only |
| #6 `close()` drains worker idempotently | ✓ `is_alive()` guard |
| #7 Worker lifespan calls `close()` once | ✓ `test_lifespan_calls_close_exactly_once` |
| #8 No `_seen_teams` attribute | ✓ `test_no_seen_teams_attribute` |
| #9 `on_message` appends every event | ✓ tested with duplicates |
| #10 `on_stop` removes exactly one team | ✓ tested with two pre-populated teams |
| #11 `set_restoring` is documented no-op | ✓ `test_set_restoring_is_noop` |
| #12 `TeamService.stop_team` preserved | ✓ source untouched |
| #13 Scope discipline | ✓ all paths under `packages/akgentic-infra/` |
| #14 mypy --strict clean | ✓ 110 source files, no issues |
| #15 Tests green, coverage ≥ 90% | ✓ 1427 passed, coverage 90.71% |

## Scope guard note

Every changed path in `46b2217..HEAD` lives under `packages/akgentic-infra/` — no cross-submodule edits (Golden Rule #4). Verified by `git diff --name-only`.

## Epic 27 slice complete

This is the only story in Epic 27 (single-story epic after consolidation). Merging this PR closes Epic 27. The Protocol shape lives in `akgentic-core` (ADR-011, already merged); the `akgentic-team` migration landed via ADR-18 (already merged); department-tier (`RedisStreamSubscriber`) and enterprise-tier (`DaprStreamSubscriber`) parallel work tracks under `akgentic-infra-department` ADR-002 and `akgentic-infra-enterprise` ADR-030 respectively, in their own submodule epics.

Relates to #285
