### PR TITLE
feat(akgentic-infra): 24-2 lift runtime_cache.store into shared worker create_team handler

### DIFF
--- a/src/akgentic/infra/worker/routes/teams.py
+++ b/src/akgentic/infra/worker/routes/teams.py
@@ -13,6 +13,7 @@ from fastapi import APIRouter, Depends, HTTPException, Request
 from pydantic import BaseModel, Field
 
 from akgentic.core.messages.orchestrator import SentMessage
+from akgentic.infra.adapters.community.local_team_handle import LocalTeamHandle
 from akgentic.infra.server.models import HumanInputRequest, SendMessageRequest, TeamResponse
 from akgentic.infra.worker.deps import WorkerServices
 from akgentic.infra.worker.state_keys import SERVICES
@@ -93,6 +94,13 @@ def create_team(
         team_id=body.team_id,
         catalog_namespace=body.catalog_namespace,
     )
+
+    # Make the team reachable by this router's message / human-input routes,
+    # which all resolve the live handle via runtime_cache.get (ADR-001 Decision 1;
+    # mirrors resume_team's store). Without this, every post-create call 404s.
+    handle = LocalTeamHandle(runtime)
+    services.runtime_cache.store(runtime.id, handle)
+
     process = services.worker_handle.get_team(runtime.id)
     if process is None:  # pragma: no cover
         msg = f"Team {runtime.id} was created but not found in event store"
@@ -147,9 +155,7 @@ def send_message_from_to(
     services: WorkerServices = Depends(get_services),
 ) -> None:
     """Send a message from a specific agent to another agent."""
-    logger.info(
-        "POST /teams/%s/message/from/%s/to/%s", team_id, sender_name, recipient_name
-    )
+    logger.info("POST /teams/%s/message/from/%s/to/%s", team_id, sender_name, recipient_name)
     handle = services.runtime_cache.get(team_id)
     if handle is None:
         raise HTTPException(status_code=404, detail="Team not found in worker cache")
