### PR TITLE
feat(akgentic-infra): epic 33 — Optional workspace_id Selector on Workspace Routes (33-1)

### DIFF
--- a/src/akgentic/infra/server/routes/workspace.py
+++ b/src/akgentic/infra/server/routes/workspace.py
@@ -1,9 +1,29 @@
-"""Workspace file access endpoints — tree listing, file read, file upload."""
+"""Workspace file access endpoints — tree listing, file read, file upload.
+
+All three routes (GET ``.../tree``, GET ``.../file``, POST ``.../file``) accept an
+optional ``workspace_id`` **query** parameter that selects which directory under
+``workspaces_root`` is served:
+
+- When omitted, the directory is the team's own (``<workspaces_root>/<team_id>``) —
+  byte-identical to the historical behaviour.
+- When present, it must be a single safe path segment matching
+  ``[A-Za-z0-9._-]{1,128}`` (``_validate_workspace_id``); anything else (empty,
+  ``.``/``..``, separators, absolute paths, over-length) is rejected with HTTP 400
+  *before* any ``Filesystem`` is constructed. This mirrors the agent side's
+  ``WorkspaceTool.workspace_id or str(team_id)`` (ADR-029), letting an HTTP caller
+  name the same non-default workspace an agent was configured with.
+
+The guard is a route-boundary traversal/correctness invariant, NOT an access
+policy: it proves the value is a safe segment, not that the caller may read the
+selected workspace. **Ownership authorization is deferred to the ADR-023
+request-user-identity seam.**
+"""
 
 from __future__ import annotations
 
 import asyncio
 import logging
+import re
 import uuid
 from pathlib import PurePosixPath
 from typing import Annotated, cast
@@ -26,10 +46,43 @@ router = APIRouter(prefix="/workspace", tags=["workspace"])
 
 _MAX_FILE_SIZE = 10_485_760  # 10 MB
 
+# A workspace_id is a single safe path segment: alphanumerics plus dot, dash, and
+# underscore, 1-128 chars. This is a route-boundary traversal guard (a correctness
+# invariant), NOT an access-policy check — ownership authz is deferred to the
+# ADR-023 request-user-identity seam.
+_WORKSPACE_ID_RE = re.compile(r"\A[A-Za-z0-9._-]{1,128}\Z")
 
-def _get_workspace(team_id: uuid.UUID, settings: CommunitySettings) -> Filesystem:
-    """Instantiate a Filesystem scoped to a team's workspace directory."""
-    return Filesystem(base_path=str(settings.workspaces_root), workspace_name=str(team_id))
+
+def _validate_workspace_id(workspace_id: str) -> str:
+    """Reject any workspace_id that is not a single safe path segment.
+
+    Mandatory traversal guard (ADR-029 §2): rejects ``""``, ``"."``, ``".."``,
+    any value containing a path separator, absolute paths, and over-length
+    values with HTTP 400, raising **before** any ``Filesystem`` is constructed.
+    Returns the value unchanged when it is a valid single segment.
+    """
+    if workspace_id in ("", ".", "..") or not _WORKSPACE_ID_RE.fullmatch(workspace_id):
+        raise HTTPException(status_code=400, detail="Invalid workspace_id")
+    return workspace_id
+
+
+def _get_workspace(
+    team_id: uuid.UUID,
+    settings: CommunitySettings,
+    workspace_id: str | None = None,
+) -> Filesystem:
+    """Instantiate a Filesystem scoped to a workspace directory.
+
+    Uses ``workspace_id`` when provided, otherwise falls back to the team's own
+    directory (``team_id``). Mirrors ``WorkspaceTool.workspace_id or str(team_id)``
+    on the agent side (ADR-029). Validation runs before the ``Filesystem`` is
+    constructed, so a rejected ``workspace_id`` never resolves a traversal root.
+    """
+    # Distinguish an *omitted* param (None → team-id fallback, AC #1) from an
+    # *empty* one (""→ 400, AC #6): only None falls back; any present value,
+    # including "", goes through the guard.
+    name = str(team_id) if workspace_id is None else _validate_workspace_id(workspace_id)
+    return Filesystem(base_path=str(settings.workspaces_root), workspace_name=name)
 
 
 def _validate_team(team_id: uuid.UUID, request: Request) -> None:
@@ -44,12 +97,13 @@ def list_workspace_tree(
     team_id: uuid.UUID,
     request: Request,
     path: str = "",
+    workspace_id: str | None = None,
 ) -> WorkspaceTreeResponse:
     """List files in a team's workspace directory."""
     logger.debug("GET /workspace/%s/tree path=%s", team_id, path)
     _validate_team(team_id, request)
     settings = cast(CommunitySettings, request.app.state.settings)
