### PR TITLE
feat(akgentic-infra): epic 36 — Typed ServerError → HTTP Status Mapping (36.1 → 36.2)

### DIFF
--- a/src/akgentic/infra/__init__.py
+++ b/src/akgentic/infra/__init__.py
@@ -22,6 +22,7 @@ from akgentic.infra.adapters import (
     TelemetrySubscriber,
     YamlChannelRegistry,
 )
+from akgentic.infra.errors import PlacementConsistencyError, ServerError
 from akgentic.infra.protocols import (
     AuthStrategy,
     ChannelMessage,
@@ -32,6 +33,9 @@ from akgentic.infra.protocols import (
     InteractionChannelAdapter,
     InteractionChannelIngestion,
     JsonValue,
+    NoCapacityError,
+    NoSandboxCapacityError,
+    PlacementError,
     PlacementStrategy,
     RecoveryPolicy,
     RuntimeCache,
@@ -39,6 +43,7 @@ from akgentic.infra.protocols import (
     StreamReader,
     TeamHandle,
     WorkerHandle,
+    WorkerRejectedError,
 )
 from akgentic.infra.server.app import create_app
 from akgentic.infra.server.deps import CommunityServices, TierServices
@@ -71,13 +76,19 @@ __all__ = [
     "InteractionChannelAdapter",
     "InteractionChannelIngestion",
     "JsonValue",
+    "NoCapacityError",
+    "NoSandboxCapacityError",
+    "PlacementConsistencyError",
+    "PlacementError",
     "PlacementStrategy",
     "RecoveryPolicy",
     "RuntimeCache",
+    "ServerError",
     "StreamClosed",
     "StreamReader",
     "TeamHandle",
     "WorkerHandle",
+    "WorkerRejectedError",
     # Adapters
     "ChannelConfig",
     "ChannelParserRegistry",

--- a/src/akgentic/infra/adapters/community/local_placement.py
+++ b/src/akgentic/infra/adapters/community/local_placement.py
@@ -7,6 +7,7 @@ import uuid
 from typing import TYPE_CHECKING
 
 from akgentic.infra.adapters.community.local_team_handle import LocalTeamHandle
+from akgentic.infra.protocols.placement import PlacementError
 from akgentic.team.manager import TeamManager
 from akgentic.team.ports import ServiceRegistry
 
@@ -70,12 +71,24 @@ class LocalPlacement:
             catalog_namespace,
             team_id,
         )
-        runtime = self._team_manager.create_team(
-            team_card,
-            user_id,
-            user_email=user_email,
-            team_id=team_id,
-            catalog_namespace=catalog_namespace,
-        )
+        try:
+            runtime = self._team_manager.create_team(
+                team_card,
+                user_id,
+                user_email=user_email,
+                team_id=team_id,
+                catalog_namespace=catalog_namespace,
+            )
+        except PlacementError:
+            # Already typed — re-raise so the create-path surfaces the carried
+            # HTTP mapping unchanged.
+            raise
+        except Exception as exc:
+            # Community is single-process: the create-path failure is
+            # TeamManager.create_team raising, not capacity exhaustion. Surface
+            # it as a PlacementError (a ServerError) so the single handler maps
+            # it instead of leaking a bare exception (ADR-031 §Decision 4).
+            msg = f"Local team creation failed: {exc}"
+            raise PlacementError(msg) from exc
         logger.debug("Team created locally: team_id=%s", runtime.id)
         return LocalTeamHandle(runtime)

--- a/src/akgentic/infra/errors.py
+++ b/src/akgentic/infra/errors.py
@@ -1,0 +1,49 @@
+"""Framework-agnostic server-error base carrying its own HTTP mapping.
+
+``ServerError`` subclasses pin ``status_code`` (and optionally ``code``) as
+class attributes; the single FastAPI handler in ``server/errors.py`` reads them
+to build the response. No FastAPI import here — the base is a plain ``Exception``
+carrying data, so ``protocols/`` and ``services/`` can raise it without dragging
+in the web framework. See ADR-031 §Decision 1.
+"""
+
+from __future__ import annotations
+
+
+class ServerError(Exception):
+    """Base for infra-server domain errors that carry their own HTTP mapping.
+
+    Subclasses pin ``status_code`` (and optionally ``code``) as class attributes;
+    the single registered handler reads them. A call site may still override
+    ``status_code``/``headers``/``code`` per instance for a one-off mapping.
+    """
+
+    status_code: int = 500
+    code: str | None = None
+
+    def __init__(
+        self,
+        detail: str,
+        *,
+        status_code: int | None = None,
+        headers: dict[str, str] | None = None,
+        code: str | None = None,
+    ) -> None:
+        super().__init__(detail)
+        self.detail = detail
+        if status_code is not None:
+            self.status_code = status_code
+        self.headers = headers
+        if code is not None:
+            self.code = code
+
+
+class PlacementConsistencyError(ServerError):
+    """A team was created but is absent from the event store afterwards.
+
+    Fires *after* a successful placement, so it is a ``ServerError`` but not a
+    ``PlacementError`` (no worker-selection failure). See ADR-031 §Decision 4.
+    """
+
+    status_code = 502
+    code = "placement_consistency"

--- a/src/akgentic/infra/protocols/__init__.py
+++ b/src/akgentic/infra/protocols/__init__.py
@@ -13,7 +13,13 @@ from akgentic.infra.protocols.channels import (
 )
 from akgentic.infra.protocols.event_stream import EventStream, StreamClosed, StreamReader
 from akgentic.infra.protocols.health import HealthMonitor
-from akgentic.infra.protocols.placement import PlacementStrategy
+from akgentic.infra.protocols.placement import (
+    NoCapacityError,
+    NoSandboxCapacityError,
+    PlacementError,
+    PlacementStrategy,
+    WorkerRejectedError,
+)
 from akgentic.infra.protocols.recovery import RecoveryPolicy
 from akgentic.infra.protocols.runtime_cache import RuntimeCache
 from akgentic.infra.protocols.team_handle import TeamHandle
@@ -29,8 +35,12 @@ __all__ = [
     "InteractionChannelAdapter",
     "InteractionChannelIngestion",
     "JsonValue",
+    "NoCapacityError",
+    "NoSandboxCapacityError",
+    "PlacementError",
     "PlacementStrategy",
     "RecoveryPolicy",
+    "WorkerRejectedError",
     "RuntimeCache",
     "StreamClosed",
     "StreamReader",

--- a/src/akgentic/infra/protocols/placement.py
+++ b/src/akgentic/infra/protocols/placement.py
@@ -1,13 +1,63 @@
-"""PlacementStrategy protocol — creates teams on worker instances."""
+"""PlacementStrategy protocol — creates teams on worker instances.
+
+Also home to the placement error hierarchy (the protocol's error contract).
+The placement errors subclass both ``ServerError`` (so the single infra handler
+maps them to HTTP statuses) and ``RuntimeError`` (so the documented contract and
+any existing ``except RuntimeError`` keep holding). See ADR-031 §Decision 2.
+"""
 
 from __future__ import annotations
 
 import uuid
 from typing import TYPE_CHECKING, Protocol, runtime_checkable
 
+from akgentic.infra.errors import ServerError
+
 if TYPE_CHECKING:
     from akgentic.infra.protocols.team_handle import TeamHandle
     from akgentic.team.models import TeamCard
+
+
+class PlacementError(ServerError, RuntimeError):
+    """A team could not be placed on any worker. Defaults to 503."""
+
+    status_code = 503
+    code = "placement_failed"
+
+
+class NoCapacityError(PlacementError):
+    """No eligible worker had free capacity — transient, retryable.
+
+    Attaches a default ``Retry-After`` header when the caller supplies none, so
+    the 503 response tells the client to retry later.
+    """
+
+    code = "no_worker_capacity"
+
+    def __init__(
+        self,
+        detail: str,
+        *,
+        status_code: int | None = None,
+        headers: dict[str, str] | None = None,
+        code: str | None = None,
+    ) -> None:
+        if headers is None:
+            headers = {"Retry-After": "30"}
+        super().__init__(detail, status_code=status_code, headers=headers, code=code)
+
+
+class NoSandboxCapacityError(NoCapacityError):
+    """A sandbox-requiring team found no sandbox-capable worker."""
+
+    code = "no_sandbox_capacity"
+
+
+class WorkerRejectedError(PlacementError):
+    """The selected worker returned a non-2xx from team creation — upstream fault."""
+
+    status_code = 502
+    code = "worker_rejected"
 
 
 @runtime_checkable
@@ -29,8 +79,9 @@ class PlacementStrategy(Protocol):
       Creates via Dapr service invocation or direct gRPC.
 
     Error contract:
-        Raises ``RuntimeError`` if no healthy worker is available or team
-        creation fails on the selected worker. Callers must not retry
+        Raises ``PlacementError`` (a ``ServerError``, and — for backward
+        compatibility — a ``RuntimeError``) if no healthy worker is available
+        or team creation fails on the selected worker. Callers must not retry
         automatically — surface the error to the user.
     """
 
@@ -60,6 +111,8 @@ class PlacementStrategy(Protocol):
             A TeamHandle for interacting with the newly created team.
 
         Raises:
-            RuntimeError: If no worker is available or team creation fails.
+            PlacementError: If no worker is available or team creation fails.
+                A ``ServerError``, and — for backward compatibility — a
+                ``RuntimeError``.
         """
         ...

--- a/src/akgentic/infra/server/app.py
+++ b/src/akgentic/infra/server/app.py
@@ -27,6 +27,7 @@ from akgentic.catalog.api._settings import CatalogRouterSettings
 from akgentic.catalog.api.router import build_router as build_catalog_router
 from akgentic.catalog.api.router import set_catalog as set_unified_catalog
 from akgentic.infra.server.deps import TierServices
+from akgentic.infra.server.errors import add_server_exception_handlers
 from akgentic.infra.server.logging_config import configure_logging
 from akgentic.infra.server.routes._admin_mutation_log import AdminCatalogMutationLogMiddleware
 from akgentic.infra.server.routes._auth_dep import require_authenticated_principal
@@ -175,6 +176,7 @@ def _build_app(
     # Starlette's protocol vs. a concrete class mismatch.
     app.add_middleware(AdminCatalogMutationLogMiddleware)  # type: ignore[arg-type]
     add_exception_handlers(app)
+    add_server_exception_handlers(app)
     return app
 
 

--- a/src/akgentic/infra/server/errors.py
+++ b/src/akgentic/infra/server/errors.py
@@ -1,0 +1,44 @@
+"""Single FastAPI exception handler mapping the whole ``ServerError`` hierarchy.
+
+One ``add_exception_handler(ServerError, ...)`` registration covers every
+subclass: Starlette resolves a raised exception by walking its MRO, so any
+``ServerError`` subclass routes to this base handler. Response shape mirrors the
+catalog ``ErrorResponse`` (``{"detail": ..., "code": ...}``). See ADR-031
+§Decision 3.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from fastapi import FastAPI, Request
+from fastapi.responses import JSONResponse
+from pydantic import BaseModel
+
+from akgentic.infra.errors import ServerError
+
+__all__ = ["ServerErrorResponse", "add_server_exception_handlers"]
+
+logger = logging.getLogger(__name__)
+
+
+class ServerErrorResponse(BaseModel):
+    """Structured error response for any mapped ``ServerError``."""
+
+    detail: str
+    code: str | None = None
+
+
+async def _handle_server_error(request: Request, exc: ServerError) -> JSONResponse:
+    """Map any ``ServerError`` to a JSON response using its carried attributes."""
+    logger.warning("ServerError %s (%d): %s", exc.code, exc.status_code, exc.detail)
+    return JSONResponse(
+        status_code=exc.status_code,
+        content=ServerErrorResponse(detail=exc.detail, code=exc.code).model_dump(),
+        headers=exc.headers or None,
+    )
+
+
+def add_server_exception_handlers(app: FastAPI) -> None:
+    """Register the single ``ServerError`` handler covering the whole hierarchy."""
+    app.add_exception_handler(ServerError, _handle_server_error)  # type: ignore[arg-type]

--- a/src/akgentic/infra/server/services/team_service.py
+++ b/src/akgentic/infra/server/services/team_service.py
@@ -9,6 +9,7 @@ from pathlib import Path
 
 from akgentic.catalog.models.errors import CatalogValidationError, EntryNotFoundError
 from akgentic.core.messages.orchestrator import SentMessage
+from akgentic.infra.errors import PlacementConsistencyError
 from akgentic.infra.protocols.event_stream import EventStream
 from akgentic.infra.protocols.runtime_cache import RuntimeCache
 from akgentic.infra.protocols.team_handle import TeamHandle
@@ -120,7 +121,7 @@ class TeamService:
         process = self._services.worker_handle.get_team(handle.team_id)
         if process is None:  # pragma: no cover
             msg = f"Team {handle.team_id} was created but not found in event store"
-            raise RuntimeError(msg)
+            raise PlacementConsistencyError(msg)
         logger.info(
             "Team created: team_id=%s, catalog_namespace=%s",
             process.team_id,

--- a/tests/adapters/community/test_local_placement.py
+++ b/tests/adapters/community/test_local_placement.py
@@ -6,9 +6,13 @@ import inspect
 import uuid
 from unittest.mock import MagicMock
 
+import pytest
 from akgentic.infra.adapters.community.local_placement import LocalPlacement
 from akgentic.infra.adapters.community.local_team_handle import LocalTeamHandle
-from akgentic.infra.protocols.placement import PlacementStrategy
+from akgentic.infra.protocols.placement import (
+    PlacementError,
+    PlacementStrategy,
+)
 
 
 def _make_adapter() -> LocalPlacement:
@@ -74,9 +78,7 @@ class TestLocalPlacementBehavior:
         adapter = LocalPlacement(team_manager, service_registry)
         team_card = MagicMock()
         explicit_id = uuid.uuid4()
-        adapter.create_team(
-            team_card, "user-1", user_email="user@example.com", team_id=explicit_id
-        )
+        adapter.create_team(team_card, "user-1", user_email="user@example.com", team_id=explicit_id)
         team_manager.create_team.assert_called_once_with(
             team_card,
             "user-1",
@@ -108,3 +110,28 @@ class TestLocalPlacementBehavior:
         a = _make_adapter()
         b = _make_adapter()
         assert a.instance_id != b.instance_id
+
+
+class TestLocalPlacementCreateFailure:
+    """AC12: a TeamManager.create_team failure surfaces as a PlacementError."""
+
+    def test_create_team_failure_raises_placement_error(self) -> None:
+        """A delegate exception is wrapped in PlacementError (a ServerError)."""
+        team_manager = MagicMock()
+        team_manager.create_team.side_effect = RuntimeError("boom")
+        adapter = LocalPlacement(team_manager, MagicMock())
+        with pytest.raises(PlacementError) as exc_info:
+            adapter.create_team(MagicMock(), "user-1")
+        # Wrapped, not re-raised verbatim: carries the placement HTTP mapping.
+        assert exc_info.value.status_code == 503
+        assert exc_info.value.__cause__ is not None
+
+    def test_create_team_passes_through_placement_error(self) -> None:
+        """An already-typed PlacementError propagates unchanged (not re-wrapped)."""
+        original = PlacementError("already typed")
+        team_manager = MagicMock()
+        team_manager.create_team.side_effect = original
+        adapter = LocalPlacement(team_manager, MagicMock())
+        with pytest.raises(PlacementError) as exc_info:
+            adapter.create_team(MagicMock(), "user-1")
+        assert exc_info.value is original

--- a/tests/server/routes/test_server_error_handler.py
+++ b/tests/server/routes/test_server_error_handler.py
@@ -1,0 +1,100 @@
+"""End-to-end tests for the single ServerError -> HTTP handler via POST /teams.
+
+A stub ``PlacementStrategy`` raising a placement error is swapped into the
+community services before building the app, so ``POST /teams`` drives the
+status/code/Retry-After mapping infra owns. Community's ``LocalPlacement``
+never naturally exhausts capacity, so the stub is the only way to exercise
+these branches (ADR-031 §Decision 4 / §Validation).
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import Generator
+
+import pytest
+from akgentic.infra.protocols.placement import (
+    NoCapacityError,
+    WorkerRejectedError,
+)
+from akgentic.infra.server.app import create_app
+from akgentic.infra.server.deps import CommunityServices
+from akgentic.infra.server.settings import CommunitySettings
+from fastapi.testclient import TestClient
+
+
+class _RaisingPlacement:
+    """Stub PlacementStrategy whose create_team raises a fixed placement error."""
+
+    def __init__(self, error: Exception) -> None:
+        self._error = error
+        self._instance_id = uuid.uuid4()
+
+    @property
+    def instance_id(self) -> uuid.UUID:
+        return self._instance_id
+
+    def create_team(
+        self,
+        team_card: object,
+        user_id: str,
+        user_email: str = "",
+        team_id: uuid.UUID | None = None,
+        catalog_namespace: str | None = None,
+    ) -> object:
+        raise self._error
+
+
+def _client_with_placement(
+    services: CommunityServices,
+    settings: CommunitySettings,
+    error: Exception,
+) -> TestClient:
+    """Swap a raising placement stub into the services, then build the app."""
+    services.placement = _RaisingPlacement(error)  # type: ignore[assignment]
+    return TestClient(create_app(services, settings))
+
+
+@pytest.fixture()
+def no_capacity_client(
+    community_services: CommunityServices,
+    seeded_settings: CommunitySettings,
+) -> Generator[TestClient, None, None]:
+    """Client whose placement raises NoCapacityError."""
+    yield _client_with_placement(
+        community_services,
+        seeded_settings,
+        NoCapacityError("No worker available with capacity to place team"),
+    )
+
+
+@pytest.fixture()
+def worker_rejected_client(
+    community_services: CommunityServices,
+    seeded_settings: CommunitySettings,
+) -> Generator[TestClient, None, None]:
+    """Client whose placement raises WorkerRejectedError."""
+    yield _client_with_placement(
+        community_services,
+        seeded_settings,
+        WorkerRejectedError("Worker returned 500 from create"),
+    )
+
+
+def test_no_capacity_maps_to_503(no_capacity_client: TestClient) -> None:
+    """AC #13: NoCapacityError -> 503 + Retry-After + code=no_worker_capacity."""
+    resp = no_capacity_client.post("/teams/", json={"catalog_namespace": "test-team"})
+    assert resp.status_code == 503
+    assert "retry-after" in {k.lower() for k in resp.headers}
+    body = resp.json()
+    assert body["code"] == "no_worker_capacity"
+    assert isinstance(body["detail"], str) and body["detail"]
+
+
+def test_worker_rejected_maps_to_502(worker_rejected_client: TestClient) -> None:
+    """AC #14: WorkerRejectedError -> 502 + code=worker_rejected."""
+    resp = worker_rejected_client.post("/teams/", json={"catalog_namespace": "test-team"})
+    assert resp.status_code == 502
+    body = resp.json()
+    assert body["code"] == "worker_rejected"
+    assert isinstance(body["detail"], str) and body["detail"]

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -1,0 +1,188 @@
+"""Unit tests for the ServerError base and the placement error hierarchy.
+
+Covers ADR-031 §Decision 1 (base shape) and §Decision 2 (placement types: MRO,
+isinstance, status/code, Retry-After), plus the backward-compatibility contract
+that placement errors are still caught by ``except RuntimeError``.
+"""
+
+from __future__ import annotations
+
+import pytest
+from akgentic.infra.errors import PlacementConsistencyError, ServerError
+from akgentic.infra.protocols.placement import (
+    NoCapacityError,
+    NoSandboxCapacityError,
+    PlacementError,
+    WorkerRejectedError,
+)
+
+_PLACEMENT_TYPES = [
+    PlacementError,
+    NoCapacityError,
+    NoSandboxCapacityError,
+    WorkerRejectedError,
+]
+
+
+class TestServerErrorBase:
+    """AC #1, #2: the generic base carries its HTTP mapping as data."""
+
+    def test_default_attrs(self) -> None:
+        """Bare ServerError defaults to 500, no code, no headers."""
+        err = ServerError("boom")
+        assert err.status_code == 500
+        assert err.code is None
+        assert err.detail == "boom"
+        assert err.headers is None
+
+    def test_per_instance_overrides(self) -> None:
+        """Keyword overrides set status_code / headers / code on the instance."""
+        err = ServerError("boom", status_code=418, headers={"X-A": "1"}, code="teapot")
+        assert err.status_code == 418
+        assert err.code == "teapot"
+        assert err.headers == {"X-A": "1"}
+
+    def test_str_is_detail(self) -> None:
+        """str(ServerError) is the detail passed to Exception.__init__."""
+        assert str(ServerError("boom")) == "boom"
+
+    def test_is_exception(self) -> None:
+        """ServerError is a plain Exception (no Pydantic, no framework)."""
+        assert isinstance(ServerError("boom"), Exception)
+
+
+class TestPlacementErrorStatusAndCode:
+    """AC #5: each placement type pins its status_code / code."""
+
+    def test_placement_error(self) -> None:
+        err = PlacementError("x")
+        assert err.status_code == 503
+        assert err.code == "placement_failed"
+
+    def test_no_capacity_error(self) -> None:
+        err = NoCapacityError("full")
+        assert err.status_code == 503
+        assert err.code == "no_worker_capacity"
+
+    def test_no_sandbox_capacity_error(self) -> None:
+        err = NoSandboxCapacityError("no sandbox")
+        assert err.status_code == 503
+        assert err.code == "no_sandbox_capacity"
+
+    def test_worker_rejected_error(self) -> None:
+        err = WorkerRejectedError("rejected")
+        assert err.status_code == 502
+        assert err.code == "worker_rejected"
+
+
+class TestNoCapacityRetryAfter:
+    """AC #5: NoCapacity attaches a default Retry-After; subclass inherits it."""
+
+    def test_default_retry_after_attached(self) -> None:
+        assert "Retry-After" in (NoCapacityError("full").headers or {})
+
+    def test_sandbox_inherits_retry_after(self) -> None:
+        assert "Retry-After" in (NoSandboxCapacityError("x").headers or {})
+
+    def test_caller_headers_preserved(self) -> None:
+        """A caller-supplied headers dict is not clobbered by the default."""
+        err = NoCapacityError("full", headers={"X-Custom": "1"})
+        assert err.headers == {"X-Custom": "1"}
+
+
+class TestPlacementErrorMRO:
+    """AC #6: MRO is PlacementError -> ServerError -> RuntimeError -> Exception."""
+
+    def test_placement_error_mro(self) -> None:
+        assert PlacementError.__mro__[:4] == (
+            PlacementError,
+            ServerError,
+            RuntimeError,
+            Exception,
+        )
+
+    @pytest.mark.parametrize("typ", _PLACEMENT_TYPES)
+    def test_is_runtime_error_and_server_error(self, typ: type[PlacementError]) -> None:
+        inst = typ("x")
+        assert isinstance(inst, RuntimeError)
+        assert isinstance(inst, ServerError)
+
+    def test_subclass_isinstance_chain(self) -> None:
+        assert isinstance(NoSandboxCapacityError("x"), NoCapacityError)
+        assert isinstance(NoCapacityError("x"), PlacementError)
+
+
+class TestBackwardCompatibility:
+    """AC #15: existing ``except RuntimeError`` still catches placement errors."""
+
+    def test_except_runtime_error_catches(self) -> None:
+        caught = False
+        try:
+            raise NoCapacityError("full")
+        except RuntimeError:
+            caught = True
+        assert caught
+
+
+class TestPlacementConsistencyError:
+    """AC #11: the post-create consistency error is a ServerError, not a placement one."""
+
+    def test_status_and_code(self) -> None:
+        err = PlacementConsistencyError("missing")
+        assert err.status_code == 502
+        assert err.code == "placement_consistency"
+
+    def test_is_server_error_not_placement_error(self) -> None:
+        err = PlacementConsistencyError("missing")
+        assert isinstance(err, ServerError)
+        assert not isinstance(err, PlacementError)
+
+
+class TestModuleHygiene:
+    """AC #3, #4: errors.py is FastAPI-free and not a Pydantic model."""
+
+    def test_errors_module_has_no_web_framework_import(self) -> None:
+        """The module's import statements pull in no FastAPI/Starlette/Pydantic."""
+        import ast
+
+        import akgentic.infra.errors as errors_module
+
+        source = errors_module.__file__
+        assert source is not None
+        with open(source, encoding="utf-8") as handle:
+            tree = ast.parse(handle.read())
+        imported: list[str] = []
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                imported.extend(alias.name for alias in node.names)
+            elif isinstance(node, ast.ImportFrom) and node.module is not None:
+                imported.append(node.module)
+        # The only import is ``from __future__ import annotations``.
+        assert imported == ["__future__"]
+
+    def test_errors_module_declares_no_pydantic_config(self) -> None:
+        """No ``arbitrary_types_allowed`` (Golden Rule #1b) — no Pydantic fields here."""
+        import akgentic.infra.errors as errors_module
+
+        source = errors_module.__file__
+        assert source is not None
+        with open(source, encoding="utf-8") as handle:
+            assert "arbitrary_types_allowed" not in handle.read()
+
+    def test_re_exported_from_protocols(self) -> None:
+        from akgentic.infra.protocols import (
+            NoCapacityError as ProtoNoCapacity,
+        )
+        from akgentic.infra.protocols import (
+            PlacementError as ProtoPlacementError,
+        )
+
+        assert ProtoPlacementError is PlacementError
+        assert ProtoNoCapacity is NoCapacityError
+
+    def test_re_exported_from_top_level(self) -> None:
+        import akgentic.infra as infra
+
+        assert infra.ServerError is ServerError
+        assert infra.PlacementError is PlacementError
+        assert infra.WorkerRejectedError is WorkerRejectedError


### PR DESCRIPTION
## Epic 36 — Typed ServerError → HTTP Status Mapping

Introduces a framework-agnostic `ServerError` base whose subclasses carry their own HTTP mapping as data, a **single** FastAPI handler registered once in `_build_app` that maps the whole hierarchy via Starlette's MRO walk, and the placement error types as the first concrete consumer raised on infra's own create path. A domain failure becomes the right HTTP status with a machine-readable `code` instead of an opaque 500; the next service reuses the mechanism with zero new handler code; the documented "raises `RuntimeError`" placement contract stays backward-compatible (placement errors subclass both `ServerError` and `RuntimeError`).

Design per ADR-031 (Typed ServerError → HTTP Status Mapping). This is the umbrella PR for Epic 36; story 36.2 (docs) lands on the same branch.

## Stories

- [x] 36-1-servererror-http-mapping-and-placement-errors — generic `ServerError` base + single FastAPI handler + placement error types (`PlacementError`/`NoCapacityError`/`NoSandboxCapacityError`/`WorkerRejectedError`) + infra create-path typed raises (Relates to #315)
- [ ] 36-2-architecture-and-readme-servererror-mapping — architecture/README documentation of the mapping (issue TBD)

## Review status

- 36-1 review: **PASS** — ADR-031 fidelity confirmed (FastAPI-free `ServerError` base; placement types subclass both `ServerError` and `RuntimeError` with correct statuses 503 + `Retry-After` / 502; single handler registered once in `_build_app`). Golden Rules #1/#1b (`ServerError` not Pydantic, `ServerErrorResponse` is Pydantic with no `arbitrary_types_allowed`), #4 (scope), and #8 (no string assertions/branches) all satisfied. No HIGH/MEDIUM findings; one LOW cosmetic `__all__`-ordering nit left as-is (not lint-enforced, zero behavioral value). No fixup commit required.
- Local gates: ruff clean, mypy --strict clean, pytest **1549 passed / 39 skipped**, total coverage **90.38%** (≥ 90% infra threshold).

## Scope guard

All changes stay inside `packages/akgentic-infra/` — no edit to `akgentic-infra-department`, `akgentic-infra-enterprise`, or `akgentic-catalog`. Department/enterprise typed raises and the `teams.py:_raise_action_error` migration are tracked future amendments on their own submodules/stories.
