### PR TITLE
feat(akgentic-infra): epic 30 — human-input Resolves by Inner Message Id (30-1-resolve-human-input-by-inner-message-id -> 30-2-audit-human-input-callers-cli-tui-and-angular-v1)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "akgentic-infra"
-version = "1.3.1"
+version = "1.3.2"
 description = "Infrastructure backend: protocol abstractions and community-tier implementations for akgentic"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/akgentic/infra/cli/event_router.py
+++ b/src/akgentic/infra/cli/event_router.py
@@ -103,14 +103,37 @@ class EventRouter:
             tool_output = str(raw_output)
         self._renderer.render_tool_call(tool_name, tool_input, tool_output)
 
-    def _notify_human_input(self, event: Message) -> None:
-        """Extract message_id and agent_name from the event and invoke callback."""
-        raw_id = str(event.id)
+    def _notify_human_input(self, event: EventMessage) -> None:
+        """Invoke the human-input callback with the **inner** message id.
+
+        The human-input prompt arrives as an ``EventMessage`` whose ``.event``
+        is the request the user must answer. The reply is resolved server-side
+        by the **inner** ``SentMessage.message.id`` (Story 30-1), NOT by the
+        outer ``EventMessage`` envelope id — forwarding ``str(event.id)`` here
+        would 404 against the flipped ``_find_message``. So the inner id is
+        extracted from the nested request event; the envelope id is only a
+        last-resort fallback when the nested event exposes no id.
+        """
+        raw_id = self._inner_human_input_id(event)
         if not raw_id:
             return
         sender_name = event.sender.name if event.sender else "Agent"
         if self._on_human_input is not None:
             self._on_human_input(raw_id, sender_name)