-    ws = _get_workspace(team_id, settings)
+    ws = _get_workspace(team_id, settings, workspace_id)
     try:
         entries = ws.list(path)
     except PermissionError:
@@ -66,12 +120,13 @@ def read_workspace_file(
     team_id: uuid.UUID,
     request: Request,
     path: str,
+    workspace_id: str | None = None,
 ) -> Response:
     """Read a file from a team's workspace."""
     logger.debug("GET /workspace/%s/file path=%s", team_id, path)
     _validate_team(team_id, request)
     settings = cast(CommunitySettings, request.app.state.settings)
-    ws = _get_workspace(team_id, settings)
+    ws = _get_workspace(team_id, settings, workspace_id)
     try:
         data = ws.read(path)
     except FileNotFoundError:
@@ -94,11 +149,12 @@ async def upload_workspace_file(
     request: Request,
     path: Annotated[str, Form()],
     file: Annotated[UploadFile, File()],
+    workspace_id: str | None = None,
 ) -> WorkspaceFileUploadResponse:
     """Upload a file to a team's workspace."""
     await asyncio.to_thread(_validate_team, team_id, request)
     settings = cast(CommunitySettings, request.app.state.settings)
-    ws = _get_workspace(team_id, settings)
+    ws = _get_workspace(team_id, settings, workspace_id)
     data = await file.read()
     if len(data) > _MAX_FILE_SIZE:
         raise HTTPException(status_code=413, detail="File exceeds 10 MB size limit")

