### PR TITLE
feat(akgentic-infra): epic 34 — Typed app.state via a StateKey[T] Registry (ADR-030) (34-1-statekey-factory-and-key-declarations → 34-3-architecture-and-readme-update)

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,10 +290,13 @@ src/akgentic/infra/
     routes/             REST, WebSocket, webhook, and frontend adapter routes
     services/           TeamService (tier-agnostic orchestrator)
     settings.py         Pydantic-settings configuration classes
+    state_keys.py       Typed app.state key declarations (server tier)
     app.py              Application factory (create_app)
   cli/                Typer-based CLI (ak-infra)
+  utils.py            StateKey[T] — typed app.state handle factory
   wiring.py           Dependency injection — wires adapters into services
   worker/             Worker module (planned for department/enterprise tiers)
+    state_keys.py       Typed app.state key declarations (worker tier)
 ```
 
 ## Quick Start
@@ -387,6 +390,38 @@ Tier-agnostic adapters that work across community, department, and enterprise de
 | `TelegramParser`             | Parses inbound Telegram webhook payloads                     |
 | `ChannelParserRegistry`      | Resolves and holds channel parsers/adapters from config      |
 | `TelemetrySubscriber`        | Event subscriber that traces messages via Logfire            |
+
+### Typed `app.state` access (`StateKey[T]`)
+
+`create_app()` stores its wired services on FastAPI's `app.state` so routes can reach them. `app.state` is a `starlette.datastructures.State` whose attribute reads are typed `Any`, so routes used to `cast(...)` every read. `StateKey[T]` (see ADR-030 — Typed `app.state` Access via a `StateKey[T]` Registry) replaces that with a typed, serialization-free handle to one slot. The API is three calls:
+
+- `KEY.set(source, value)` — the producer writes the slot.
+- `KEY.get(source) -> T | None` — soft read; returns the key's `default` when the slot is unset (or raises `LookupError` if the key is `required=True`).
+- `KEY.require(source) -> T` — loud read; never returns `None` (raises `LookupError` when unset/`None`).
+
+`source` may be a `FastAPI`, `Request`, or `WebSocket`. A key is declared once as a module-level constant — that declaration *is* the registration; there is no central registry. `StateKey("name", *, default=..., required=...)` is the full constructor.
+
+**Producer / consumer.** `create_app()` (the producer) sets each slot through its key, and routes (the consumers) read the same key handle:
+
+```python
+# producer — server/app.py
+SERVICES.set(app, services)
+TEAM_SERVICE.set(app, team_service)
+
+# consumer — server/routes/teams.py
+team_service = TEAM_SERVICE.require(request)
+```
+
+**Soft defaults.** A key declared with a `default` reads that default back when its slot was never set: `CHANNEL_PARSERS` and `FRONTEND_ADAPTER` default to `None`, `DRAINING` defaults to `False`. So `CHANNEL_PARSERS.get(request)` returns `ChannelParserRegistry | None` without any `getattr(..., None)` at the call site.
+
+**`Depends` bridge.** DI-shaped handlers wrap the same key in a one-line provider — no second source of truth:
+
+```python
+def get_team_service(request: Request) -> TeamService:
+    return TEAM_SERVICE.require(request)
+```
+
+**Key lives with its producer.** Server keys are declared in `server/state_keys.py`, worker keys in `worker/state_keys.py` — each in the package that writes the slot. Both tiers export a `SERVICES` key, but they are different keys typed to different containers (`TierServices` server-side, `WorkerServices` worker-side); the worker route imports its own (`from akgentic.infra.worker.state_keys import SERVICES`). Department and enterprise tiers adopt these keys on their own branches/PRs — a tracked follow-up (see `_bmad-output/akgentic-infra-department/migration-plan-lift-shared-auth-and-http-helpers-to-akgentic-infra.md`); the coexistence with the older `cast`/`getattr` style during that rollout is intentional.
 
 ## CLI
 

--- a/src/akgentic/infra/server/app.py
+++ b/src/akgentic/infra/server/app.py
@@ -44,6 +44,17 @@ from akgentic.infra.server.routes.ws import ConnectionManager, shutdown_reader_p
 from akgentic.infra.server.routes.ws import router as ws_router
 from akgentic.infra.server.services.team_service import TeamService
 from akgentic.infra.server.settings import ServerSettings
+from akgentic.infra.server.state_keys import (
+    CHANNEL_PARSERS,
+    CHANNEL_REGISTRY,
+    CONNECTION_MANAGER,
+    DRAINING,
+    FRONTEND_ADAPTER,
+    INGESTION,
+    SERVICES,
+    SETTINGS,
+    TEAM_SERVICE,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -100,26 +111,26 @@ async def _lifespan(app: FastAPI) -> AsyncIterator[None]:
     Shutdown: sets draining flag, waits pre-drain delay, disconnects all
     WebSocket clients, then stops all teams via ``worker_handle.stop_all()``.
     """
-    app.state.draining = False
+    DRAINING.set(app, value=False)
     logger.info("Lifespan startup: draining=False")
     yield
     # --- Shutdown sequence (ADR-013 Decision 2) ---
-    app.state.draining = True
+    DRAINING.set(app, value=True)
     logger.info("Lifespan shutdown: draining=True")
 
-    delay = app.state.settings.shutdown_pre_drain_delay
+    delay = SETTINGS.require(app).shutdown_pre_drain_delay
     if delay > 0:
         logger.info("Pre-drain delay: sleeping %ds", delay)
         await asyncio.sleep(delay)
 
     logger.info("Disconnecting all WebSocket clients")
-    await app.state.connection_manager.disconnect_all()
+    await CONNECTION_MANAGER.require(app).disconnect_all()
 
-    timeout = app.state.settings.shutdown_drain_timeout
+    timeout = SETTINGS.require(app).shutdown_drain_timeout
     logger.info("Stopping all teams (timeout=%ds)", timeout)
     try:
         await asyncio.wait_for(
-            asyncio.to_thread(app.state.services.worker_handle.stop_all),
+            asyncio.to_thread(SERVICES.require(app).worker_handle.stop_all),
             timeout=timeout,
         )
         logger.info("stop_all() completed successfully")
@@ -192,13 +203,19 @@ def _store_state(
     settings: ServerSettings,
 ) -> None:
     """Store services and configuration on app.state for dependency injection."""
-    app.state.services = services
-    app.state.team_service = team_service
-    app.state.settings = settings
-    app.state.connection_manager = ConnectionManager()
-    app.state.channel_parser_registry = getattr(services, "channel_parser_registry", None)
-    app.state.channel_registry = services.channel_registry
-    app.state.ingestion = services.ingestion
+    SERVICES.set(app, services)
+    TEAM_SERVICE.set(app, team_service)
+    SETTINGS.set(app, settings)
+    CONNECTION_MANAGER.set(app, ConnectionManager())
+    # ``channel_parser_registry`` is optional on the services container (only the
+    # community tier declares it). Read it the same way as before; only ``set``
+    # it when present. CHANNEL_PARSERS is a soft key (default None), so an unset
+    # slot reads back as None — byte-identical to storing None explicitly.
+    channel_parsers = getattr(services, "channel_parser_registry", None)
+    if channel_parsers is not None:
+        CHANNEL_PARSERS.set(app, channel_parsers)
+    CHANNEL_REGISTRY.set(app, services.channel_registry)
+    INGESTION.set(app, services.ingestion)
 
 
 def _mount_routes(app: FastAPI, settings: ServerSettings) -> None:
@@ -254,7 +271,7 @@ def _mount_routes(app: FastAPI, settings: ServerSettings) -> None:
     if settings.frontend_adapter:
         adapter = load_frontend_adapter(settings.frontend_adapter)
         adapter.register_routes(app)
-        app.state.frontend_adapter = adapter
+        FRONTEND_ADAPTER.set(app, adapter)
         logger.debug("Building app: Frontend adapter loaded: %s", settings.frontend_adapter)
 
 

--- a/src/akgentic/infra/server/app.py
+++ b/src/akgentic/infra/server/app.py
@@ -208,9 +208,10 @@ def _store_state(
     SETTINGS.set(app, settings)
     CONNECTION_MANAGER.set(app, ConnectionManager())
     # ``channel_parser_registry`` is optional on the services container (only the
-    # community tier declares it). Read it the same way as before; only ``set``
-    # it when present. CHANNEL_PARSERS is a soft key (default None), so an unset
-    # slot reads back as None — byte-identical to storing None explicitly.
+    # community tier declares it). CHANNEL_PARSERS is a required key, so the slot
+    # is only set when the services container actually exposes a registry; a tier
+    # without one leaves the slot unset and any webhook request fails loud
+    # (``require()`` → LookupError → 500) instead of reading back a silent None.
     channel_parsers = getattr(services, "channel_parser_registry", None)
     if channel_parsers is not None:
         CHANNEL_PARSERS.set(app, channel_parsers)

--- a/src/akgentic/infra/server/routes/teams.py
+++ b/src/akgentic/infra/server/routes/teams.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import logging
 import uuid
-from typing import NoReturn, cast
+from typing import NoReturn
 
 from fastapi import APIRouter, Depends, HTTPException, Request
 
@@ -20,6 +20,7 @@ from akgentic.infra.server.models import (
     TeamResponse,
 )
 from akgentic.infra.server.services.team_service import TeamService
+from akgentic.infra.server.state_keys import CONNECTION_MANAGER, TEAM_SERVICE
 from akgentic.team.models import Process
 
 logger = logging.getLogger(__name__)
@@ -29,7 +30,7 @@ router = APIRouter(prefix="/teams", tags=["teams"])
 
 def get_team_service(request: Request) -> TeamService:
     """FastAPI dependency: extract TeamService from app.state."""
-    return cast(TeamService, request.app.state.team_service)
+    return TEAM_SERVICE.require(request)
 
 
 def _process_to_response(process: Process) -> TeamResponse:
@@ -193,7 +194,7 @@ def restore_team(
     except ValueError as exc:
         _raise_action_error(exc)
 
-    conn_mgr = getattr(request.app.state, "connection_manager", None)
+    conn_mgr = CONNECTION_MANAGER.get(request)
     if conn_mgr is not None:
         from akgentic.infra.server.routes.ws import notify_restore
 

--- a/src/akgentic/infra/server/routes/webhook.py
+++ b/src/akgentic/infra/server/routes/webhook.py
@@ -19,14 +19,16 @@ logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/webhook", tags=["webhook"])
 
 
-def get_channel_parser_registry(request: Request) -> ChannelParserRegistry | None:
+def get_channel_parser_registry(request: Request) -> ChannelParserRegistry:
     """FastAPI dependency: extract ChannelParserRegistry from app.state.
 
-    ``channel_parser_registry`` is a soft slot (a tier without channel parsers
-    legitimately leaves it ``None``), so this returns ``ChannelParserRegistry |
-    None``. The handler turns an unset registry into a deliberate 500.
+    ``channel_parser_registry`` is a required slot on any webhook-serving tier:
+    a request reaching this route on a deployment that never wired a registry is
+    a misconfiguration, so ``.require()`` raises ``LookupError`` (surfaced as a
+    500) rather than returning ``None`` and crashing later. The non-optional
+    ``-> ChannelParserRegistry`` return means the handler needs no null-check.
     """
-    return CHANNEL_PARSERS.get(request)
+    return CHANNEL_PARSERS.require(request)
 
 
 def get_channel_registry(request: Request) -> ChannelRegistry:
@@ -43,7 +45,7 @@ def get_ingestion(request: Request) -> InteractionChannelIngestion:
 async def webhook(
     channel: str,
     request: Request,
-    parser_registry: ChannelParserRegistry | None = Depends(get_channel_parser_registry),
+    parser_registry: ChannelParserRegistry = Depends(get_channel_parser_registry),
     channel_registry: ChannelRegistry = Depends(get_channel_registry),
     ingestion: InteractionChannelIngestion = Depends(get_ingestion),
 ) -> None:
@@ -56,14 +58,6 @@ async def webhook(
     """
     content_type = request.headers.get("content-type", "")
     logger.info("POST /webhook/%s — content_type=%s", channel, content_type)
-
-    if parser_registry is None:
-        # Soft slot left unset is a server misconfiguration: a webhook reached a
-        # deployment with no channel-parser registry. Surface a deliberate 500
-        # (the historical cast(...) yielded None here, then crashed on the next
-        # get_parser() call with the same effective 500).
-        logger.error("No channel parser registry configured")
-        raise HTTPException(status_code=500, detail="Channel parsing not configured")
 
     parser = parser_registry.get_parser(channel)
     if parser is None:
@@ -97,7 +91,7 @@ async def webhook(
                 message.channel_user_id,
                 existing_team,
             )
-            await ingestion.route_reply(existing_team, message.content)
+            await ingestion.route_reply(existing_team, message.content, message.message_id)
         else:
             # Initiation flow
             new_team_id = await ingestion.initiate_team(

--- a/src/akgentic/infra/server/routes/webhook.py
+++ b/src/akgentic/infra/server/routes/webhook.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import logging
-from typing import cast
 
 from fastapi import APIRouter, Depends, HTTPException, Request
 
@@ -13,32 +12,38 @@ from akgentic.infra.protocols.channels import (
     InteractionChannelIngestion,
     JsonValue,
 )
+from akgentic.infra.server.state_keys import CHANNEL_PARSERS, CHANNEL_REGISTRY, INGESTION
 
 logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/webhook", tags=["webhook"])
 
 
-def get_channel_parser_registry(request: Request) -> ChannelParserRegistry:
-    """FastAPI dependency: extract ChannelParserRegistry from app.state."""
-    return cast(ChannelParserRegistry, request.app.state.channel_parser_registry)
+def get_channel_parser_registry(request: Request) -> ChannelParserRegistry | None:
+    """FastAPI dependency: extract ChannelParserRegistry from app.state.
+
+    ``channel_parser_registry`` is a soft slot (a tier without channel parsers
+    legitimately leaves it ``None``), so this returns ``ChannelParserRegistry |
+    None``. The handler turns an unset registry into a deliberate 500.
+    """
+    return CHANNEL_PARSERS.get(request)
 
 
 def get_channel_registry(request: Request) -> ChannelRegistry:
     """FastAPI dependency: extract ChannelRegistry from app.state."""
-    return cast(ChannelRegistry, request.app.state.channel_registry)
+    return CHANNEL_REGISTRY.require(request)
 
 
 def get_ingestion(request: Request) -> InteractionChannelIngestion:
     """FastAPI dependency: extract InteractionChannelIngestion from app.state."""
-    return cast(InteractionChannelIngestion, request.app.state.ingestion)
+    return INGESTION.require(request)
 
 
 @router.post("/{channel}", status_code=204)
 async def webhook(
     channel: str,
     request: Request,
-    parser_registry: ChannelParserRegistry = Depends(get_channel_parser_registry),
+    parser_registry: ChannelParserRegistry | None = Depends(get_channel_parser_registry),
     channel_registry: ChannelRegistry = Depends(get_channel_registry),
     ingestion: InteractionChannelIngestion = Depends(get_ingestion),
 ) -> None:
@@ -51,6 +56,14 @@ async def webhook(
     """
     content_type = request.headers.get("content-type", "")
     logger.info("POST /webhook/%s — content_type=%s", channel, content_type)
+
+    if parser_registry is None:
+        # Soft slot left unset is a server misconfiguration: a webhook reached a
+        # deployment with no channel-parser registry. Surface a deliberate 500
+        # (the historical cast(...) yielded None here, then crashed on the next
+        # get_parser() call with the same effective 500).
+        logger.error("No channel parser registry configured")
+        raise HTTPException(status_code=500, detail="Channel parsing not configured")
 
     parser = parser_registry.get_parser(channel)
     if parser is None:

--- a/src/akgentic/infra/server/routes/workspace.py
+++ b/src/akgentic/infra/server/routes/workspace.py
@@ -25,8 +25,8 @@ import asyncio
 import logging
 import re
 import uuid
-from pathlib import PurePosixPath
-from typing import Annotated, cast
+from pathlib import Path, PurePosixPath
+from typing import Annotated
 
 from fastapi import APIRouter, HTTPException, Request, Response, UploadFile
 from fastapi.params import File, Form
@@ -36,8 +36,8 @@ from akgentic.infra.server.models import (
     WorkspaceFileUploadResponse,
     WorkspaceTreeResponse,
 )
-from akgentic.infra.server.services.team_service import TeamService
-from akgentic.infra.server.settings import CommunitySettings
+from akgentic.infra.server.settings import ServerSettings
+from akgentic.infra.server.state_keys import SETTINGS, TEAM_SERVICE
 from akgentic.tool.workspace import Filesystem
 
 logger = logging.getLogger(__name__)
@@ -68,7 +68,7 @@ def _validate_workspace_id(workspace_id: str) -> str:
 
 def _get_workspace(
     team_id: uuid.UUID,
-    settings: CommunitySettings,
+    settings: ServerSettings,
     workspace_id: str | None = None,
 ) -> Filesystem:
     """Instantiate a Filesystem scoped to a workspace directory.
@@ -77,17 +77,23 @@ def _get_workspace(
     directory (``team_id``). Mirrors ``WorkspaceTool.workspace_id or str(team_id)``
     on the agent side (ADR-029). Validation runs before the ``Filesystem`` is
     constructed, so a rejected ``workspace_id`` never resolves a traversal root.
+
+    ``workspaces_root`` is declared on ``CommunitySettings``; a base
+    ``ServerSettings`` deployment falls back to the same default the field
+    declares, mirroring ``create_app``'s own defensive read (byte-identical
+    behaviour to the historical ``cast(CommunitySettings, ...)``).
     """
     # Distinguish an *omitted* param (None → team-id fallback, AC #1) from an
     # *empty* one (""→ 400, AC #6): only None falls back; any present value,
     # including "", goes through the guard.
     name = str(team_id) if workspace_id is None else _validate_workspace_id(workspace_id)
-    return Filesystem(base_path=str(settings.workspaces_root), workspace_name=name)
+    workspaces_root = getattr(settings, "workspaces_root", Path("workspaces"))
+    return Filesystem(base_path=str(workspaces_root), workspace_name=name)
 
 
 def _validate_team(team_id: uuid.UUID, request: Request) -> None:
     """Raise 404 if the team does not exist."""
-    service = cast(TeamService, request.app.state.team_service)
+    service = TEAM_SERVICE.require(request)
     if service.get_team(team_id) is None:
         raise HTTPException(status_code=404, detail="Team not found")
 
@@ -102,7 +108,7 @@ def list_workspace_tree(
     """List files in a team's workspace directory."""
     logger.debug("GET /workspace/%s/tree path=%s", team_id, path)
     _validate_team(team_id, request)
-    settings = cast(CommunitySettings, request.app.state.settings)
+    settings = SETTINGS.require(request)
     ws = _get_workspace(team_id, settings, workspace_id)
     try:
         entries = ws.list(path)
@@ -125,7 +131,7 @@ def read_workspace_file(
     """Read a file from a team's workspace."""
     logger.debug("GET /workspace/%s/file path=%s", team_id, path)
     _validate_team(team_id, request)
-    settings = cast(CommunitySettings, request.app.state.settings)
+    settings = SETTINGS.require(request)
     ws = _get_workspace(team_id, settings, workspace_id)
     try:
         data = ws.read(path)
@@ -153,7 +159,7 @@ async def upload_workspace_file(
 ) -> WorkspaceFileUploadResponse:
     """Upload a file to a team's workspace."""
     await asyncio.to_thread(_validate_team, team_id, request)
-    settings = cast(CommunitySettings, request.app.state.settings)
+    settings = SETTINGS.require(request)
     ws = _get_workspace(team_id, settings, workspace_id)
     data = await file.read()
     if len(data) > _MAX_FILE_SIZE:

--- a/src/akgentic/infra/server/routes/ws.py
+++ b/src/akgentic/infra/server/routes/ws.py
@@ -15,7 +15,6 @@ import contextlib
 import logging
 import uuid
 from concurrent.futures import ThreadPoolExecutor
-from typing import cast
 
 from fastapi import APIRouter, WebSocket, WebSocketDisconnect
 from starlette.websockets import WebSocketState
@@ -25,6 +24,12 @@ from akgentic.infra.protocols.event_stream import StreamClosed, StreamReader
 from akgentic.infra.server.routes.frontend_adapter import FrontendAdapter
 from akgentic.infra.server.services.team_service import TeamService
 from akgentic.team.models import TeamStatus
+
+# NOTE: ``state_keys`` is imported lazily inside the functions below, not at
+# module top. ``state_keys`` imports ``ConnectionManager`` from THIS module to
+# type its ``CONNECTION_MANAGER`` key, so a top-level import here would form an
+# import cycle (state_keys ⇄ ws). The keys are only needed at request time, so a
+# function-local import resolves the already-cached module with no runtime cost.
 
 logger = logging.getLogger(__name__)
 
@@ -45,9 +50,11 @@ def _get_reader_pool(websocket: WebSocket) -> ThreadPoolExecutor:
 
     See issue #227.
     """
+    from akgentic.infra.server.state_keys import SETTINGS
+
     global _WS_READER_POOL
     if _WS_READER_POOL is None:
-        settings = websocket.app.state.settings
+        settings = SETTINGS.require(websocket)
         _WS_READER_POOL = ThreadPoolExecutor(
             max_workers=settings.ws_reader_pool_size,
             thread_name_prefix="ws-reader",
@@ -148,12 +155,16 @@ class ConnectionManager:
 
 def _get_team_service(ws: WebSocket) -> TeamService:
     """Extract TeamService from app.state."""
-    return cast(TeamService, ws.app.state.team_service)
+    from akgentic.infra.server.state_keys import TEAM_SERVICE
+
+    return TEAM_SERVICE.require(ws)
 
 
 def _get_connection_manager(ws: WebSocket) -> ConnectionManager:
     """Extract ConnectionManager from app.state."""
-    return cast(ConnectionManager, ws.app.state.connection_manager)
+    from akgentic.infra.server.state_keys import CONNECTION_MANAGER
+
+    return CONNECTION_MANAGER.require(ws)
 
 
 @router.websocket("/ws/{team_id}")
@@ -177,7 +188,9 @@ async def websocket_events(websocket: WebSocket, team_id: uuid.UUID) -> None:
     conn_mgr.track(websocket)
     logger.info("WebSocket connected: team_id=%s", team_id)
 
-    adapter: FrontendAdapter | None = getattr(websocket.app.state, "frontend_adapter", None)
+    from akgentic.infra.server.state_keys import FRONTEND_ADAPTER
+
+    adapter = FRONTEND_ADAPTER.get(websocket)
 
     try:
         if process.status == TeamStatus.RUNNING:

--- a/src/akgentic/infra/server/state_keys.py
+++ b/src/akgentic/infra/server/state_keys.py
@@ -1,0 +1,36 @@
+"""Typed ``app.state`` key declarations for the server tier (ADR-030 §Decision 2).
+
+Each module-level :class:`~akgentic.infra.utils.StateKey` constant pins one
+server ``app.state`` slot's name, type, default, and required-ness. Declaring a
+key *is* the registration — there is no central runtime-mutable registry. The
+keys live in the package that writes the slot (``server/app.py``'s
+``_store_state`` / ``_lifespan``) so the type contract and the producer stay
+together and no import cycle is introduced.
+
+The slot *names* are the exact attribute strings the current producers and
+consumers use against ``app.state``, so a later consumer migration (Story 34.2)
+targets byte-for-byte the same slot.
+"""
+
+from __future__ import annotations
+
+from akgentic.infra.adapters.shared.channel_parser_registry import ChannelParserRegistry
+from akgentic.infra.protocols.channels import ChannelRegistry, InteractionChannelIngestion
+from akgentic.infra.server.deps import TierServices
+from akgentic.infra.server.routes.frontend_adapter import FrontendAdapter
+from akgentic.infra.server.routes.ws import ConnectionManager
+from akgentic.infra.server.services.team_service import TeamService
+from akgentic.infra.server.settings import ServerSettings
+from akgentic.infra.utils import StateKey
+
+SERVICES: StateKey[TierServices] = StateKey("services", required=True)
+TEAM_SERVICE: StateKey[TeamService] = StateKey("team_service", required=True)
+SETTINGS: StateKey[ServerSettings] = StateKey("settings", required=True)
+CONNECTION_MANAGER: StateKey[ConnectionManager] = StateKey("connection_manager", required=True)
+CHANNEL_REGISTRY: StateKey[ChannelRegistry] = StateKey("channel_registry", required=True)
+# Soft key — defaults to None when the slot is unset.
+CHANNEL_PARSERS: StateKey[ChannelParserRegistry] = StateKey("channel_parser_registry")
+INGESTION: StateKey[InteractionChannelIngestion] = StateKey("ingestion", required=True)
+# Soft key — only set when a frontend adapter is configured.
+FRONTEND_ADAPTER: StateKey[FrontendAdapter] = StateKey("frontend_adapter")
+DRAINING: StateKey[bool] = StateKey("draining", default=False)

--- a/src/akgentic/infra/server/state_keys.py
+++ b/src/akgentic/infra/server/state_keys.py
@@ -23,14 +23,17 @@ from akgentic.infra.server.services.team_service import TeamService
 from akgentic.infra.server.settings import ServerSettings
 from akgentic.infra.utils import StateKey
 
+DRAINING: StateKey[bool] = StateKey("draining", default=False)
+
 SERVICES: StateKey[TierServices] = StateKey("services", required=True)
 TEAM_SERVICE: StateKey[TeamService] = StateKey("team_service", required=True)
 SETTINGS: StateKey[ServerSettings] = StateKey("settings", required=True)
 CONNECTION_MANAGER: StateKey[ConnectionManager] = StateKey("connection_manager", required=True)
 CHANNEL_REGISTRY: StateKey[ChannelRegistry] = StateKey("channel_registry", required=True)
-# Soft key — defaults to None when the slot is unset.
-CHANNEL_PARSERS: StateKey[ChannelParserRegistry] = StateKey("channel_parser_registry")
+CHANNEL_PARSERS: StateKey[ChannelParserRegistry] = StateKey(
+    "channel_parser_registry", required=True
+)
 INGESTION: StateKey[InteractionChannelIngestion] = StateKey("ingestion", required=True)
+
 # Soft key — only set when a frontend adapter is configured.
 FRONTEND_ADAPTER: StateKey[FrontendAdapter] = StateKey("frontend_adapter")
-DRAINING: StateKey[bool] = StateKey("draining", default=False)

--- a/src/akgentic/infra/utils.py
+++ b/src/akgentic/infra/utils.py
@@ -1,0 +1,56 @@
+"""Typed ``app.state`` access via a ``StateKey[T]`` handle (ADR-030).
+
+``app.state`` is a ``starlette.datastructures.State`` whose ``__getattr__`` is
+deliberately dynamic and typed ``Any``, so every attribute read decays to
+``Any`` and consumers paper over it with ``cast(...)``. A :class:`StateKey` is a
+serialization-free, stateless handle to one slot: it pins the slot's *name*, its
+*type* (via the generic parameter ``T``), its *default*, and whether it is
+*required*. Producers ``set`` through it; consumers ``get``/``require`` through
+it and receive a typed object — no ``cast``, no string literal at the call site.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Generic, TypeVar
+
+from fastapi import FastAPI, Request, WebSocket
+from starlette.datastructures import State
+
+T = TypeVar("T")
+
+# Typed ``Any`` so ``getattr(state, name, _MISSING)`` stays ``Any`` (matching
+# ``State.__getattr__``), keeping ``get``'s final ``return value`` a documented
+# ``no-any-return`` rather than widening the read to ``object``.
+_MISSING: Any = object()
+
+
+class StateKey(Generic[T]):  # noqa: UP046  # ADR-030 pins the classic Generic[T] form
+    """Typed handle to one slot in ``app.state`` (ADR-030)."""
+
+    __slots__ = ("name", "default", "required")
+
+    def __init__(self, name: str, *, default: T | None = None, required: bool = False) -> None:
+        self.name = name
+        self.default = default
+        self.required = required
+
+    def set(self, source: FastAPI | Request | WebSocket, value: T) -> None:
+        setattr(self._state(source), self.name, value)
+
+    def get(self, source: FastAPI | Request | WebSocket) -> T | None:
+        value = getattr(self._state(source), self.name, _MISSING)
+        if value is _MISSING:
+            if self.required:
+                raise LookupError(f"app.state.{self.name} is not set")
+            return self.default
+        return value  # type: ignore[no-any-return]  # invariant: only set() writes this slot
+
+    def require(self, source: FastAPI | Request | WebSocket) -> T:
+        value = self.get(source)
+        if value is None:
+            raise LookupError(f"app.state.{self.name} is not set")
+        return value
+
+    @staticmethod
+    def _state(source: FastAPI | Request | WebSocket) -> State:
+        return source.state if isinstance(source, FastAPI) else source.app.state

--- a/src/akgentic/infra/utils.py
+++ b/src/akgentic/infra/utils.py
@@ -35,9 +35,23 @@ class StateKey(Generic[T]):  # noqa: UP046  # ADR-030 pins the classic Generic[T
         self.required = required
 
     def set(self, source: FastAPI | Request | WebSocket, value: T) -> None:
+        """Write ``value`` into this key's ``app.state`` slot (producer side).
+
+        The only writer of the slot — :meth:`get`/:meth:`require` rely on this
+        invariant for their typed reads. ``source`` may be the ``FastAPI`` app
+        or any ``Request``/``WebSocket`` that reaches it.
+        """
         setattr(self._state(source), self.name, value)
 
     def get(self, source: FastAPI | Request | WebSocket) -> T | None:
+        """Read this key's slot, typed as ``T``, without a ``cast`` (consumer side).
+
+        Returns the stored value if present. If the slot was never ``set``,
+        raises ``LookupError`` when the key is ``required``, otherwise returns
+        ``self.default``. A ``_MISSING`` sentinel distinguishes "never set" from
+        a slot deliberately set to ``None``. See :meth:`require` for the strict,
+        non-optional variant.
+        """
         value = getattr(self._state(source), self.name, _MISSING)
         if value is _MISSING:
             if self.required:
@@ -46,6 +60,14 @@ class StateKey(Generic[T]):  # noqa: UP046  # ADR-030 pins the classic Generic[T
         return value  # type: ignore[no-any-return]  # invariant: only set() writes this slot
 
     def require(self, source: FastAPI | Request | WebSocket) -> T:
+        """Return the slot's value, raising ``LookupError`` if it is missing.
+
+        Strict counterpart to :meth:`get`: it returns a non-optional ``T`` so
+        callers need no null-check. Any ``None`` from ``get`` (absent slot, a
+        ``None`` default, or a slot explicitly set to ``None``) is turned into
+        a named ``LookupError`` so a missing dependency fails fast at the
+        access site instead of crashing later as ``NoneType``.
+        """
         value = self.get(source)
         if value is None:
             raise LookupError(f"app.state.{self.name} is not set")

--- a/src/akgentic/infra/worker/routes/teams.py
+++ b/src/akgentic/infra/worker/routes/teams.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 import logging
 import uuid
-from typing import NoReturn, cast
+from typing import NoReturn
 
 from fastapi import APIRouter, Depends, HTTPException, Request
 from pydantic import BaseModel, Field
@@ -15,6 +15,7 @@ from pydantic import BaseModel, Field
 from akgentic.core.messages.orchestrator import SentMessage
 from akgentic.infra.server.models import HumanInputRequest, SendMessageRequest, TeamResponse
 from akgentic.infra.worker.deps import WorkerServices
+from akgentic.infra.worker.state_keys import SERVICES
 from akgentic.team.models import Process, TeamCard, TeamRuntime
 from akgentic.team.ports import EventStore
 
@@ -45,7 +46,7 @@ class WorkerCreateTeamRequest(BaseModel):
 
 def get_services(request: Request) -> WorkerServices:
     """FastAPI dependency: extract WorkerServices from app.state."""
-    return cast(WorkerServices, request.app.state.services)
+    return SERVICES.require(request)
 
 
 def _process_to_response(process: Process) -> TeamResponse:

--- a/src/akgentic/infra/worker/state_keys.py
+++ b/src/akgentic/infra/worker/state_keys.py
@@ -1,0 +1,15 @@
+"""Typed ``app.state`` key declarations for the worker tier (ADR-030 §Decision 2).
+
+The worker process stores its :class:`~akgentic.infra.worker.deps.WorkerServices`
+DI container under ``app.state.services``; ``SERVICES`` is the typed handle to
+that slot. Tier-specific worker slots (department ``worker_identity`` /
+``service_registry``, enterprise ``loop_watchdog``) are declared the same way in
+their own packages — infra never sees them.
+"""
+
+from __future__ import annotations
+
+from akgentic.infra.utils import StateKey
+from akgentic.infra.worker.deps import WorkerServices
+
+SERVICES: StateKey[WorkerServices] = StateKey("services", required=True)

--- a/tests/server/routes/test_state_key_migration.py
+++ b/tests/server/routes/test_state_key_migration.py
@@ -1,0 +1,143 @@
+"""Behaviour tests for the Story 34.2 ``app.state`` → ``StateKey`` migration.
+
+These are *behaviour* tests for the migrated consumer sites (ADR-030 §Decision 2,
+§Validation): a **required** dependency raises ``LookupError`` (not
+``AttributeError``) when exercised against an app that never ran
+``_store_state``, and returns the wired service after the normal app factory; a
+**soft** slot still yields ``None`` when unset and the route path tolerates it
+exactly as before. No assertion checks for a comment/docstring/ADR string
+(Golden Rule #8); the concrete-type headline is left to ``mypy --strict`` and
+``test_state_key.py``'s ``assert_type`` coverage.
+"""
+
+from __future__ import annotations
+
+from typing import cast
+from unittest.mock import MagicMock
+
+import pytest
+from akgentic.infra.server.app import _store_state
+from akgentic.infra.server.deps import TierServices
+from akgentic.infra.server.routes.teams import get_team_service
+from akgentic.infra.server.routes.webhook import get_channel_parser_registry
+from akgentic.infra.server.routes.webhook import router as webhook_router
+from akgentic.infra.server.services.team_service import TeamService
+from akgentic.infra.server.settings import ServerSettings
+from akgentic.infra.server.state_keys import CHANNEL_PARSERS, FRONTEND_ADAPTER
+from akgentic.infra.worker.deps import WorkerServices
+from akgentic.infra.worker.routes.teams import get_services as worker_get_services
+from akgentic.infra.worker.state_keys import SERVICES as WORKER_SERVICES
+from fastapi import FastAPI, Request
+from fastapi.testclient import TestClient
+
+from tests.server.routes.test_webhook_route import StubIngestion
+
+
+class _RequestStub:
+    """Minimal ``Request``-shaped source exposing ``.app`` for ``StateKey._state``.
+
+    ``StateKey._state`` resolves ``source.app.state`` for any non-``FastAPI``
+    source, so a stub carrying the target app is enough to drive a dependency
+    getter without spinning up a real request scope (mirrors
+    ``test_state_key.py``'s ``_AppStub``).
+    """
+
+    def __init__(self, app: FastAPI) -> None:
+        self.app = app
+
+
+# --- AC 20/22: required consumer raises LookupError on a bare app ----------
+
+
+def test_get_team_service_raises_lookup_error_on_bare_app() -> None:
+    """A bare FastAPI (never ran ``_store_state``) makes the required server
+    dependency raise ``LookupError``, not ``AttributeError``."""
+    request = cast(Request, _RequestStub(FastAPI()))
+    with pytest.raises(LookupError):
+        get_team_service(request)
+
+
+def test_get_team_service_returns_wired_service(client: TestClient) -> None:
+    """After the normal ``create_app`` (which runs ``_store_state``), the
+    required server dependency returns the wired ``TeamService``."""
+    request = cast(Request, _RequestStub(cast(FastAPI, client.app)))
+    assert isinstance(get_team_service(request), TeamService)
+
+
+def test_worker_get_services_raises_lookup_error_on_bare_app() -> None:
+    """The worker ``get_services`` raises ``LookupError`` on a bare worker app
+    that never had its ``services`` slot set."""
+    request = cast(Request, _RequestStub(FastAPI()))
+    with pytest.raises(LookupError):
+        worker_get_services(request)
+
+
+def test_worker_get_services_returns_wired_services() -> None:
+    """Once the worker ``SERVICES`` slot is set, ``get_services`` returns it."""
+    app = FastAPI()
+    services = cast(WorkerServices, MagicMock())
+    WORKER_SERVICES.set(app, services)
+    request = cast(Request, _RequestStub(app))
+    assert worker_get_services(request) is services
+
+
+# --- AC 19/23: soft slot stays None when unset; route tolerates it ----------
+
+
+def test_channel_parsers_get_is_none_when_unset() -> None:
+    """The soft ``CHANNEL_PARSERS`` slot resolves to ``None`` (not a raise) when
+    the producer never set it — preserving the historical soft read."""
+    request = cast(Request, _RequestStub(FastAPI()))
+    assert get_channel_parser_registry(request) is None
+
+
+def test_frontend_adapter_get_is_none_when_unset() -> None:
+    """The soft ``FRONTEND_ADAPTER`` slot resolves to ``None`` when unset, so the
+    WS handler runs its unwrapped-event-send path exactly as before."""
+    request = cast(Request, _RequestStub(FastAPI()))
+    assert FRONTEND_ADAPTER.get(request) is None
+
+
+def _build_webhook_app_without_parser_registry() -> FastAPI:
+    """Webhook app with the required slots set but the soft parser registry left
+    unset, so ``CHANNEL_PARSERS.get`` returns ``None`` at request time."""
+    app = FastAPI()
+    # The two required webhook slots must be present so their ``.require`` does
+    # not raise before the soft-registry guard runs — FastAPI resolves all three
+    # dependencies up front, before the handler body.
+    app.state.channel_registry = MagicMock()
+    app.state.ingestion = StubIngestion()
+    app.include_router(webhook_router)
+    return app
+
+
+def test_webhook_returns_500_when_parser_registry_unset() -> None:
+    """With no parser registry configured the webhook surfaces a deliberate 500
+    (D3): byte-equivalent to the historical ``None`` cast then ``AttributeError``
+    → 500, now an explicit ``HTTPException(500)``."""
+    client = TestClient(_build_webhook_app_without_parser_registry())
+    resp = client.post("/webhook/some-channel", json={"text": "hi"})
+    assert resp.status_code == 500
+
+
+# --- AC 1: producer leaves the soft parser-registry slot None when absent ----
+
+
+def test_store_state_leaves_channel_parsers_none_when_services_lacks_it() -> None:
+    """``_store_state`` must NOT raise when the services container has no
+    ``channel_parser_registry`` attribute, and ``CHANNEL_PARSERS.get`` must read
+    back ``None`` — byte-identical to the historical ``getattr(..., None)``
+    store. (A base ``TierServices`` deployment has no channel parsers.)"""
+    app = FastAPI()
+    services = MagicMock(spec=["channel_registry", "ingestion"])
+    services.channel_registry = MagicMock()
+    services.ingestion = StubIngestion()
+
+    _store_state(
+        app,
+        cast(TierServices, services),
+        cast(TeamService, MagicMock()),
+        ServerSettings(),
+    )
+
+    assert CHANNEL_PARSERS.get(app) is None

--- a/tests/server/routes/test_state_key_migration.py
+++ b/tests/server/routes/test_state_key_migration.py
@@ -81,14 +81,16 @@ def test_worker_get_services_returns_wired_services() -> None:
     assert worker_get_services(request) is services
 
 
-# --- AC 19/23: soft slot stays None when unset; route tolerates it ----------
+# --- AC 19/23: required parser-registry raises; surviving soft slot stays None
 
 
-def test_channel_parsers_get_is_none_when_unset() -> None:
-    """The soft ``CHANNEL_PARSERS`` slot resolves to ``None`` (not a raise) when
-    the producer never set it — preserving the historical soft read."""
+def test_get_channel_parser_registry_raises_when_unset() -> None:
+    """``CHANNEL_PARSERS`` is required: the webhook dependency raises
+    ``LookupError`` (via ``.require()``) when the producer never set the slot,
+    rather than returning a silent ``None``."""
     request = cast(Request, _RequestStub(FastAPI()))
-    assert get_channel_parser_registry(request) is None
+    with pytest.raises(LookupError):
+        get_channel_parser_registry(request)
 
 
 def test_frontend_adapter_get_is_none_when_unset() -> None:
@@ -99,12 +101,12 @@ def test_frontend_adapter_get_is_none_when_unset() -> None:
 
 
 def _build_webhook_app_without_parser_registry() -> FastAPI:
-    """Webhook app with the required slots set but the soft parser registry left
-    unset, so ``CHANNEL_PARSERS.get`` returns ``None`` at request time."""
+    """Webhook app with the other required slots set but the parser registry left
+    unset, so ``CHANNEL_PARSERS.require`` raises ``LookupError`` at request time."""
     app = FastAPI()
-    # The two required webhook slots must be present so their ``.require`` does
-    # not raise before the soft-registry guard runs — FastAPI resolves all three
-    # dependencies up front, before the handler body.
+    # The other two required webhook slots are present so the failure is isolated
+    # to the missing parser registry — FastAPI resolves all three dependencies up
+    # front, before the handler body.
     app.state.channel_registry = MagicMock()
     app.state.ingestion = StubIngestion()
     app.include_router(webhook_router)
@@ -112,22 +114,28 @@ def _build_webhook_app_without_parser_registry() -> FastAPI:
 
 
 def test_webhook_returns_500_when_parser_registry_unset() -> None:
-    """With no parser registry configured the webhook surfaces a deliberate 500
-    (D3): byte-equivalent to the historical ``None`` cast then ``AttributeError``
-    → 500, now an explicit ``HTTPException(500)``."""
-    client = TestClient(_build_webhook_app_without_parser_registry())
+    """With no parser registry configured the webhook surfaces a 500: the
+    required ``CHANNEL_PARSERS.require()`` raises ``LookupError`` in the
+    dependency, which an ASGI server turns into a 500 (no ``HTTPException`` and
+    no "Channel parsing not configured" detail). ``raise_server_exceptions=False``
+    makes the TestClient return the server's 500 instead of re-raising."""
+    client = TestClient(
+        _build_webhook_app_without_parser_registry(),
+        raise_server_exceptions=False,
+    )
     resp = client.post("/webhook/some-channel", json={"text": "hi"})
     assert resp.status_code == 500
 
 
-# --- AC 1: producer leaves the soft parser-registry slot None when absent ----
+# --- AC 1: producer leaves the parser-registry slot unset when absent --------
 
 
-def test_store_state_leaves_channel_parsers_none_when_services_lacks_it() -> None:
+def test_store_state_leaves_channel_parsers_unset_when_services_lacks_it() -> None:
     """``_store_state`` must NOT raise when the services container has no
-    ``channel_parser_registry`` attribute, and ``CHANNEL_PARSERS.get`` must read
-    back ``None`` — byte-identical to the historical ``getattr(..., None)``
-    store. (A base ``TierServices`` deployment has no channel parsers.)"""
+    ``channel_parser_registry`` attribute (a base ``TierServices`` deployment has
+    no channel parsers): it simply leaves the slot unset. Because
+    ``CHANNEL_PARSERS`` is now required, a later read raises ``LookupError``
+    rather than reading back a silent ``None``."""
     app = FastAPI()
     services = MagicMock(spec=["channel_registry", "ingestion"])
     services.channel_registry = MagicMock()
@@ -140,4 +148,5 @@ def test_store_state_leaves_channel_parsers_none_when_services_lacks_it() -> Non
         ServerSettings(),
     )
 
-    assert CHANNEL_PARSERS.get(app) is None
+    with pytest.raises(LookupError):
+        CHANNEL_PARSERS.require(app)

--- a/tests/server/routes/test_webhook_route.py
+++ b/tests/server/routes/test_webhook_route.py
@@ -162,7 +162,7 @@ class TestWebhookReplyFlow:
 
 
 class TestWebhookContinuationFlow:
-    """AC #4: no team_id but registered team → route_reply."""
+    """AC #4: no team_id but registered team → route_reply (forwarding message_id)."""
 
     async def test_continuation_flow_calls_route_reply(self, tmp_path: Path) -> None:
         existing_team_id = uuid.uuid4()
@@ -171,6 +171,7 @@ class TestWebhookContinuationFlow:
             ChannelMessage(
                 content="continuation msg",
                 channel_user_id="user-2",
+                message_id="msg-cont",
             )
         )
         ingestion = StubIngestion()
@@ -186,6 +187,9 @@ class TestWebhookContinuationFlow:
         call = ingestion.route_reply_calls[0]
         assert call[0] == existing_team_id
         assert call[1] == "continuation msg"
+        # Story 30.3: the continuation flow forwards the parsed message_id as the
+        # third positional arg, in lockstep with the reply flow (TestWebhookReplyFlow).
+        assert call[2] == "msg-cont"
 
 
 class TestWebhookInitiationFlow:

--- a/tests/server/test_lifespan.py
+++ b/tests/server/test_lifespan.py
@@ -7,7 +7,6 @@ from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-
 from akgentic.infra.server.app import _lifespan
 
 
@@ -29,11 +28,19 @@ def _make_app_state(
     services = SimpleNamespace(worker_handle=worker_handle)
 
     app = MagicMock()
-    app.state = SimpleNamespace(
+    state = SimpleNamespace(
         settings=settings,
         connection_manager=connection_manager,
         services=services,
     )
+    app.state = state
+    # ``_lifespan`` now reads/writes through ``StateKey`` handles (ADR-030).
+    # ``StateKey._state`` takes ``source.state`` only for a real ``FastAPI``;
+    # for any other source it resolves ``source.app.state``. This stub is a
+    # ``MagicMock`` (not a ``FastAPI``), so point ``app.app`` back at ``app`` to
+    # make ``app.app.state`` the same namespace the assertions read on
+    # ``app.state`` — behaviour-identical to the pre-migration attribute access.
+    app.app = app
     return app
 
 

--- a/tests/test_state_key.py
+++ b/tests/test_state_key.py
@@ -85,8 +85,17 @@ def test_get_on_required_unset_raises() -> None:
 
 def test_soft_get_returns_none_default_when_unset() -> None:
     app = FastAPI()
-    assert CHANNEL_PARSERS.get(app) is None
+    # FRONTEND_ADAPTER is the surviving soft slot — its unset read is the None
+    # default (CHANNEL_PARSERS is now required; see the LookupError test below).
     assert FRONTEND_ADAPTER.get(app) is None
+
+
+def test_channel_parsers_get_raises_when_unset() -> None:
+    # CHANNEL_PARSERS is now required: an unset slot raises LookupError rather
+    # than reading back a silent None default.
+    app = FastAPI()
+    with pytest.raises(LookupError):
+        CHANNEL_PARSERS.get(app)
 
 
 def test_draining_returns_false_default_before_startup() -> None:
@@ -191,7 +200,7 @@ def test_server_keys_declare_expected_names_and_flags() -> None:
         (SETTINGS, "settings", True, None),
         (CONNECTION_MANAGER, "connection_manager", True, None),
         (CHANNEL_REGISTRY, "channel_registry", True, None),
-        (CHANNEL_PARSERS, "channel_parser_registry", False, None),
+        (CHANNEL_PARSERS, "channel_parser_registry", True, None),
         (INGESTION, "ingestion", True, None),
         (FRONTEND_ADAPTER, "frontend_adapter", False, None),
         (DRAINING, "draining", False, False),

--- a/tests/test_state_key.py
+++ b/tests/test_state_key.py
@@ -1,0 +1,225 @@
+"""Behaviour tests for the ``StateKey[T]`` factory (ADR-030 §Decision 1).
+
+Tests assert behaviour only — construction, get/set/require return values, the
+unset-vs-set-to-None distinction, ``LookupError`` on required/None slots, soft
+defaults, and ``_state`` resolution off a ``Request``/``WebSocket``-shaped
+source. The typing headline (a keyed read returns the concrete type, not
+``Any``) is encoded with ``typing.assert_type`` and verified by ``mypy
+--strict``, never by asserting on a source/docstring string (Golden Rule #8).
+"""
+
+from __future__ import annotations
+
+from typing import Any, assert_type, cast
+from unittest.mock import MagicMock
+
+import pytest
+from akgentic.infra.server import state_keys as server_keys
+from akgentic.infra.server.deps import TierServices
+from akgentic.infra.server.state_keys import (
+    CHANNEL_PARSERS,
+    CHANNEL_REGISTRY,
+    CONNECTION_MANAGER,
+    DRAINING,
+    FRONTEND_ADAPTER,
+    INGESTION,
+    SERVICES,
+    SETTINGS,
+    TEAM_SERVICE,
+)
+from akgentic.infra.utils import StateKey
+from akgentic.infra.worker import state_keys as worker_keys
+from akgentic.infra.worker.deps import WorkerServices
+from fastapi import FastAPI, Request
+
+
+def _services_stub() -> TierServices:
+    """A non-None value typed as ``TierServices`` for the require() typing check.
+
+    The typing assertion only needs ``require`` to return a non-``None`` value of
+    the declared type; a real DI container (many protocol-typed fields) is not
+    required, so a typed ``MagicMock`` stands in.
+    """
+    return cast(TierServices, MagicMock())
+
+
+class _AppStub:
+    """Minimal stand-in exposing ``.app.state`` like a ``Request``/``WebSocket``.
+
+    ``StateKey._state`` only needs ``source.app.state`` for the non-``FastAPI``
+    branch; this avoids spinning up a full request/connection scope just to
+    exercise that resolution path.
+    """
+
+    def __init__(self, app: FastAPI) -> None:
+        self.app = app
+
+
+# --- AC 14: required key raises on unset, returns value after set ----------
+
+
+def test_require_raises_lookup_error_on_bare_app() -> None:
+    app = FastAPI()
+    with pytest.raises(LookupError):
+        SERVICES.require(app)
+
+
+def test_require_returns_value_after_set() -> None:
+    app = FastAPI()
+    sentinel = object()
+    key: StateKey[object] = StateKey("services", required=True)
+    key.set(app, sentinel)
+    assert key.require(app) is sentinel
+
+
+def test_get_on_required_unset_raises() -> None:
+    # required=True makes get itself raise on an unset slot (distinct from
+    # set-to-None, which get returns as the value).
+    app = FastAPI()
+    with pytest.raises(LookupError):
+        SERVICES.get(app)
+
+
+# --- AC 15: soft get returns the key default when unset --------------------
+
+
+def test_soft_get_returns_none_default_when_unset() -> None:
+    app = FastAPI()
+    assert CHANNEL_PARSERS.get(app) is None
+    assert FRONTEND_ADAPTER.get(app) is None
+
+
+def test_draining_returns_false_default_before_startup() -> None:
+    app = FastAPI()
+    assert DRAINING.get(app) is False
+
+
+def test_soft_get_returns_stored_value_after_set() -> None:
+    app = FastAPI()
+    DRAINING.set(app, value=True)
+    assert DRAINING.get(app) is True
+
+
+# --- AC 16: set/get round-trip and _state resolution ----------------------
+
+
+def test_set_get_round_trip_on_fastapi() -> None:
+    app = FastAPI()
+    key: StateKey[int] = StateKey("answer")
+    key.set(app, 42)
+    assert key.get(app) == 42
+
+
+def test_state_resolves_via_app_for_request_like_source() -> None:
+    app = FastAPI()
+    key: StateKey[str] = StateKey("token", required=True)
+    # _state only reads source.app.state for the non-FastAPI branch; a stub with
+    # an .app attribute exercises that path without a full request scope. The cast
+    # narrows the static type to the accepted Request shape.
+    request_like = cast(Request, _AppStub(app))
+    # set/get through a Request/WebSocket-shaped source go through source.app.state,
+    # which is the same State the FastAPI app exposes directly.
+    key.set(request_like, "abc")
+    assert key.get(request_like) == "abc"
+    assert key.require(request_like) == "abc"
+    # And the value is visible on the app's own .state (single underlying State).
+    assert key.get(app) == "abc"
+
+
+# --- AC 5/6: unset vs set-to-None distinction; require rejects None --------
+
+
+def test_get_returns_none_when_slot_explicitly_set_to_none() -> None:
+    app = FastAPI()
+    key: StateKey[object | None] = StateKey("maybe")
+    key.set(app, None)
+    # Slot is set (to None), so get returns the stored value, not LookupError.
+    assert key.get(app) is None
+
+
+def test_require_raises_when_value_is_none() -> None:
+    app = FastAPI()
+    key: StateKey[object | None] = StateKey("maybe")
+    key.set(app, None)
+    with pytest.raises(LookupError):
+        key.require(app)
+
+
+def test_soft_get_returns_explicit_default_when_unset() -> None:
+    app = FastAPI()
+    key: StateKey[str] = StateKey("greeting", default="hi")
+    assert key.get(app) == "hi"
+
+
+# --- AC 2: serialization-free / stateless construction --------------------
+
+
+def test_state_key_is_slotted_and_stores_only_three_attrs() -> None:
+    key: StateKey[int] = StateKey("n", default=7, required=False)
+    assert key.name == "n"
+    assert key.default == 7
+    assert key.required is False
+    assert StateKey.__slots__ == ("name", "default", "required")
+    # __slots__ means no per-instance __dict__ — nothing else can be stored.
+    assert not hasattr(key, "__dict__")
+
+
+# --- AC 17: typing headline (checked by mypy --strict, not at runtime) ------
+
+
+def test_keyed_read_is_typed_not_any() -> None:
+    app = FastAPI()
+    # These assert_type calls are static assertions verified by mypy --strict:
+    # a soft get returns the concrete ``T | None`` and require returns ``T``.
+    assert_type(DRAINING.get(app), bool | None)
+    DRAINING.set(app, value=False)
+    assert_type(DRAINING.require(app), bool)
+    SERVICES.set(app, _services_stub())
+    assert_type(SERVICES.require(app), TierServices)
+
+
+# --- AC 7: server-tier key declarations (name + required/default flags) -----
+
+
+def test_server_keys_declare_expected_names_and_flags() -> None:
+    # StateKey is invariant in T, so the heterogeneous declarations are collected
+    # as StateKey[Any]; only the name/required/default fields are asserted here.
+    # (key, expected slot name, expected required, expected default)
+    expected: list[tuple[StateKey[Any], str, bool, object]] = [
+        (SERVICES, "services", True, None),
+        (TEAM_SERVICE, "team_service", True, None),
+        (SETTINGS, "settings", True, None),
+        (CONNECTION_MANAGER, "connection_manager", True, None),
+        (CHANNEL_REGISTRY, "channel_registry", True, None),
+        (CHANNEL_PARSERS, "channel_parser_registry", False, None),
+        (INGESTION, "ingestion", True, None),
+        (FRONTEND_ADAPTER, "frontend_adapter", False, None),
+        (DRAINING, "draining", False, False),
+    ]
+    for key, name, required, default in expected:
+        assert key.name == name
+        assert key.required is required
+        assert key.default == default
+
+
+def test_server_keys_module_exposes_nine_state_keys() -> None:
+    keys = [v for v in vars(server_keys).values() if isinstance(v, StateKey)]
+    assert len(keys) == 9
+
+
+# --- AC 9: worker-tier key declaration --------------------------------------
+
+
+def test_worker_services_key_declaration() -> None:
+    assert worker_keys.SERVICES.name == "services"
+    assert worker_keys.SERVICES.required is True
+    assert worker_keys.SERVICES.default is None
+
+
+def test_worker_services_key_round_trip() -> None:
+    app = FastAPI()
+    with pytest.raises(LookupError):
+        worker_keys.SERVICES.require(app)
+    services = cast(WorkerServices, MagicMock())
+    worker_keys.SERVICES.set(app, services)
+    assert worker_keys.SERVICES.require(app) is services


### PR DESCRIPTION
## Epic 34 — Typed `app.state` via a `StateKey[T]` Registry (ADR-030)

Umbrella PR for Epic 34. `app.state` is a Starlette `State` whose `__getattr__` is typed `Any`, so every read decays to `Any` and consumers paper over it with `cast(...)`. This epic introduces a serialization-free, stateless `StateKey[T]` handle that pins each slot's name, type, default, and required-ness — so producers `set` through it and consumers `get`/`require` a typed object, with no `cast` or string literal at the call site.

ADR for context: `_bmad-output/akgentic-infra/decisions/adr-030-typed-app-state-via-statekey-registry.md`

### Stories

- [x] `34-1-statekey-factory-and-key-declarations` — `StateKey[T]` factory + per-tier key declarations (Relates to #306)
- [x] `34-2-migrate-infra-server-and-worker-state-access-to-keys` — migrate infra server + worker state access to keys (Relates to #308)
- [x] `34-3-architecture-and-readme-update` — architecture + README update (Relates to #309)
- [x] `34-4-finalize-staged-channel-parsers-required-and-webhook-hardening` — `CHANNEL_PARSERS` required + StateKey docstrings + webhook hardening (Relates to #310)
- [x] `30-3-webhook-continuation-flow-forward-message-id` — continuation flow forwards `message_id` (landed in commit `86186a1` / #310)

### Review status

**34-1 — Approved (Rex / Dev Code Reviewer).** Commit `6eeb2f6`, +332 lines across 4 new files.

- All 17 ACs implemented; all 5 `[x]` tasks verified against the actual files.
- Slot names verified byte-for-byte against the producers (`_store_state`, `_lifespan`, `frontend_adapter`) so the later consumer migration (34-2) targets the same slots.
- Two documented deviations judged sound and behaviour-neutral: `_MISSING: Any` (keeps the single permitted `# type: ignore[no-any-return]` correctly-coded — mypy `--strict` fired no `unused-ignore`) and `# noqa: UP046` (keeps the classic `Generic[T]` form the ADR pins).
- No HIGH/MEDIUM findings; one LOW note (a structural 9-key count guard) judged acceptable.
- Local gate green: `ruff check` + `ruff format --check` clean, `mypy --strict` clean on all 4 files, `pytest` 1508 passed / 39 skipped / 0 failed, coverage 90.05% (the three new src modules at 100%).