@@ -159,9 +165,7 @@ def send_message_from_to(
         _raise_action_error(exc)
 
 
-def _find_message(
-    event_store: EventStore, team_id: uuid.UUID, message_id: str
-) -> SentMessage:
+def _find_message(event_store: EventStore, team_id: uuid.UUID, message_id: str) -> SentMessage:
     """Find a SentMessage by its inner ``message.id`` in persisted events.
 
     Resolution is by the **inner** ``SentMessage.message.id`` — the id a

--- a/tests/worker/test_routes_teams.py
+++ b/tests/worker/test_routes_teams.py
@@ -1,0 +1,201 @@
+"""Shared worker team-route tests — create-team populates the runtime cache.
+
+These tests pin ADR-001 Story 1: the shared ``create_team`` handler must wrap
+the new runtime in a ``LocalTeamHandle`` and ``runtime_cache.store`` it before
+returning, so that every other route on the same router — all of which resolve
+the live handle via ``runtime_cache.get`` — can reach the freshly created team.
+Without the store, a follow-up ``POST /teams/{id}/message`` 404s on a cache miss.
+
+The handlers are exercised directly (the existing worker-route test style) with
+a real ``LocalRuntimeCache`` and lightweight stubs for the team manager and
+worker handle, so the assertion is on the genuine cache interaction.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+from types import SimpleNamespace
+
+import pytest
+from akgentic.team.models import Process, TeamCard, TeamStatus
+
+from akgentic.infra.adapters.community.local_runtime_cache import LocalRuntimeCache
+from akgentic.infra.adapters.community.local_team_handle import LocalTeamHandle
+from akgentic.infra.server.models import SendMessageRequest
+from akgentic.infra.worker.routes.teams import (
+    WorkerCreateTeamRequest,
+    create_team,
+    send_message,
+)
+
+_TEAM_CARD_PAYLOAD = {
+    "name": "Test Team",
+    "description": "worker-route test team",
+    "entry_point": {
+        "card": {
+            "role": "Human",
+            "description": "Human user interface",
+            "skills": [],
+            "agent_class": "akgentic.core.agent.Akgent",
+            "config": {"name": "@Human", "role": "Human"},
+            "routes_to": ["@Manager"],
+        },
+        "headcount": 1,
+        "members": [],
+    },
+    "members": [
+        {
+            "card": {
+                "role": "Manager",
+                "description": "Test manager agent",
+                "skills": ["coordination"],
+                "agent_class": "akgentic.core.agent.Akgent",
+                "config": {"name": "@Manager", "role": "Manager"},
+                "routes_to": [],
+            },
+            "headcount": 1,
+            "members": [],
+        },
+    ],
+    "message_types": [{"__type__": "akgentic.core.messages.UserMessage"}],
+    "agent_profiles": [],
+}
+
+
+class _FakeRuntime:
+    """Stand-in for ``TeamRuntime`` exposing only what ``LocalTeamHandle`` uses.
+
+    ``LocalTeamHandle`` reads ``runtime.id`` and delegates ``send`` to it; a
+    full actor-backed ``TeamRuntime`` is unnecessary for a route-level cache test.
+    """
+
+    def __init__(self, team_id: uuid.UUID) -> None:
+        self.id = team_id
+        self.sent: list[str] = []
+
+    def send(self, content: str) -> None:
+        self.sent.append(content)
+
+
+def _build_team_card() -> TeamCard:
+    """Build a validated minimal TeamCard for the worker create request."""
+    return TeamCard.model_validate(_TEAM_CARD_PAYLOAD)
+
+
+def _build_process(team_id: uuid.UUID, team_card: TeamCard) -> Process:
+    """Build the persisted Process metadata the worker handle returns."""
+    now = datetime.now(UTC)
+    return Process(
+        team_id=team_id,
+        team_card=team_card,
+        status=TeamStatus.RUNNING,
+        user_id="user-1",
+        created_at=now,
+        updated_at=now,
+    )
+
+
+def _build_services(
+    runtime: _FakeRuntime,
+    process: Process,
+    cache: LocalRuntimeCache,
+) -> SimpleNamespace:
+    """Assemble a WorkerServices-shaped stub around a real LocalRuntimeCache."""
+    return SimpleNamespace(
+        team_manager=SimpleNamespace(create_team=lambda **_kwargs: runtime),
+        worker_handle=SimpleNamespace(get_team=lambda _tid: process),
+        runtime_cache=cache,
+    )
+
+
+def _make_create_body(team_id: uuid.UUID, team_card: TeamCard) -> WorkerCreateTeamRequest:
+    """Build a valid WorkerCreateTeamRequest for the given team."""
+    return WorkerCreateTeamRequest(
+        team_card=team_card,
+        user_id="user-1",
+        user_email="user@example.com",
+        team_id=team_id,
+    )
+
+
+def test_create_team_stores_handle_in_cache() -> None:
+    """AC#1: POST /teams stores a LocalTeamHandle before returning (201 shape)."""
+    team_id = uuid.uuid4()
+    team_card = _build_team_card()
+    runtime = _FakeRuntime(team_id)
+    process = _build_process(team_id, team_card)
+    cache = LocalRuntimeCache()
+    services = _build_services(runtime, process, cache)
+
+    response = create_team(_make_create_body(team_id, team_card), services)  # type: ignore[arg-type]
+
+    cached = cache.get(team_id)
+    assert isinstance(cached, LocalTeamHandle)
+    assert cached.team_id == team_id
+    # Response shape / id unchanged from today.
+    assert response.team_id == team_id
+    assert response.name == "Test Team"
+    assert response.user_id == "user-1"
+    assert response.status == TeamStatus.RUNNING.value
+
+
+def test_create_then_message_hits_cache_and_returns_204() -> None:
+    """AC#2: a message sent right after create resolves the cached handle."""
+    team_id = uuid.uuid4()
+    team_card = _build_team_card()
+    runtime = _FakeRuntime(team_id)
+    process = _build_process(team_id, team_card)
+    cache = LocalRuntimeCache()
+    services = _build_services(runtime, process, cache)
+
+    create_team(_make_create_body(team_id, team_card), services)  # type: ignore[arg-type]
+
+    # send_message returns None (HTTP 204) only if the cache lookup hit.
+    result = send_message(
+        team_id,
+        SendMessageRequest(content="hello team"),
+        services,  # type: ignore[arg-type]
+    )
+
+    assert result is None
+    assert runtime.sent == ["hello team"]
+
+
+def test_create_team_store_is_idempotent_overwrite() -> None:
+    """AC#3: re-creating the same team id overwrites the cache entry harmlessly."""
+    team_id = uuid.uuid4()
+    team_card = _build_team_card()
+    cache = LocalRuntimeCache()
+
+    first_runtime = _FakeRuntime(team_id)
+    services_a = _build_services(first_runtime, _build_process(team_id, team_card), cache)
+    create_team(_make_create_body(team_id, team_card), services_a)  # type: ignore[arg-type]
+    first_handle = cache.get(team_id)
+
+    second_runtime = _FakeRuntime(team_id)
+    services_b = _build_services(second_runtime, _build_process(team_id, team_card), cache)
+    create_team(_make_create_body(team_id, team_card), services_b)  # type: ignore[arg-type]
+    second_handle = cache.get(team_id)
+
+    assert isinstance(second_handle, LocalTeamHandle)
+    assert second_handle is not first_handle
+    assert second_handle.team_id == team_id
+
+
+def test_send_message_without_create_returns_404() -> None:
+    """Control: an un-stored team still 404s, proving the cache gates the route."""
+    from fastapi import HTTPException
+
+    team_id = uuid.uuid4()
+    cache = LocalRuntimeCache()
+    services = SimpleNamespace(runtime_cache=cache)
+
+    with pytest.raises(HTTPException) as exc_info:
+        send_message(
+            team_id,
+            SendMessageRequest(content="nobody home"),
+            services,  # type: ignore[arg-type]
+        )
+
+    assert exc_info.value.status_code == 404


### PR DESCRIPTION
## Summary

Epic 24 — Story 24.2. Lifts the missing `runtime_cache.store()` into the **shared** worker `create_team` handler.

### The bug

The shared worker `POST /teams` handler (`worker/routes/teams.py::create_team`) called `team_manager.create_team(...)` and returned the metadata, but never called `services.runtime_cache.store(team_id, handle)`. Every other route on that same router — `/{id}/message`, `/message/{agent}`, `/message/from/.../to/...`, `/human-input` — resolves the live handle via `runtime_cache.get(team_id)` as the first line of its body and returns **404** on a cache miss. So a team created through the shared handler was **not reachable** by any follow-up call on the same router. The companion `resume_team` handler already stored the handle — `create_team` was the lone outlier.

### The fix

After `create_team(...)` returns the `TeamRuntime` and before the `get_team` lookup:

```python
handle = LocalTeamHandle(runtime)
services.runtime_cache.store(runtime.id, handle)
```

`runtime_cache` was already a field on `WorkerServices` — no new dependency, no settings change. This mirrors `resume_team`'s existing store. No `store_on_create` flag (ADR-001 Alternative C rejected) — the store is always correct. `stop_team` / `delete_team` are untouched (the eviction half is Story 24.3).

This is correct for every consumer (Department + Enterprise worker apps) and inert for Community, whose server app mounts the *server* teams router (which already stores via `TeamService.create_team`), not the worker router.

### Tests

New `tests/worker/test_routes_teams.py`, exercising the handlers directly with a real `LocalRuntimeCache`:

- `test_create_team_stores_handle_in_cache` — cache populated with a `LocalTeamHandle` after `POST /teams`; 201 response shape unchanged.
- `test_create_then_message_hits_cache_and_returns_204` — follow-up `send_message` resolves the cached handle and returns 204 (no 404).
- `test_create_team_store_is_idempotent_overwrite` — re-creating the same id overwrites harmlessly.
- `test_send_message_without_create_returns_404` — control proving the cache gates the route.

### Local gates

- `pytest packages/akgentic-infra/tests/` — 1521 passed, 39 skipped; coverage 90.25% (branch on, ≥ 80%).
- `ruff check src/` + new test — clean.
- `ruff format --check` (changed files) — clean.
- `mypy src/` (strict) — Success, 112 files.

### Decision of record

[`adr-001-lift-create-team-cache-store-to-shared-worker-handler.md`](https://github.com/b12consulting/akgentic-infra-department/blob/master/decisions/adr-001-lift-create-team-cache-store-to-shared-worker-handler.md) (Accepted 2026-05-21), Decision 1: *the shared handler owns the store*. This PR is the ADR's **Story 1 — akgentic-infra**.

### Downstream cleanup (separate PRs, not in scope here — Golden Rule #4)

Once this lands, both deployment tiers can delete their copy-paste wrappers that exist only to add these two lines:

- **Department** — delete `department/routes/department_teams.py::create_team` + its mount (ADR Story 2 / Department Story 4.9).
- **Enterprise** — delete `enterprise/routes/enterprise_teams.py::create_team` + the redundant `EnterpriseCreateTeamRequest` + its mount (ADR Story 3, follow-up issue to be filed).

Relates to #312