--- a/tests/server/routes/test_workspace_does_not_block_event_loop.py
+++ b/tests/server/routes/test_workspace_does_not_block_event_loop.py
@@ -146,3 +146,53 @@ def test_upload_does_not_block_event_loop(
     body = slow_resp.json()  # type: ignore[attr-defined]
     assert body["path"] == "slow.txt"
     assert body["size"] == len(payload)
+
+
+def test_upload_with_workspace_id_does_not_block_event_loop(
+    client: TestClient,
+    team_for_upload: uuid.UUID,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A selector-bearing upload (Story 33.1) keeps the same offload guarantee.
+
+    Passing ``?workspace_id=alt-ws`` only changes which directory the
+    ``Filesystem`` is rooted at; the two ``asyncio.to_thread`` offloads in
+    ``upload_workspace_file`` are unchanged. While a deliberately slow
+    ``Filesystem.write`` is in flight, a concurrent ``/readiness`` probe must
+    still return in under 100 ms, and the upload must still return 201.
+    """
+    _patch_slow_filesystem_write(monkeypatch)
+
+    payload = b"slow alt data"
+    team_id = team_for_upload
+
+    def fire_slow_upload() -> object:
+        return client.post(
+            f"/workspace/{team_id}/file",
+            params={"workspace_id": "alt-ws"},
+            data={"path": "slow.txt"},
+            files={"file": ("slow.txt", payload, "text/plain")},
+        )
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=2) as executor:
+        slow_future = executor.submit(fire_slow_upload)
+        time.sleep(0.05)
+
+        start = time.perf_counter()
+        probe_resp = client.get("/readiness")
+        elapsed_s = time.perf_counter() - start
+
+        assert probe_resp.status_code == 200
+        assert elapsed_s < 0.1, (
+            f"GET /readiness took {elapsed_s:.3f}s while a workspace_id-bearing upload "
+            "was in flight; expected < 0.1s (loop is stalled by sync work in the handler)"
+        )
+
+        slow_resp = slow_future.result(timeout=10.0)
+
+    assert slow_resp.status_code == 201, (  # type: ignore[attr-defined]
+        f"selector upload returned {slow_resp.status_code}"  # type: ignore[attr-defined]
+    )
+    body = slow_resp.json()  # type: ignore[attr-defined]
+    assert body["path"] == "slow.txt"
+    assert body["size"] == len(payload)

--- a/tests/server/routes/test_workspace_routes.py
+++ b/tests/server/routes/test_workspace_routes.py
@@ -45,6 +45,16 @@ def test_workspace_tree_not_found(client: TestClient) -> None:
     assert resp.status_code == 404
 
 
+def test_workspace_tree_traversal_attack(
+    client: TestClient, team_with_workspace: uuid.UUID
+) -> None:
+    """GET /workspace/{team_id}/tree rejects in-root path traversal with 403."""
+    resp = client.get(
+        f"/workspace/{team_with_workspace}/tree", params={"path": "../../etc"}
+    )
+    assert resp.status_code == 403
+
+
 # --- File read tests ---
 
 
@@ -142,3 +152,147 @@ def test_workspace_file_upload_traversal_attack(
         files={"file": ("evil.txt", b"malicious", "text/plain")},
     )
     assert resp.status_code == 403
+
+
+# --- workspace_id selector tests (Story 33.1) ---
+
+# Values that _validate_workspace_id must reject with HTTP 400: empty, the dot
+# segments, anything containing a path separator, absolute paths, and an
+# over-length (129-char) value.
+_REJECTED_WORKSPACE_IDS = [
+    "../x",
+    "a/b",
+    "a\\b",
+    "/abs",
+    "..",
+    ".",
+    "",
+    "a" * 129,
+]
+
+
+def test_workspace_tree_honours_selector(
+    client: TestClient,
+    team_with_workspace: uuid.UUID,
+    seeded_settings: ServerSettings,
+) -> None:
+    """GET .../tree with ?workspace_id=alt-ws lists <root>/alt-ws, isolated from the team dir."""
+    alt_root = seeded_settings.workspaces_root / "alt-ws"
+    alt_root.mkdir(parents=True, exist_ok=True)
+    (alt_root / "alt-only.txt").write_text("alt content")
+
+    resp = client.get(
+        f"/workspace/{team_with_workspace}/tree", params={"workspace_id": "alt-ws"}
+    )
+    assert resp.status_code == 200
+    names = [e["name"] for e in resp.json()["entries"]]
+    assert "alt-only.txt" in names
+    # Isolation: the team directory's seeded files are NOT visible under alt-ws.
+    assert "output.txt" not in names
+    assert "subdir" not in names
+
+
+def test_workspace_file_read_honours_selector(
+    client: TestClient,
+    team_with_workspace: uuid.UUID,
+    seeded_settings: ServerSettings,
+) -> None:
+    """GET .../file with ?workspace_id=alt-ws reads from <root>/alt-ws."""
+    alt_root = seeded_settings.workspaces_root / "alt-ws"
+    alt_root.mkdir(parents=True, exist_ok=True)
+    (alt_root / "alt.txt").write_text("from alt")
+
+    resp = client.get(
+        f"/workspace/{team_with_workspace}/file",
+        params={"path": "alt.txt", "workspace_id": "alt-ws"},
+    )
+    assert resp.status_code == 200
+    assert resp.content == b"from alt"
+
+    # Isolation: the same filename does NOT resolve in the team directory.
+    team_resp = client.get(
+        f"/workspace/{team_with_workspace}/file", params={"path": "alt.txt"}
+    )
+    assert team_resp.status_code == 404
+
+
+def test_workspace_file_upload_honours_selector(
+    client: TestClient,
+    team_with_workspace: uuid.UUID,
+    seeded_settings: ServerSettings,
+) -> None:
+    """POST .../file with ?workspace_id=alt-ws writes to <root>/alt-ws, isolated from team dir."""
+    resp = client.post(
+        f"/workspace/{team_with_workspace}/file",
+        params={"workspace_id": "alt-ws"},
+        data={"path": "uploaded-alt.txt"},
+        files={"file": ("uploaded-alt.txt", b"alt upload", "text/plain")},
+    )
+    assert resp.status_code == 201
+    assert resp.json()["path"] == "uploaded-alt.txt"
+
+    # The write landed under <root>/alt-ws ...
+    alt_file = seeded_settings.workspaces_root / "alt-ws" / "uploaded-alt.txt"
+    assert alt_file.exists()
+    assert alt_file.read_bytes() == b"alt upload"
+
+    # ... and NOT under the team directory (isolation both ways).
+    team_file = seeded_settings.workspaces_root / str(team_with_workspace) / "uploaded-alt.txt"
+    assert not team_file.exists()
+    read_back = client.get(
+        f"/workspace/{team_with_workspace}/file", params={"path": "uploaded-alt.txt"}
+    )
+    assert read_back.status_code == 404
+
+
+@pytest.mark.parametrize("bad_value", _REJECTED_WORKSPACE_IDS)
+def test_workspace_tree_rejects_bad_selector(
+    client: TestClient,
+    team_with_workspace: uuid.UUID,
+    seeded_settings: ServerSettings,
+    bad_value: str,
+) -> None:
+    """GET .../tree returns 400 for any malformed workspace_id and creates no stray dir."""
+    before = set(seeded_settings.workspaces_root.iterdir())
+    resp = client.get(
+        f"/workspace/{team_with_workspace}/tree", params={"workspace_id": bad_value}
+    )
+    assert resp.status_code == 400
+    # No directory was created or read outside the existing workspace roots.
+    assert set(seeded_settings.workspaces_root.iterdir()) == before
+
+
+@pytest.mark.parametrize("bad_value", _REJECTED_WORKSPACE_IDS)
+def test_workspace_file_read_rejects_bad_selector(
+    client: TestClient,
+    team_with_workspace: uuid.UUID,
+    seeded_settings: ServerSettings,
+    bad_value: str,
+) -> None:
+    """GET .../file returns 400 for any malformed workspace_id and creates no stray dir."""
+    before = set(seeded_settings.workspaces_root.iterdir())
+    resp = client.get(
+        f"/workspace/{team_with_workspace}/file",
+        params={"path": "output.txt", "workspace_id": bad_value},
+    )
+    assert resp.status_code == 400
+    assert set(seeded_settings.workspaces_root.iterdir()) == before
+
+
+@pytest.mark.parametrize("bad_value", _REJECTED_WORKSPACE_IDS)
+def test_workspace_file_upload_rejects_bad_selector(
+    client: TestClient,
+    team_with_workspace: uuid.UUID,
+    seeded_settings: ServerSettings,
+    bad_value: str,
+) -> None:
+    """POST .../file returns 400 for any malformed workspace_id and creates no stray dir."""
+    before = set(seeded_settings.workspaces_root.iterdir())
+    resp = client.post(
+        f"/workspace/{team_with_workspace}/file",
+        params={"workspace_id": bad_value},
+        data={"path": "evil.txt"},
+        files={"file": ("evil.txt", b"data", "text/plain")},
+    )
+    assert resp.status_code == 400
+    assert set(seeded_settings.workspaces_root.iterdir()) == before


### PR DESCRIPTION
# Epic 33 — Optional `workspace_id` Selector on Workspace Routes

Adds an optional `workspace_id` query parameter to the three `/workspace/{team_id}/*` routes (GET `tree`, GET `file`, POST `file`). When present, the route serves `<workspaces_root>/<workspace_id>`; when omitted, it falls back to `<workspaces_root>/<team_id>`, byte-identical to prior behaviour — mirroring `WorkspaceTool.workspace_id or str(team_id)` on the agent side (ADR-029).

A mandatory single-segment traversal guard (`_validate_workspace_id`, charset `[A-Za-z0-9._-]{1,128}`) rejects empty, `.`/`..`, path separators, absolute paths, and over-length values with HTTP 400 **before** any `Filesystem` is constructed. The guard is a route-boundary correctness invariant, not an access policy — ownership authorization is deferred to the ADR-023 request-user-identity seam.

The ADR-026 event-loop offload in `upload_workspace_file` is preserved: `_get_workspace` stays a plain call; only `_validate_team` and `ws.write` remain in `asyncio.to_thread`.

## Stories

- [x] 33-1-optional-workspace-id-query-param-with-segment-guard — optional workspace_id selector with mandatory segment guard (Relates to #302)

## Review status

| Story | Reviewer | Verdict | Issues fixed |
|-------|----------|---------|--------------|
| 33-1 | Rex (adversarial code review) | DONE — clean, no fix-worthy issues | 0 |

The implementation faithfully mirrors ADR-029. All nine acceptance criteria are satisfied:

- `_validate_workspace_id` raises HTTP 400 before `Filesystem()` construction, foreclosing the latent traversal hole in `Filesystem.__init__`'s unguarded root join.
- The `None` vs `""` distinction is handled correctly: an *omitted* param falls back to the team id (byte-identical to prior behaviour); a *present* `""` is rejected with 400. The dev correctly used `is None` rather than the ADR snippet's truthiness check, which would have let `""` fall through.
- All three handlers gain the optional query param and forward it.
- The upload offload guarantee is preserved, verified by a selector-bearing event-loop regression test.

Verification: `pytest packages/akgentic-infra/tests/` — 1491 passed, 39 skipped, 0 failures. `workspace.py` at 100% line/branch coverage (total 89.92%, gate 80%). `ruff check` and `mypy --strict` clean on all modified files.

## Scope guard

All changes are confined to `packages/akgentic-infra/`:

- `src/akgentic/infra/server/routes/workspace.py`
- `tests/server/routes/test_workspace_routes.py`
- `tests/server/routes/test_workspace_does_not_block_event_loop.py`

No edits to `akgentic-tool` — hardening `Filesystem.__init__` to self-verify its root is a deliberate, out-of-scope, separate-submodule follow-up (ADR-029 §"What we will not do"; Golden Rule #4). No ownership/authorization checks (deferred to ADR-023).

## Epic 33 slice complete

This is the only story in Epic 33 and it is `done`. The epic closes the single gap it set out to close: an HTTP caller (frontend, CLI, operator) can now name the same non-default workspace an agent was configured with via `WorkspaceTool.workspace_id`, while default team-directory behaviour stays exactly as before. The deferred risk — authorization decoupled from team ownership — is recorded in ADR-029 and tracked against the ADR-023 seam.

Relates to #302