**34-2 — PASS (Rex / Dev Code Reviewer).** Commit `f916ae1`, +244/-43 across 8 files (6 src + 2 test). No fixup needed — no fix-worthy defect in the diff.

- All 27 ACs verified against the actual source and the frozen 34-1 `StateKey` contract; all 5 `[x]` tasks confirmed done. The migration is faithful, mechanical, and behaviour-preserving.
- Decisions D1/D2/D3 implemented exactly as documented: `workspace.py` retyped to `ServerSettings` with a defensive `getattr(settings, "workspaces_root", Path("workspaces"))` byte-identical to the producer's own read at `app.py:84`; `restore_team` keeps the conn-mgr guard with `CONNECTION_MANAGER.get`; `get_channel_parser_registry` returns `... | None` with an explicit 500 guard preserving the historical effective-500.
- The `ws ⇄ state_keys` import cycle (state_keys imports `ConnectionManager` from ws) is correctly broken with function-local imports matching the existing codebase idiom; justified in a module comment. The `CHANNEL_PARSERS` guarded producer-set is byte-identical for a soft `default=None` key whose only consumer uses `.get`.
- Behaviour preserved: soft `DRAINING default=False` keeps the un-migrated readiness consumers (`getattr(..., "draining", False)`) identical (slot name + default unchanged); required slots raise `LookupError` not `AttributeError`; soft slots return `None` when unset. No `cast`/`Any` introduced; F401 clean.
- Local gate green: `ruff check src/` clean, `mypy --strict` clean (111 src files), `pytest packages/akgentic-infra/tests/` 1516 passed / 39 skipped / 0 failed, coverage 90.09% ≥ 90% (`webhook.py`/`workspace.py`/`state_keys.py`/`utils.py` at 100%).
- Two non-blocking notes for the lead (not 34-2 defects): (1) 4 `app.state` sites in `readiness.py`/`worker/readiness.py`/`_admin_mutation_log.py`/`angular_v1/router.py` remain un-migrated, deliberately out of the story's declared 6-file scope with behaviour fully preserved — a completeness follow-up, not an AC gap; (2) pre-existing `ruff format` drift in `worker/routes/teams.py:147-163` (present at base `6eeb2f6`, outside the diff; CI does not run `ruff format --check`, so it is not a gate).

