### PR TITLE
feat(akgentic-infra): epic 29 — Offload Blocking Calls in upload_workspace_file Off the Event Loop (29-1 → 29-2)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "akgentic-infra"
-version = "1.3.0"
+version = "1.3.1"
 description = "Infrastructure backend: protocol abstractions and community-tier implementations for akgentic"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/akgentic/infra/server/routes/workspace.py
+++ b/src/akgentic/infra/server/routes/workspace.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import uuid
 from pathlib import PurePosixPath
@@ -95,7 +96,7 @@ async def upload_workspace_file(
     file: Annotated[UploadFile, File()],
 ) -> WorkspaceFileUploadResponse:
     """Upload a file to a team's workspace."""
-    _validate_team(team_id, request)
+    await asyncio.to_thread(_validate_team, team_id, request)
     settings = cast(CommunitySettings, request.app.state.settings)
     ws = _get_workspace(team_id, settings)
     data = await file.read()
@@ -103,7 +104,7 @@ async def upload_workspace_file(
         raise HTTPException(status_code=413, detail="File exceeds 10 MB size limit")
     logger.info("POST /workspace/%s/file path=%s, size=%d", team_id, path, len(data))
     try:
-        ws.write(path, data)
+        await asyncio.to_thread(ws.write, path, data)
     except PermissionError:
         raise HTTPException(status_code=403, detail="Path access denied") from None
     return WorkspaceFileUploadResponse(path=path, size=len(data))

--- a/tests/server/routes/test_workspace_does_not_block_event_loop.py
+++ b/tests/server/routes/test_workspace_does_not_block_event_loop.py
@@ -1,0 +1,148 @@
+"""Regression test: ``upload_workspace_file`` must not stall the event loop.
+
+The ``POST /workspace/{team_id}/file`` route invokes the synchronous
+``_validate_team`` and ``Filesystem.write`` calls via ``asyncio.to_thread``
+(per ADR-026 / Story 29.1). This module pins that offload behaviour in
+place with an executable regression guard: while the upload coroutine is
+suspended on a deliberately slow stub of one of those two sync calls, a
+concurrent ``GET /readiness`` request MUST return in under 100 ms,
+demonstrating the FastAPI event loop is not blocked.
+
+The two cases (slow ``_validate_team`` and slow ``Filesystem.write``)
+provide symmetric coverage of both ``to_thread`` call sites. If a future
+refactor reverts either wrapping back to a direct sync call, the
+corresponding case in this test fails with a ``< 0.1s`` latency
+assertion well outside any reasonable CI-scheduler / container-startup
+timing jitter (the slow stub sleeps for 2 s — a 20x margin from the
+100 ms ceiling).
+
+See also the sibling pattern in ``akgentic-infra-department`` Epic 13 /
+Story 13.2 (same bug class, different submodule).
+"""
+
+from __future__ import annotations
+
+import concurrent.futures
+import time
+import uuid
+from collections.abc import Callable
+
+import pytest
+from akgentic.tool.workspace import Filesystem
+from fastapi.testclient import TestClient
+
+import akgentic.infra.server.routes.workspace as workspace_module
+from akgentic.infra.server.settings import ServerSettings
+
+
+@pytest.fixture()
+def team_for_upload(client: TestClient, seeded_settings: ServerSettings) -> uuid.UUID:
+    """Create a team via REST and ensure its workspace directory exists.
+
+    Mirrors the local fixture in ``test_workspace_routes.py``; duplicated
+    here so this module is self-contained and does not depend on import
+    order.
+    """
+    resp = client.post("/teams/", json={"catalog_namespace": "test-team"})
+    assert resp.status_code == 201
+    team_id = uuid.UUID(resp.json()["team_id"])
+    ws_root = seeded_settings.workspaces_root / str(team_id)
+    ws_root.mkdir(parents=True, exist_ok=True)
+    return team_id
+
+
+def _patch_slow_validate_team(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Patch the module-level ``_validate_team`` to sleep for 2 s.
+
+    ``asyncio.to_thread(_validate_team, ...)`` reads the module-level
+    name at call time, so patching the attribute on the module object
+    intercepts every dispatch for the test's lifetime.
+    """
+
+    def slow_validate(team_id: uuid.UUID, request: object) -> None:
+        time.sleep(2.0)
+
+    monkeypatch.setattr(workspace_module, "_validate_team", slow_validate)
+
+
+def _patch_slow_filesystem_write(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Patch ``Filesystem.write`` to sleep for 2 s (and skip the real write).
+
+    ``ws.write(path, data)`` dispatches through the class attribute, so a
+    class-level ``setattr`` intercepts every existing and future
+    ``Filesystem`` instance. The handler returns 201 because no
+    exception was raised; the file is not actually written to disk
+    (the assertion only requires the response shape, AC #7).
+    """
+
+    def slow_write(self: Filesystem, path: str, data: bytes) -> None:
+        time.sleep(2.0)
+
+    monkeypatch.setattr(Filesystem, "write", slow_write)
+
+
+@pytest.mark.parametrize(
+    ("case_name", "patch_fn"),
+    [
+        ("slow _validate_team", _patch_slow_validate_team),
+        ("slow Filesystem.write", _patch_slow_filesystem_write),
+    ],
+)
+def test_upload_does_not_block_event_loop(
+    client: TestClient,
+    team_for_upload: uuid.UUID,
+    monkeypatch: pytest.MonkeyPatch,
+    case_name: str,
+    patch_fn: Callable[[pytest.MonkeyPatch], None],
+) -> None:
+    """A concurrent ``/readiness`` probe must return in <100 ms while a
+    slow ``upload_workspace_file`` request is in flight.
+
+    The two parametrised cases stub each of the two ``asyncio.to_thread``
+    call sites independently. Both must satisfy the latency ceiling — if
+    either ``to_thread`` wrapping is ever reverted, the corresponding
+    case fails with the AC #4 message identifying which call site
+    regressed.
+    """
+    patch_fn(monkeypatch)
+
+    payload = b"slow data"
+    team_id = team_for_upload
+
+    def fire_slow_upload() -> object:
+        return client.post(
+            f"/workspace/{team_id}/file",
+            data={"path": "slow.txt"},
+            files={"file": ("slow.txt", payload, "text/plain")},
+        )
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=2) as executor:
+        slow_future = executor.submit(fire_slow_upload)
+
+        # Settle so the slow request reaches its asyncio.to_thread
+        # dispatch and the upload coroutine is parked on a worker
+        # thread. Fixed 50 ms; do NOT poll (per AC #6).
+        time.sleep(0.05)
+
+        # Probe runs on the main test thread, racing the in-flight
+        # upload. Sample latency around the single sync call.
+        start = time.perf_counter()
+        probe_resp = client.get("/readiness")
+        elapsed_s = time.perf_counter() - start
+
+        assert probe_resp.status_code == 200
+        assert elapsed_s < 0.1, (
+            f"GET /readiness took {elapsed_s:.3f}s while {case_name} was in flight; "
+            "expected < 0.1s (loop is stalled by sync work inside the upload handler)"
+        )
+
+        slow_resp = slow_future.result(timeout=10.0)
+
+    # Slow upload still completes normally — the offload allowed the
+    # request to finish, not just unblocked the loop.
+    assert slow_resp.status_code == 201, (  # type: ignore[attr-defined]
+        f"slow upload returned {slow_resp.status_code} for case {case_name!r}"  # type: ignore[attr-defined]
+    )
+    body = slow_resp.json()  # type: ignore[attr-defined]
+    assert body["path"] == "slow.txt"
+    assert body["size"] == len(payload)


### PR DESCRIPTION
## Epic 29 — Offload Blocking Calls in `upload_workspace_file` Off the Event Loop

Umbrella PR for Epic 29 (`Relates to #290`), implementing ADR-026 (`_bmad-output/akgentic-infra/decisions/adr-026-offload-blocking-workspace-upload-from-event-loop.md`).

`upload_workspace_file` is the only remaining `async def` handler in `akgentic-infra/server/routes/` that called into the synchronous service / filesystem layer without offloading. While stalled inside `_validate_team` or `Filesystem.write`, the FastAPI event loop's thread cannot service any other request, WebSocket frame, or background task. This epic offloads both blocking calls onto Starlette's threadpool via `asyncio.to_thread`, then locks the behavior in with a regression test.

## Stories

- [x] **29-1-wrap-validate-team-and-filesystem-write-with-to-thread** — wrap `_validate_team` and `Filesystem.write` with `asyncio.to_thread` in `upload_workspace_file` (Relates to #290)
- [x] **29-2-event-loop-responsiveness-regression-test** — regression integration test (Relates to #292)

## Review status

**Story 29.1 — APPROVED for merge.**

- Diff is exactly 3 lines + 1 import (`import asyncio`); wraps the two blocking calls verbatim per AC #1 and AC #2.
- The `try` / `except PermissionError` block is preserved around `await asyncio.to_thread(ws.write, path, data)` — 403 mapping intact.
- Handler signature unchanged (AC #3); sibling `def` routes `list_workspace_tree` and `read_workspace_file` untouched (AC #4); `_validate_team` and `Filesystem.write` remain sync (AC #5); no `async_call` helper introduced (AC #6).
- All 4 existing upload tests (`test_workspace_file_upload`, `test_workspace_file_upload_team_not_found`, `test_workspace_file_upload_size_limit`, `test_workspace_file_upload_traversal_attack`) pass with assertion shape unchanged (AC #7).
- `ruff check`, `ruff format --check`, and `mypy --strict` all green on `packages/akgentic-infra/src/akgentic/infra/server/routes/workspace.py`.

Rex's verdict: no fix-worthy issues — Amelia's commit is minimal, focused, and fully spec-compliant. No fixup commit produced.

- 29-2 review: PASS — single parametrised test covers both `to_thread` call sites with self-describing failure messages, fixed 50 ms settle (no polling), `ThreadPoolExecutor(max_workers=2)` via sync `TestClient`, 20× margin from the 100 ms ceiling. `monkeypatch` patches the module-level `_validate_team` symbol and the `Filesystem.write` class attribute — both resolved at call-time by `asyncio.to_thread`, so a reverted offload triggers the latency assertion. Scope is test-only (`tests/server/routes/test_workspace_does_not_block_event_loop.py`, +148 lines); no `src/` edits, no sibling-submodule edits, no new `dict[str, Any]`, no `httpx.AsyncClient`, no `@pytest.mark.asyncio`. Inline ADR-026 / Story 29.1 references in the module docstring are navigation aids only (no assertions branch on them). Targeted local run: 12 passed in 9.74 s. No fixup commit produced.

## Epic 29 slice complete

Both stories landed on `feat/290-epic-29-offload-blocking-workspace-upload-from-event-loop`:

- **29.1 (production fix)** — `upload_workspace_file` now `await asyncio.to_thread(_validate_team, ...)` and `await asyncio.to_thread(ws.write, ...)`. Handler signature unchanged; sibling `def` routes untouched; `_validate_team` and `Filesystem.write` remain sync. The four existing upload tests continue to pass unmodified.
- **29.2 (regression guard)** — parametrised in-process test in `tests/server/routes/test_workspace_does_not_block_event_loop.py` proves a concurrent `GET /readiness` returns in `< 0.1 s` while a 2 s slow stub on either `to_thread` call site is in flight. If a future refactor drops either `asyncio.to_thread(...)` wrapping, the corresponding case fails with a `case_name`-tagged latency assertion (20× margin from the 100 ms ceiling).

ADR-026 §Validation is now executable: the loop stays responsive under a slow `_validate_team` or `Filesystem.write`, and the assertion is anchored to the discriminating `async def` `/readiness` probe so a stalled loop cannot hide behind Starlette's threadpool auto-dispatch.

## Scope guard

All changes in this epic stay inside `packages/akgentic-infra/` per Golden Rule #4. No edits to sibling submodules (`akgentic-core`, `akgentic-llm`, `akgentic-tool`, `akgentic-agent`, `akgentic-team`, `akgentic-catalog`, `akgentic-infra-department`, `akgentic-infra-enterprise`).
