### PR TITLE
feat(akgentic-infra): 35-1 GET /teams/{id}/agent-states endpoint

### DIFF
--- a/src/akgentic/infra/server/models.py
+++ b/src/akgentic/infra/server/models.py
@@ -71,6 +71,31 @@ class EventListResponse(BaseModel):
     events: list[EventResponse] = Field(description="List of persisted events")
 
 
+class AgentStateResponse(BaseModel):
+    """Serialized form of a persisted AgentStateSnapshot.
+
+    A faithful passthrough of the snapshot store: ``agent_id`` and ``name``
+    are returned exactly as stored (no resolution / re-keying), and ``state``
+    is the snapshot's serialized ``BaseState`` — same shape convention as
+    ``EventResponse.event``.
+    """
+
+    agent_id: str = Field(
+        description="Snapshot's stored agent identifier, returned as-is (no resolution)"
+    )
+    name: str | None = Field(
+        description="Agent display name as stored; None for pre-Epic-23 snapshots"
+    )
+    state: dict[str, object] = Field(description="Serialized agent state payload")
+    updated_at: datetime = Field(description="Timestamp when the snapshot was taken")
+
+
+class AgentStateListResponse(BaseModel):
+    """Response body for GET /teams/{team_id}/agent-states."""
+
+    states: list[AgentStateResponse] = Field(description="List of persisted agent state snapshots")
+
+
 # --- Workspace response models ---
 
 

--- a/src/akgentic/infra/server/routes/teams.py
+++ b/src/akgentic/infra/server/routes/teams.py
@@ -11,6 +11,8 @@ from fastapi import APIRouter, Depends, HTTPException, Request
 from akgentic.catalog.models.errors import EntryNotFoundError
 from akgentic.infra.server.auth import RequestUser, get_request_user
 from akgentic.infra.server.models import (
+    AgentStateListResponse,
+    AgentStateResponse,
     CreateTeamRequest,
     EventListResponse,
     EventResponse,
@@ -223,6 +225,30 @@ def get_events(
                 timestamp=ev.timestamp,
             )
             for ev in events
+        ]
+    )
+
+
+@router.get("/{team_id}/agent-states", response_model=AgentStateListResponse)
+def get_agent_states(
+    team_id: uuid.UUID,
+    service: TeamService = Depends(get_team_service),
+) -> AgentStateListResponse:
+    """Get the latest persisted state snapshot for each agent of a team."""
+    logger.debug("GET /teams/%s/agent-states", team_id)
+    try:
+        snapshots = service.get_agent_states(team_id)
+    except ValueError:
+        raise HTTPException(status_code=404, detail="Team not found") from None
+    return AgentStateListResponse(
+        states=[
+            AgentStateResponse(
+                agent_id=s.agent_id,
+                name=s.name,
+                state=s.state.model_dump(mode="json"),
+                updated_at=s.updated_at,
+            )
+            for s in snapshots
         ]
     )
 

--- a/src/akgentic/infra/server/services/team_service.py
+++ b/src/akgentic/infra/server/services/team_service.py
@@ -13,7 +13,7 @@ from akgentic.infra.protocols.event_stream import EventStream
 from akgentic.infra.protocols.runtime_cache import RuntimeCache
 from akgentic.infra.protocols.team_handle import TeamHandle
 from akgentic.infra.server.deps import TierServices
-from akgentic.team.models import PersistedEvent, Process, TeamStatus
+from akgentic.team.models import AgentStateSnapshot, PersistedEvent, Process, TeamStatus
 
 logger = logging.getLogger(__name__)
 
@@ -286,6 +286,25 @@ class TeamService:
             raise ValueError(msg)
         logger.debug("Loading events for team %s", team_id)
         return self._services.event_store.load_events(team_id)