**34-3 — PASS (Rex / Dev Code Reviewer).** Commit `76c3c01`, +35 lines, `README.md` only. Docs-only — no fixup needed; the prose is byte-accurate against the frozen 34-1/34-2 source.

- README `StateKey` section verified claim-by-claim against the frozen source: `set`/`get`/`require` + the `StateKey("name", *, default=..., required=...)` constructor (`utils.py:32-56`); the producer/consumer example (`SERVICES.set`/`TEAM_SERVICE.set` at `app.py:206-207`, `TEAM_SERVICE.require(request)` at `teams.py:33`); the soft defaults; the `Depends` bridge (`get_team_service` at `teams.py:31-33`); the key-lives-with-its-producer rule incl. the dual `SERVICES`/`WorkerServices` distinction (`worker/state_keys.py:15`). No invented symbol.
- Source Layout tree correctly adds `utils.py` at the `infra/` level and `state_keys.py` under both `server/` and `worker/`.
- Golden Rule #8 honored: ADR-030 appears only as a prose navigation aid in the README — no test asserts on the string, no code branches on it (there is no code/test in this story).
- Companion architecture shard `_bmad-output/akgentic-infra/architecture/04-project-structure.md` (root-repo planning doc, NOT part of this submodule commit by design) verified to match, incl. the `ws ⇄ state_keys` lazy-import cycle note (`ws.py:28-32,53`) and the top-level imports in `teams.py`/`webhook.py`/`workspace.py`.
- Scope: `76c3c01` touches `README.md` only; nothing under `akgentic-infra-department`/`akgentic-infra-enterprise`. The department/enterprise follow-up pointer (infra-department migration plan) is present in both docs.
- Local gate green: `ruff check src/` clean, `mypy --strict` clean (112 src files), `pytest packages/akgentic-infra/tests/` 1516 passed / 39 skipped / 0 failed, coverage 90.04% ≥ 90% (src unchanged vs 34-2). One single-test timing flake confirmed non-deterministic (passed in isolation + on a clean full-suite re-run; unrelated to this docs-only change).