+
+    @staticmethod
+    def _inner_human_input_id(event: EventMessage) -> str:
+        """Resolve the inner ``Message.id`` of a human-input ``EventMessage``.
+
+        Prefers the id of the nested request the user is answering — that is the
+        inner ``Message.id`` the server resolves the reply by. Falls back to the
+        outer ``EventMessage`` envelope id only when the nested request exposes
+        no ``id`` (a duck-typed stand-in without one).
+        """
+        nested_id = getattr(event.event, "id", None)
+        if nested_id is not None:
+            return str(nested_id)
+        return str(event.id)
 
     def to_widget(
         self,

--- a/src/akgentic/infra/server/models.py
+++ b/src/akgentic/infra/server/models.py
@@ -47,7 +47,13 @@ class HumanInputRequest(BaseModel):
     """Request body for POST /teams/{team_id}/human-input."""
 
     content: str = Field(description="Human response content")
-    message_id: str = Field(description="ID of the original message being answered")
+    message_id: str = Field(
+        description=(
+            "Inner Message.id (SentMessage.message.id) of the original message "
+            "being answered — the id a reply's parent_id references, not the "
+            "outer SentMessage envelope id."
+        )
+    )
 
 
 class EventResponse(BaseModel):

--- a/src/akgentic/infra/server/routes/frontend_adapter/angular_v1/router.py
+++ b/src/akgentic/infra/server/routes/frontend_adapter/angular_v1/router.py
@@ -14,6 +14,7 @@ from pydantic import BaseModel, Field
 
 from akgentic.catalog.models.entry import EntryKind
 from akgentic.core.messages.orchestrator import (
+    SentMessage,
     StateChangedMessage,
 )
 from akgentic.infra.server.routes.frontend_adapter.angular_v1._helpers import (
@@ -246,12 +247,39 @@ def process_human_input(
     team_id = _parse_uuid(id)
     if "id" not in body.message:
         raise HTTPException(status_code=422, detail="message must contain 'id' field")
-    message_id = str(body.message["id"])
+    posted_id = str(body.message["id"])
     try:
+        # The v1 message history (``_events_to_v1_messages``) exposes the
+        # **outer** ``SentMessage.id`` (the event-envelope id), so the modal
+        # posts that id back here. Since Story 30-1 the gateway resolves human
+        # input by the **inner** ``SentMessage.message.id``, so translate the
+        # outer id to the inner id server-side before delegating. An id that is
+        # already the inner id (or genuinely unknown) is passed through
+        # unchanged and resolved/rejected by ``TeamService._find_message``.
+        message_id = _resolve_inner_message_id(service, team_id, posted_id)
         service.process_human_input(team_id, body.content, message_id)
     except ValueError as exc:
         _raise_action_error(exc)
     return V1StatusResponse(status="ok")
+
+
+def _resolve_inner_message_id(
+    service: TeamService, team_id: uuid.UUID, posted_id: str
+) -> str:
+    """Translate a posted v1 message id to the inner ``SentMessage.message.id``.
+
+    The v1 frontend holds the **outer** envelope id (``V1MessageEntry.id`` is
+    built from ``str(ev.event.id)``). The gateway's ``_find_message`` resolves
+    human input by the **inner** ``SentMessage.message.id`` (Story 30-1), so a
+    posted outer id is mapped to its inner id here. If ``posted_id`` matches no
+    ``SentMessage`` outer id (already inner, or unknown), it is returned
+    unchanged so the downstream lookup resolves or 404s as before.
+    """
+    events = service.get_events(team_id)
+    for ev in events:
+        if isinstance(ev.event, SentMessage) and str(ev.event.id) == posted_id:
+            return str(ev.event.message.id)
+    return posted_id
 
 
 # --- Messages route ---

--- a/src/akgentic/infra/server/services/team_service.py
+++ b/src/akgentic/infra/server/services/team_service.py
@@ -8,7 +8,6 @@ import uuid
 from pathlib import Path
 
 from akgentic.catalog.models.errors import CatalogValidationError, EntryNotFoundError
-from akgentic.core.messages.message import Message
 from akgentic.core.messages.orchestrator import SentMessage
 from akgentic.infra.protocols.event_stream import EventStream
 from akgentic.infra.protocols.runtime_cache import RuntimeCache
@@ -220,12 +219,10 @@ class TeamService:
             ValueError: If team not found, not running, or message not found.
         """
         handle = self._get_running_handle(team_id)
+        # _find_message resolves by inner id and returns only SentMessage, so
+        # event.message is the inner Message to route (ADR-027 §Decision 1).
         event = self._find_message(team_id, message_id)
-        if not isinstance(event, SentMessage):
-            msg = f"Message {message_id} is a {type(event).__name__}, expected SentMessage"
-            raise ValueError(msg)
-        inner = event.message
-        handle.process_human_input(content, inner)
+        handle.process_human_input(content, event.message)
         logger.debug("Human input routed to team %s, message_id=%s", team_id, message_id)
 
     def stop_team(self, team_id: uuid.UUID) -> None:
@@ -325,15 +322,21 @@ class TeamService:
             raise ValueError(msg)
         return handle
 
-    def _find_message(self, team_id: uuid.UUID, message_id: str) -> Message:
-        """Find a message by ID in persisted events.
+    def _find_message(self, team_id: uuid.UUID, message_id: str) -> SentMessage:
+        """Find a SentMessage by its inner ``message.id`` in persisted events.
+
+        Mirrors the worker route's ``_find_message``: resolution is by the
+        **inner** ``SentMessage.message.id`` — the id every distributed tier
+        puts on the wire — not the outer envelope ``SentMessage.id``
+        (ADR-027 §Decision 1).
 
         Raises:
-            ValueError: If message not found.
+            ValueError: If no matching SentMessage is found. The ``not found``
+                substring is load-bearing for the 404 mapping.
         """
         events = self._services.event_store.load_events(team_id)
         for ev in events:
-            if str(ev.event.id) == message_id:
+            if isinstance(ev.event, SentMessage) and str(ev.event.message.id) == message_id:
                 return ev.event
         msg = f"Message {message_id} not found"
         raise ValueError(msg)

--- a/src/akgentic/infra/worker/routes/teams.py
+++ b/src/akgentic/infra/worker/routes/teams.py
@@ -12,7 +12,6 @@ from typing import NoReturn, cast
 from fastapi import APIRouter, Depends, HTTPException, Request
 from pydantic import BaseModel, Field
 
-from akgentic.core.messages.message import Message
 from akgentic.core.messages.orchestrator import SentMessage
 from akgentic.infra.server.models import HumanInputRequest, SendMessageRequest, TeamResponse
 from akgentic.infra.worker.deps import WorkerServices
@@ -161,15 +160,22 @@ def send_message_from_to(
 
 def _find_message(
     event_store: EventStore, team_id: uuid.UUID, message_id: str
-) -> Message:
-    """Find a message by ID in persisted events.
+) -> SentMessage:
+    """Find a SentMessage by its inner ``message.id`` in persisted events.
+
+    Resolution is by the **inner** ``SentMessage.message.id`` — the id a
+    reply's ``parent_id`` references and the id every distributed tier
+    (``HttpTeamHandle``, ``RemoteTeamHandle``) puts on the wire — not the
+    outer event-envelope ``SentMessage.id`` (ADR-027 §Decision 1).
 
     Raises:
-        ValueError: If message not found.
+        ValueError: If no matching SentMessage is found. The ``not found``
+            substring is load-bearing: ``_raise_action_error`` maps it to
+            HTTP 404.
     """
     events = event_store.load_events(team_id)
     for ev in events:
-        if str(ev.event.id) == message_id:
+        if isinstance(ev.event, SentMessage) and str(ev.event.message.id) == message_id:
             return ev.event
     msg = f"Message {message_id} not found"
     raise ValueError(msg)
@@ -187,12 +193,10 @@ def human_input(
     if handle is None:
         raise HTTPException(status_code=404, detail="Team not found in worker cache")
     try:
+        # _find_message resolves by inner id and returns only SentMessage, so
+        # event.message is the inner Message to route (ADR-027 §Decision 1).
         event = _find_message(services.event_store, team_id, body.message_id)
-        if not isinstance(event, SentMessage):
-            msg = f"Message {body.message_id} is a {type(event).__name__}, expected SentMessage"
-            raise ValueError(msg)
-        inner = event.message
-        handle.process_human_input(body.content, inner)
+        handle.process_human_input(body.content, event.message)
     except ValueError as exc:
         _raise_action_error(exc)
 

--- a/tests/cli/test_cli_event_router.py
+++ b/tests/cli/test_cli_event_router.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import uuid
 from dataclasses import dataclass
 from typing import Any
 from unittest.mock import MagicMock
@@ -181,6 +182,70 @@ class TestNotifyHumanInput:
         callback.assert_called_once()
         args = callback.call_args[0]
         assert args[1] == "BotX"
+
+    def test_forwards_inner_message_id_for_message_nested_event(self) -> None:
+        """Story 30-2: the inner request's ``message.id`` is forwarded, not the envelope id.
+
+        The reply is resolved server-side by the inner ``SentMessage.message.id``
+        (Story 30-1), so the CLI must forward the id of the request the user is
+        answering — never the outer ``EventMessage`` envelope id — or the reply
+        404s against ``_find_message``. The human-input prompt nests the inner
+        ``Message`` (it carries ``.content`` and its own ``.id``).
+        """
+        renderer, buf = _captured_renderer()
+        captured: list[str] = []
+        router = EventRouter(
+            renderer, on_human_input=lambda mid, _name: captured.append(mid)
+        )
+
+        inner = build_sent_message(content="please confirm").message
+        event = build_event_message(event=inner)
+        # The EventMessage envelope id must differ from the inner id we expect.
+        assert str(event.id) != str(inner.id)
+
+        router.route(event)
+
+        assert captured == [str(inner.id)]
+
+    def test_forwards_nested_event_id_when_present(self) -> None:
+        """A nested request carrying its own ``id`` forwards that id, not the envelope id."""
+        renderer, buf = _captured_renderer()
+        captured: list[str] = []
+        router = EventRouter(
+            renderer, on_human_input=lambda mid, _name: captured.append(mid)
+        )
+
+        nested_id = uuid.uuid4()
+
+        @dataclass
+        class FakeHumanInput:
+            prompt: str
+            id: uuid.UUID
+
+        event = build_event_message(event=FakeHumanInput(prompt="q?", id=nested_id))
+        assert str(event.id) != str(nested_id)
+
+        router.route(event)
+
+        assert captured == [str(nested_id)]
+
+    def test_falls_back_to_envelope_id_when_no_nested_id(self) -> None:
+        """When the nested request exposes no id, the envelope id is the fallback."""
+        renderer, buf = _captured_renderer()
+        captured: list[str] = []
+        router = EventRouter(
+            renderer, on_human_input=lambda mid, _name: captured.append(mid)
+        )
+
+        @dataclass
+        class FakeHumanInput:
+            prompt: str
+
+        event = build_event_message(event=FakeHumanInput(prompt="q?"))
+
+        router.route(event)
+
+        assert captured == [str(event.id)]
 
 
 class TestToolCallArgFormats:

--- a/tests/frontend_adapter/test_v1_human_input_inner_id.py
+++ b/tests/frontend_adapter/test_v1_human_input_inner_id.py
@@ -1,0 +1,154 @@
+"""Guarding tests for the angular_v1 ``process_human_input`` inner-id alignment.
+
+Story 30-2: the v1 message history (``_events_to_v1_messages``) exposes the
+**outer** ``SentMessage.id`` (the event-envelope id), so the v1 modal posts that
+id back to ``POST /process_human_input/{id}/human/{proxy}``. Since Story 30-1 the
+gateway resolves human input by the **inner** ``SentMessage.message.id``, so the
+route translates the posted outer id to the inner id server-side before calling
+``TeamService.process_human_input``. These tests lock that behavior in: an outer
+id resolves (routes the inner Message to the cached handle / 200), an unknown id
+404s, and an id that is already the inner id still resolves (pass-through).
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+
+import pytest
+from akgentic.core.messages.orchestrator import SentMessage
+from akgentic.team.models import PersistedEvent
+from fastapi import HTTPException
+
+from akgentic.infra.server.routes.frontend_adapter.angular_v1.router import (
+    V1HumanInputBody,
+    _resolve_inner_message_id,
+    process_human_input,
+)
+from akgentic.infra.server.services.team_service import TeamService
+from tests.fixtures.events import build_sent_message
+
+
+def _seed_sent_message(team_service: TeamService, team_id: uuid.UUID) -> SentMessage:
+    """Persist a SentMessage (inner id != outer id) into a team's event store."""
+    sent = build_sent_message(content="please confirm")
+    # The translation under test is only meaningful when inner != outer.
+    assert sent.id != sent.message.id
+    team_service._services.event_store.save_event(
+        PersistedEvent(
+            team_id=team_id,
+            sequence=1,
+            event=sent,
+            timestamp=datetime.now(UTC),
+        )
+    )
+    return sent
+
+
+def test_resolve_inner_message_id_maps_outer_to_inner(team_service: TeamService) -> None:
+    """A posted outer envelope id is translated to the inner message id."""
+    process = team_service.create_team("test-team", user_id="anonymous")
+    sent = _seed_sent_message(team_service, process.team_id)
+
+    resolved = _resolve_inner_message_id(team_service, process.team_id, str(sent.id))
+
+    assert resolved == str(sent.message.id)
+
+
+def test_resolve_inner_message_id_passes_through_inner(team_service: TeamService) -> None:
+    """An id that is already the inner id is returned unchanged (pass-through)."""
+    process = team_service.create_team("test-team", user_id="anonymous")
+    sent = _seed_sent_message(team_service, process.team_id)
+
+    resolved = _resolve_inner_message_id(
+        team_service, process.team_id, str(sent.message.id)
+    )
+
+    assert resolved == str(sent.message.id)
+
+
+def test_resolve_inner_message_id_passes_through_unknown(team_service: TeamService) -> None:
+    """An unknown id is returned unchanged so the downstream lookup 404s."""
+    process = team_service.create_team("test-team", user_id="anonymous")
+    _seed_sent_message(team_service, process.team_id)
+
+    resolved = _resolve_inner_message_id(team_service, process.team_id, "nonexistent")
+
+    assert resolved == "nonexistent"
+
+
+def test_process_human_input_outer_id_routes_inner(team_service: TeamService) -> None:
+    """POSTing the outer envelope id routes the inner Message to the handle (200)."""
+    process = team_service.create_team("test-team", user_id="anonymous")
+    sent = _seed_sent_message(team_service, process.team_id)
+
+    routed: list[tuple[str, object]] = []
+    handle = team_service.get_handle(process.team_id)
+    assert handle is not None
+    handle.process_human_input = (  # type: ignore[method-assign]
+        lambda content, message: routed.append((content, message))
+    )
+
+    body = V1HumanInputBody(
+        content="yes",
+        message={"id": str(sent.id), "content": "original"},
+    )
+    resp = process_human_input(
+        id=str(process.team_id), proxy="@Human", body=body, service=team_service
+    )
+
+    assert resp.status == "ok"
+    # The inner Message — not the outer SentMessage — reaches the handle.
+    assert routed == [("yes", sent.message)]
+
+
+def test_process_human_input_inner_id_routes_inner(team_service: TeamService) -> None:
+    """POSTing the inner id directly also resolves and routes the inner Message."""
+    process = team_service.create_team("test-team", user_id="anonymous")
+    sent = _seed_sent_message(team_service, process.team_id)
+
+    routed: list[tuple[str, object]] = []
+    handle = team_service.get_handle(process.team_id)
+    assert handle is not None
+    handle.process_human_input = (  # type: ignore[method-assign]
+        lambda content, message: routed.append((content, message))
+    )
+
+    body = V1HumanInputBody(
+        content="yes",
+        message={"id": str(sent.message.id), "content": "original"},
+    )
+    resp = process_human_input(
+        id=str(process.team_id), proxy="@Human", body=body, service=team_service
+    )
+
+    assert resp.status == "ok"
+    assert routed == [("yes", sent.message)]
+
+
+def test_process_human_input_unknown_id_404(team_service: TeamService) -> None:
+    """An id matching no SentMessage maps to HTTP 404 (not-found)."""
+    process = team_service.create_team("test-team", user_id="anonymous")
+    _seed_sent_message(team_service, process.team_id)
+
+    body = V1HumanInputBody(
+        content="yes",
+        message={"id": str(uuid.uuid4()), "content": "original"},
+    )
+    with pytest.raises(HTTPException) as exc_info:
+        process_human_input(
+            id=str(process.team_id), proxy="@Human", body=body, service=team_service
+        )
+    assert exc_info.value.status_code == 404
+
+
+def test_process_human_input_missing_id_422(team_service: TeamService) -> None:
+    """A body whose message lacks an 'id' field maps to HTTP 422."""
+    process = team_service.create_team("test-team", user_id="anonymous")
+
+    body = V1HumanInputBody(content="yes", message={"content": "original"})
+    with pytest.raises(HTTPException) as exc_info:
+        process_human_input(
+            id=str(process.team_id), proxy="@Human", body=body, service=team_service
+        )
+    assert exc_info.value.status_code == 422

--- a/tests/server/services/test_team_action_service.py
+++ b/tests/server/services/test_team_action_service.py
@@ -3,11 +3,14 @@
 from __future__ import annotations
 
 import uuid
+from datetime import UTC, datetime
 
 import pytest
-from akgentic.team.models import TeamStatus
+from akgentic.core.messages.orchestrator import SentMessage
+from akgentic.team.models import PersistedEvent, TeamStatus
 
 from akgentic.infra.server.services.team_service import TeamService
+from tests.fixtures.events import build_sent_message
 
 
 def test_send_message_success(team_service: TeamService) -> None:
@@ -140,6 +143,53 @@ def test_process_human_input_invalid_message(team_service: TeamService) -> None:
     process = team_service.create_team("test-team", user_id="anonymous")
     with pytest.raises(ValueError, match="not found"):
         team_service.process_human_input(process.team_id, "yes", "nonexistent")
+
+
+def _seed_sent_message(team_service: TeamService, team_id: uuid.UUID) -> SentMessage:
+    """Persist a SentMessage (inner id != outer id) into a team's event store."""
+    sent = build_sent_message(content="please confirm")
+    # The contract under test only resolves when inner != outer; assert it.
+    assert sent.id != sent.message.id
+    team_service._services.event_store.save_event(
+        PersistedEvent(
+            team_id=team_id,
+            sequence=1,
+            event=sent,
+            timestamp=datetime.now(UTC),
+        )
+    )
+    return sent
+
+
+def test_process_human_input_resolves_by_inner_id(team_service: TeamService) -> None:
+    """process_human_input resolves a SentMessage by its inner message.id.
+
+    The cached handle's ``process_human_input`` is stubbed so the test asserts
+    the inner-id call routes the inner Message to the handle, decoupled from
+    UserProxy actor wiring.
+    """
+    process = team_service.create_team("test-team", user_id="anonymous")
+    sent = _seed_sent_message(team_service, process.team_id)
+
+    routed: list[tuple[str, object]] = []
+    handle = team_service.get_handle(process.team_id)
+    assert handle is not None
+    handle.process_human_input = (  # type: ignore[method-assign]
+        lambda content, message: routed.append((content, message))
+    )
+
+    team_service.process_human_input(process.team_id, "yes", str(sent.message.id))
+
+    assert routed == [("yes", sent.message)]
+
+
+def test_process_human_input_outer_id_not_found(team_service: TeamService) -> None:
+    """process_human_input raises 'not found' when given the outer envelope id."""
+    process = team_service.create_team("test-team", user_id="anonymous")
+    sent = _seed_sent_message(team_service, process.team_id)
+
+    with pytest.raises(ValueError, match="not found"):
+        team_service.process_human_input(process.team_id, "yes", str(sent.id))
 
 
 def test_create_team_caches_handle(team_service: TeamService) -> None:

--- a/tests/worker/test_worker_human_input_inner_id.py
+++ b/tests/worker/test_worker_human_input_inner_id.py
@@ -1,0 +1,117 @@
+"""Worker-route human-input inner-id resolution tests (Epic 30 / ADR-027).
+
+The worker ``_find_message`` resolves a persisted ``SentMessage`` by its
+**inner** ``message.id`` (the id every distributed tier puts on the wire),
+not the outer envelope ``SentMessage.id``. These tests pin that behavior:
+inner id resolves and routes to the handle; outer id is not found.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+from types import SimpleNamespace
+
+import pytest
+from akgentic.team.models import PersistedEvent
+from fastapi import HTTPException
+
+from akgentic.infra.server.models import HumanInputRequest
+from akgentic.infra.worker.routes.teams import _find_message, human_input
+from tests.fixtures.events import build_sent_message
+
+
+def _persisted(sent: object, team_id: uuid.UUID, sequence: int = 1) -> PersistedEvent:
+    """Wrap an event in a PersistedEvent envelope for a team."""
+    return PersistedEvent(
+        team_id=team_id,
+        sequence=sequence,
+        event=sent,  # type: ignore[arg-type]
+        timestamp=datetime.now(UTC),
+    )
+
+
+class _FakeEventStore:
+    """Minimal EventStore stub exposing only ``load_events``."""
+
+    def __init__(self, events: list[PersistedEvent]) -> None:
+        self._events = events
+
+    def load_events(self, team_id: uuid.UUID) -> list[PersistedEvent]:
+        return [e for e in self._events if e.team_id == team_id]
+
+
+def test_find_message_resolves_by_inner_id() -> None:
+    """_find_message returns the SentMessage matching the inner message.id."""
+    team_id = uuid.uuid4()
+    sent = build_sent_message(content="please confirm")
+    # The inner and outer ids must differ for this to be a meaningful test.
+    assert sent.id != sent.message.id
+    store = _FakeEventStore([_persisted(sent, team_id)])
+
+    resolved = _find_message(store, team_id, str(sent.message.id))
+
+    assert resolved is sent
+    assert resolved.message.id == sent.message.id
+
+
+def test_find_message_outer_id_not_found() -> None:
+    """_find_message raises 'not found' when given the outer envelope id."""
+    team_id = uuid.uuid4()
+    sent = build_sent_message(content="please confirm")
+    store = _FakeEventStore([_persisted(sent, team_id)])
+
+    with pytest.raises(ValueError, match="not found"):
+        _find_message(store, team_id, str(sent.id))
+
+
+def test_find_message_ignores_non_sent_message() -> None:
+    """_find_message skips non-SentMessage events even on an id match."""
+    team_id = uuid.uuid4()
+    inner = build_sent_message().message
+    # An inner UserMessage persisted on its own is not a SentMessage envelope.
+    store = _FakeEventStore([_persisted(inner, team_id)])
+
+    with pytest.raises(ValueError, match="not found"):
+        _find_message(store, team_id, str(inner.id))
+
+
+def test_human_input_route_routes_inner_id_to_handle() -> None:
+    """human_input route resolves the inner id and routes to the handle."""
+    team_id = uuid.uuid4()
+    sent = build_sent_message(content="please confirm")
+    store = _FakeEventStore([_persisted(sent, team_id)])
+
+    routed: list[tuple[str, object]] = []
+    handle = SimpleNamespace(
+        process_human_input=lambda content, message: routed.append((content, message))
+    )
+    services = SimpleNamespace(
+        event_store=store,
+        runtime_cache=SimpleNamespace(get=lambda _tid: handle),
+    )
+
+    body = HumanInputRequest(content="yes", message_id=str(sent.message.id))
+    human_input(team_id, body, services)  # type: ignore[arg-type]
+
+    assert routed == [("yes", sent.message)]
+
+
+def test_human_input_route_outer_id_returns_404() -> None:
+    """human_input route raises HTTP 404 when given the outer envelope id."""
+    team_id = uuid.uuid4()
+    sent = build_sent_message(content="please confirm")
+    store = _FakeEventStore([_persisted(sent, team_id)])
+
+    handle = SimpleNamespace(process_human_input=lambda content, message: None)
+    services = SimpleNamespace(
+        event_store=store,
+        runtime_cache=SimpleNamespace(get=lambda _tid: handle),
+    )
+
+    body = HumanInputRequest(content="yes", message_id=str(sent.id))
+    with pytest.raises(HTTPException) as exc_info:
+        human_input(team_id, body, services)  # type: ignore[arg-type]
+
+    assert exc_info.value.status_code == 404
+    assert "not found" in exc_info.value.detail


### PR DESCRIPTION
## Epic 30 — human-input Resolves by Inner Message Id

Resolve the human-input target by the **inner** `SentMessage.message.id` at both `_find_message` sites (worker route + gateway service), so human replies round-trip correctly across the community, department, and enterprise tiers with **no code change** in the deployment packages. The two distributed handles (`HttpTeamHandle`, `RemoteTeamHandle`) already put the inner id on the wire; converging both lookups on the inner id fixes the two-hop department/enterprise human-input 404.

### Stories

- [x] `30-1-resolve-human-input-by-inner-message-id` (Relates to #294)
- [x] `30-2-audit-human-input-callers-cli-tui-and-angular-v1` (Relates to #296)

## Review status

**30-1** — Reviewed by Rex (adversarial code review). Verdict: **DONE**.

- All 8 acceptance criteria verified against the implementation and tests.
- Both `_find_message` sites resolve by `isinstance(ev.event, SentMessage) and str(ev.event.message.id) == message_id`, returning the narrowed `SentMessage`. The `Message {message_id} not found` error text is unchanged, preserving the `not found` → 404 mapping in `_raise_action_error`.
- The redundant post-lookup `isinstance(event, SentMessage)` guard is removed at both sites — no production behavior branches on it (AC #3).
- `HumanInputRequest.message_id` field name/type unchanged; only the description docstring documents the inner-id contract (AC #4/#5). No edit to the `TeamHandle` Protocol or `LocalTeamHandle`.
- Regression tests added: worker-route (`_find_message` inner resolves / outer not-found / non-SentMessage skipped; `human_input` route inner→handle, outer→HTTP 404) and gateway-service (`process_human_input` inner routes to stubbed handle, outer raises `ValueError` matching `not found`).
- Quality gate (local): `pytest packages/akgentic-infra/tests/` green; `ruff check` and `mypy` on `packages/akgentic-infra/src/` clean.
- No review fixups were required — the implementation was clean and well-scoped.

- 30-2 review: **PASS** — all 7 acceptance criteria verified; no fixups required. Both remaining id-sending callers now hand the gateway the inner `SentMessage.message.id`:
  - **angular_v1** `process_human_input` adds `_resolve_inner_message_id`, which scans the team's event store and translates the posted **outer** envelope id (`V1MessageEntry.id = str(ev.event.id)`) to the inner `message.id` before delegating. Already-inner / unknown ids pass through unchanged, so a missing match still 404s via `TeamService._find_message` (status codes 200/404/422 unchanged).
  - **CLI** `EventRouter._notify_human_input` now forwards the nested request's inner `Message.id` (`_inner_human_input_id`), falling back to the outer `EventMessage` envelope id only when the nested request exposes no `id`.
  - **TUI** audited as render-only — no human-input send path, no edit (correct per the no-speculative-edits rule).
  - 6 new angular_v1 route/helper tests (outer→inner, inner pass-through, unknown→404, missing→422) and 3 new CLI tests (inner forwarded, nested `id` forwarded, envelope fallback) — all real behavioral assertions, no ADR-string assertions. Scope confined to `packages/akgentic-infra/`. `ruff` + `mypy` on `src/` clean; local test suite green.

## Epic 30 slice complete

Both stories of Epic 30 have landed on this branch and passed adversarial code review:

| Story | Issue | Status |
| --- | --- | --- |
| 30-1 resolve human-input by inner message id | #294 | done |
| 30-2 audit human-input callers (CLI/TUI + angular_v1) | #296 | done |

**Net effect:** every backend resolver and every in-repo human-input *sender* now agrees on the inner `SentMessage.message.id` contract. 30-1 flipped both `_find_message` sites (worker route + gateway service) to resolve by the inner id; 30-2 aligned the two remaining callers that were still handing over the outer envelope id (the angular_v1 compat router, via a server-side outer→inner translation, and the CLI reply path), and confirmed the TUI has no send path. The `not found` → 404 mapping, the `TeamHandle.process_human_input` Protocol, and `LocalTeamHandle` are untouched. The department/enterprise deployment packages need no change — they inherit the fix unchanged, closing the two-hop human-input 404.

**Sibling coordination:** the paired frontend change (modal sends the inner `Message.id`) lives in **akgentic-frontend Epic 13** — see below. This backend PR MUST land and deploy first.

## Scope guard

All changes stay inside `packages/akgentic-infra/`. No cross-submodule edits (Golden Rule #4). The department/enterprise deployment packages need no change — that is the side-effect fix this epic delivers.

## Sibling coordination

This epic is functionally paired with **akgentic-frontend Epic 13** (issue #127, branch `feat/127-epic-13-human-input-modal-sends-inner-message-id`), where the modal starts sending the inner `Message.id`.

**Merge/deploy ordering:** the backend MUST land first. This backend resolve-by-inner-id change is backward-compatible only once it ships; the frontend must not start sending the inner id before this PR is merged and deployed. Coordinate the two PRs so the backend lands ahead of the frontend.