+
+    def get_agent_states(self, team_id: uuid.UUID) -> list[AgentStateSnapshot]:
+        """Get all persisted agent-state snapshots for a team.
+
+        A thin, faithful read of the snapshot store: returns every snapshot as
+        persisted, with no liveness filtering and no name->UUID resolution. The
+        team-exists guard mirrors ``get_events`` — ``get_team`` returns the
+        persisted process for a stopped team too, so this fires only for a
+        genuinely unknown team.
+
+        Raises:
+            ValueError: If team not found.
+        """
+        process = self._services.worker_handle.get_team(team_id)
+        if process is None:
+            msg = f"Team {team_id} not found"
+            raise ValueError(msg)
+        logger.debug("Loading agent states for team %s", team_id)
+        return self._services.event_store.load_agent_states(team_id)
 
     def get_event_stream(self) -> EventStream:
         """Return the tier's EventStream for cursor-based replay and fan-out."""

--- a/tests/server/routes/test_team_agent_states_routes.py
+++ b/tests/server/routes/test_team_agent_states_routes.py
@@ -1,0 +1,133 @@
+"""Tests for GET /teams/{id}/agent-states using FastAPI TestClient.
+
+Covers the thin DB read of the per-agent snapshot store: snapshots are
+returned exactly as persisted (no liveness filtering, no name->UUID
+resolution), for running and stopped teams alike (Epic 35 / story 35-1).
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+
+from akgentic.agent.config import AgentState
+from akgentic.team.models import AgentStateSnapshot
+from fastapi.testclient import TestClient
+
+from akgentic.infra.server.deps import CommunityServices
+
+
+def _seed_snapshot(
+    services: CommunityServices,
+    team_id: uuid.UUID,
+    *,
+    agent_id: str,
+    name: str | None,
+    backstory: str,
+) -> AgentStateSnapshot:
+    """Persist one agent-state snapshot directly into the team's snapshot store."""
+    snapshot = AgentStateSnapshot(
+        team_id=team_id,
+        agent_id=agent_id,
+        name=name,
+        state=AgentState(backstory=backstory),
+        updated_at=datetime.now(UTC),
+    )
+    services.event_store.save_agent_state(snapshot)
+    return snapshot
+
+
+def test_get_agent_states_success(
+    client: TestClient, community_services: CommunityServices
+) -> None:
+    """Returns one entry per persisted snapshot with fields echoed as stored."""
+    create_resp = client.post("/teams/", json={"catalog_namespace": "test-team"})
+    team_id = uuid.UUID(create_resp.json()["team_id"])
+    agent_uuid = str(uuid.uuid4())
+    _seed_snapshot(
+        community_services,
+        team_id,
+        agent_id=agent_uuid,
+        name="@Manager",
+        backstory="You coordinate the team.",
+    )
+
+    resp = client.get(f"/teams/{team_id}/agent-states")
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert len(data["states"]) == 1
+    entry = data["states"][0]
+    assert entry["agent_id"] == agent_uuid
+    assert entry["name"] == "@Manager"
+    assert entry["state"]["backstory"] == "You coordinate the team."
+    assert entry["updated_at"] is not None
+
+
+def test_get_agent_states_legacy_name_keyed_snapshot(
+    client: TestClient, community_services: CommunityServices
+) -> None:
+    """A pre-Epic-23 snapshot (agent_id holds a name, name is None) is passed through as-is."""
+    create_resp = client.post("/teams/", json={"catalog_namespace": "test-team"})
+    team_id = uuid.UUID(create_resp.json()["team_id"])
+    _seed_snapshot(
+        community_services,
+        team_id,
+        agent_id="@Manager",
+        name=None,
+        backstory="legacy backstory",
+    )
+
+    resp = client.get(f"/teams/{team_id}/agent-states")
+
+    assert resp.status_code == 200
+    entry = resp.json()["states"][0]
+    assert entry["agent_id"] == "@Manager"
+    assert entry["name"] is None
+
+
+def test_get_agent_states_stopped_team_returns_snapshots(
+    client: TestClient, community_services: CommunityServices
+) -> None:
+    """The load-bearing case: snapshots are returned regardless of agent liveness.
+
+    A stopped team has no live (Start - Stop) agent set, yet the endpoint must
+    still return its persisted snapshots — there is no live-set filtering.
+    """
+    create_resp = client.post("/teams/", json={"catalog_namespace": "test-team"})
+    team_id = uuid.UUID(create_resp.json()["team_id"])
+    agent_uuid = str(uuid.uuid4())
+    _seed_snapshot(
+        community_services,
+        team_id,
+        agent_id=agent_uuid,
+        name="@Manager",
+        backstory="still here after stop",
+    )
+    client.post(f"/teams/{team_id}/stop")
+
+    resp = client.get(f"/teams/{team_id}/agent-states")
+
+    assert resp.status_code == 200
+    states = resp.json()["states"]
+    assert [s["agent_id"] for s in states] == [agent_uuid]
+    assert states[0]["state"]["backstory"] == "still here after stop"
+
+
+def test_get_agent_states_empty_is_200(client: TestClient) -> None:
+    """An existing team with no persisted snapshots returns 200 with an empty list."""
+    create_resp = client.post("/teams/", json={"catalog_namespace": "test-team"})
+    team_id = create_resp.json()["team_id"]
+
+    resp = client.get(f"/teams/{team_id}/agent-states")
+
+    assert resp.status_code == 200
+    assert resp.json()["states"] == []
+
+
+def test_get_agent_states_unknown_team_is_404(client: TestClient) -> None:
+    """An unknown team_id returns 404 with detail 'Team not found'."""
+    resp = client.get(f"/teams/{uuid.uuid4()}/agent-states")
+
+    assert resp.status_code == 404
+    assert resp.json()["detail"] == "Team not found"