### Scope guard

All changes across the stories stay inside `packages/akgentic-infra/`. No edits to `akgentic-infra-department` / `akgentic-infra-enterprise` (Golden Rule #4). The shipped files: `src/akgentic/infra/utils.py`, `src/akgentic/infra/server/state_keys.py`, `src/akgentic/infra/worker/state_keys.py`, the migrated server/worker producers + consumers, `tests/`, and `README.md`. The `04-project-structure.md` architecture shard is a root-repo planning doc, edited in place by design and not part of this submodule PR.

## Epic 34 slice complete

The factory + migration + docs landed:

- **34-1** — `StateKey[T]` factory (`utils.py`) + the per-tier key declarations (9 server keys in `server/state_keys.py`, 1 worker `SERVICES` key in `worker/state_keys.py`).
- **34-2** — migrated `akgentic-infra`'s own server + worker producers (`_store_state`, `_lifespan`, `frontend_adapter`) and consumers off `cast`/`getattr` onto the typed keys — behaviour byte-unchanged.
- **34-3** — documented the pattern in the package `README.md` and the `04-project-structure.md` architecture shard.

Completeness follow-up (out of this epic's scope, behaviour fully preserved): four residual `cast`/`getattr` `app.state` sites remain un-migrated — `server/routes/readiness.py`, `worker/routes/readiness.py`, `server/routes/_admin_mutation_log.py`, and `frontend_adapter/angular_v1/router.py`. Migrating them is a separate, optional cleanup, not an AC gap (34-4 did not touch them).

Department/enterprise adoption of the infra keys is an explicitly-tracked follow-up on their own submodule branches/PRs (Golden Rule #4) — see `_bmad-output/akgentic-infra-department/migration-plan-lift-shared-auth-and-http-helpers-to-akgentic-infra.md`.

## Epic 34 finalization — Story 34-4 + Story 30-3 (commit `86186a1`)

The spec-compliance review of Epic 34 raised whether `CHANNEL_PARSERS` should be soft (the ADR's original draft) or required. **Adjudicated by the owner:** the channel-parser registry is never legitimately `None` on a webhook-serving tier, so `required=True` + a loud `LookupError` is the intended design — **ADR-030 §Decision 2 was corrected** to specify this. Story 34-4 finalizes the staged cleanup that implements it, and lands Story 30-3 in the same commit.

- **34-4** — `CHANNEL_PARSERS` → `StateKey(..., required=True)`; `webhook.get_channel_parser_registry` → `.require()` (non-optional, the dead `None`→500 block removed); `StateKey.set/get/require` docstrings added; the producer comment + dependency docstring corrected from "soft/`None`" to required semantics. Closes the compliance-review's optional doc-coherence item.
- **30-3** — the webhook **continuation** flow now forwards `message.message_id` to `route_reply` (lockstep with the reply flow), so enterprise/Dapr replies route to `/human-input` (resolving the outstanding `SentMessage` by inner id) instead of `/message`.

**Tests fixed:** the "no parser registry" path now asserts `require()`→`LookupError`→500 (old `detail="Channel parsing not configured"` assertion removed); soft-default coverage moved to `FRONTEND_ADAPTER`/`DRAINING`; a continuation-flow test asserts `route_reply`'s third positional arg equals the parsed `message_id` (reply-flow assertion kept, lockstep). Local gate green: `pytest` 1517 passed / 39 skipped, coverage 90.04% ≥ 90%, `ruff` + `mypy --strict` clean on `src/`. Review verdict: PASS, no fixup commit.

> The 34-1/34-2 review notes above predate this adjudication and describe `CHANNEL_PARSERS` as a "soft `default=None`" key — that is superseded by 34-4 (`required=True`). The four residual un-migrated `app.state` sites remain a separate optional completeness follow-up.

Relates to #306
