### PR TITLE
chore(akgentic-infra): resilience to Starlette/FastAPI drift — methods guard + version pin

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,16 @@ dependencies = [
     "akgentic-agent",
     "akgentic-llm",
     "akgentic-tool",
-    "fastapi>=0.100.0",
+    # Pin away from the Starlette 1.3 / FastAPI 0.137 line: Starlette 1.3 changed
+    # include_router to wrap mounted routers in a lazy `_IncludedRouter` instead of
+    # flattening child APIRoutes into `app.routes`. That breaks the owner-or-admin
+    # gate attachment (which mutates each route's `dependant`) and route-introspection
+    # tests. CI has no lockfile (installs `-e .[dev]` from a wheelhouse), so these
+    # bounds are the only thing keeping resolution on the verified-good combo
+    # (fastapi 0.136.x + starlette 1.0.x). Revisit once the gate is reworked for the
+    # lazy-inclusion model.
+    "fastapi>=0.100.0,<0.137",
+    "starlette>=0.46.0,<1.1",
     "pydantic-settings>=2.0.0",
     "logfire>=0.1.0",
     "typer[all]>=0.9.0",

--- a/src/akgentic/infra/server/app.py
+++ b/src/akgentic/infra/server/app.py
@@ -295,7 +295,7 @@ def _attach_owner_or_admin_gate(router: APIRouter) -> None:
         for route in router.routes:
             if not isinstance(route, APIRoute):
                 continue
-            if route.path == path and method in route.methods:
+            if route.path == path and route.methods is not None and method in route.methods:
                 route.dependencies.append(dep)
                 route.dependant.dependencies.insert(
                     0,
@@ -332,7 +332,7 @@ def _attach_import_owner_or_admin_gate(router: APIRouter) -> None:
     for route in router.routes:
         if not isinstance(route, APIRoute):
             continue
-        if route.path == path and method in route.methods:
+        if route.path == path and route.methods is not None and method in route.methods:
             route.dependencies.append(dep)
             route.dependant.dependencies.insert(
                 0,


### PR DESCRIPTION
## What

Make `akgentic-infra` resilient to the FastAPI/Starlette dependency drift that turned CI red (master last green 2026-06-09). Two commits, two concerns:

1. **`fix` — guard `APIRoute.methods` optionality.** Starlette retyped `APIRoute.methods` to `set[str] | None`, making `method in route.methods` a mypy error at both owner-or-admin gate-attachment sites. Add a `route.methods is not None` guard. Type-only; runtime behaviour unchanged.
2. **`chore` — pin `starlette>=0.46.0,<1.1` and `fastapi>=0.100.0,<0.137`.** Starlette 1.3 changed `include_router` to wrap mounted routers in a lazy `_IncludedRouter` instead of flattening child `APIRoute`s into `app.routes`. That breaks the owner-or-admin gate attachment and route-introspection — surfacing as `'_IncludedRouter' object has no attribute 'path'` and missing `/teams/`, `/process/{type}`, and gated catalog routes.

## Why the pin

CI installs `-e .[dev]` from a wheelhouse with **no lockfile**, so it re-resolves to the newest allowed versions every run. The old constraint (`fastapi>=0.100.0`) plus FastAPI requiring only `starlette>=0.46.0` (no upper bound) let CI float to fastapi 0.137.1 + starlette 1.3.1. The bounds hold resolution on the verified-good combo (fastapi 0.136.x + starlette 1.0.x).

## Verification

- `uv run --no-sync mypy src/` → no issues found in 109 source files (was 2 errors).
- The previously-failing unit tests pass locally on the pinned versions: `test_app.py`, `frontend_adapter/test_angular_v1_adapter.py`, `frontend_adapter/test_frontend_adapter.py`, `server/routes/test_catalog_owner_or_admin_gate.py`, `server/routes/test_catalog_import_owner_or_admin_gate.py` → **74 passed**.

## Follow-up (not in this PR)

The pin is a stabilisation, not an endorsement of staying behind. Reworking the owner-or-admin gate attachment for Starlette's lazy `_IncludedRouter` inclusion model (so the project can move to Starlette 1.3+ / FastAPI 0.137+) is tracked separately.

Independent of the Epic 33 workspace change (PR #303), which this also unblocks once merged.

Relates to #304