--- a/tests/server/services/test_team_action_service.py
+++ b/tests/server/services/test_team_action_service.py
@@ -6,8 +6,9 @@ import uuid
 from datetime import UTC, datetime
 
 import pytest
+from akgentic.agent.config import AgentState
 from akgentic.core.messages.orchestrator import SentMessage
-from akgentic.team.models import PersistedEvent, TeamStatus
+from akgentic.team.models import AgentStateSnapshot, PersistedEvent, TeamStatus
 
 from akgentic.infra.server.services.team_service import TeamService
 from tests.fixtures.events import build_sent_message
@@ -130,6 +131,39 @@ def test_get_events_not_found(team_service: TeamService) -> None:
     """get_events raises ValueError for non-existent team."""
     with pytest.raises(ValueError, match="not found"):
         team_service.get_events(uuid.uuid4())
+
+
+def test_get_agent_states_empty(team_service: TeamService) -> None:
+    """get_agent_states returns [] for an existing team with no snapshots."""
+    process = team_service.create_team("test-team", user_id="anonymous")
+    assert team_service.get_agent_states(process.team_id) == []
+
+
+def test_get_agent_states_returns_persisted_snapshots(team_service: TeamService) -> None:
+    """get_agent_states returns persisted snapshots as-is (no resolution/filtering)."""
+    process = team_service.create_team("test-team", user_id="anonymous")
+    agent_uuid = str(uuid.uuid4())
+    snapshot = AgentStateSnapshot(
+        team_id=process.team_id,
+        agent_id=agent_uuid,
+        name="@Manager",
+        state=AgentState(backstory="coordinate"),
+        updated_at=datetime.now(UTC),
+    )
+    team_service._services.event_store.save_agent_state(snapshot)
+
+    states = team_service.get_agent_states(process.team_id)
+
+    assert [s.agent_id for s in states] == [agent_uuid]
+    assert states[0].name == "@Manager"
+    assert isinstance(states[0].state, AgentState)
+    assert states[0].state.backstory == "coordinate"
+
+
+def test_get_agent_states_not_found(team_service: TeamService) -> None:
+    """get_agent_states raises ValueError for non-existent team."""
+    with pytest.raises(ValueError, match="not found"):
+        team_service.get_agent_states(uuid.uuid4())
 
 
 def test_process_human_input_not_found_team(team_service: TeamService) -> None:


### PR DESCRIPTION
## Summary

Adds a V2 read path for the per-agent state snapshots the system already persists: `GET /teams/{team_id}/agent-states`. The endpoint is a **thin, faithful read** of the snapshot store — it returns one entry per snapshot from `EventStore.load_agent_states(team_id)`, with **no liveness filtering** and **no name→UUID resolution** — mirroring the existing `GET /teams/{team_id}/events` route. Because it never gates on a live (Start − Stop) agent set, it correctly serves **stopped** teams, which is its primary use case (reading agent state, e.g. the backstory, on page load when the live WebSocket stream is unavailable).

Implements the `akgentic-infra` slice of team ADR-020 §Decision 1, with the deliberate simplification (no server-side resolution) recorded in the story file.

## Changes

- `TeamService.get_agent_states(team_id) -> list[AgentStateSnapshot]` — team-exists guard (`worker_handle.get_team(...) is None → ValueError`) then `event_store.load_agent_states(team_id)`. No live-set / name→UUID resolver. (`services/team_service.py`)
- `AgentStateResponse` / `AgentStateListResponse` boundary models — typed Pydantic, `state: dict[str, object]` mirroring `EventResponse.event`; no `ConfigDict(arbitrary_types_allowed=True)`. (`server/models.py`)
- `GET /{team_id}/agent-states` route — `try/except ValueError → 404 "Team not found"`, builds one `AgentStateResponse` per snapshot via `s.state.model_dump(mode="json")`, no filtering. (`server/routes/teams.py`)
- Tests: route-level (happy path, legacy name-keyed passthrough, stopped-team load-bearing case, empty→200, unknown→404) and service-level (empty, persisted-snapshot read, not-found).

## Behavior

- `200` with one `AgentStateResponse` per persisted snapshot (`agent_id`, `name`, serialized `state`, `updated_at`), echoed as stored.
- `200` with `states: []` for an existing team with no snapshots (not `404`).
- `404 {"detail": "Team not found"}` for an unknown team.
- Snapshots returned **regardless of agent liveness** (stopped-team correctness).

## Scope (Golden Rule #4)

Self-contained in `akgentic-infra`: only `server/models.py`, `server/routes/teams.py`, `server/services/team_service.py`, and tests. The team `EventStore` is read through its existing public API (`load_agent_states`) only — no `akgentic-team` / `akgentic-core` / `akgentic-frontend` edit.

## Verification (local gate)

- `pytest packages/akgentic-infra/tests/`: 1529 passed, 39 skipped, 0 failed; total coverage **90.28%** (≥ 90% infra threshold). `models.py` 100%, `routes/teams.py` 99%, `team_service.py` 94% (remaining misses are pre-existing lines/branches, not the new code).
- `ruff check` + `ruff format --check` clean on all modified files.
- `mypy --strict` clean on the three modified source files.

## Cross-submodule dependency

This PR consumes `AgentStateSnapshot.name` and the UUID-form `agent_id`, which are introduced by **akgentic-team Epic 23** (team branch `feat/130`, **PR #131**) and are **not yet merged to akgentic-team `master`**.

- The local workspace has `akgentic-team` checked out at `feat/130`, so local `pytest` / `mypy` pass against the new fields.
- The **akgentic-infra repository CI** resolves its `akgentic-team` dependency from the pinned (released) version — currently team `master`, which lacks `name`. **Remote CI for this PR is therefore expected to be RED** until:
  1. akgentic-team **PR #131** (Epic 23) merges to team `master`, and
  2. akgentic-infra's `akgentic-team` dependency is bumped to that commit.

This is an expected ordering constraint, not a defect in this PR. **Do not merge this PR** until team Epic 23 lands on team `master` and the dependency is bumped; local green is the agreed gate for review.

Relates to #311
