### PR TITLE
feat(akgentic-infra): epic 36 — cursor-paginated team listing (36-1)

### DIFF
--- a/src/akgentic/infra/server/models.py
+++ b/src/akgentic/infra/server/models.py
@@ -35,6 +35,10 @@ class TeamListResponse(BaseModel):
     """Response body for GET /teams."""
 
     teams: list[TeamResponse] = Field(description="List of team metadata entries")
+    next_cursor: str | None = Field(
+        default=None,
+        description="Opaque token for the next page; null when this is the last page.",
+    )
 
 
 class SendMessageRequest(BaseModel):

--- a/src/akgentic/infra/server/routes/frontend_adapter/angular_v1/router.py
+++ b/src/akgentic/infra/server/routes/frontend_adapter/angular_v1/router.py
@@ -33,7 +33,7 @@ from akgentic.infra.server.routes.frontend_adapter.angular_v1.models import (
     V1StateUpdateBody,
     V1StatusResponse,
 )
-from akgentic.infra.server.services.team_service import TeamService
+from akgentic.infra.server.services.team_service import MAX_PAGE_LIMIT, TeamService
 from akgentic.team.models import PersistedEvent, Process, TeamStatus
 
 process_router = APIRouter(prefix="/process", tags=["v1-compat"])
@@ -148,8 +148,9 @@ def list_processes(
     service: TeamService = Depends(get_team_service),
 ) -> list[V1ProcessContext]:
     """GET /process/ -> list teams as flat list."""
-    processes = service.list_teams(user_id="anonymous")
-    return [_to_v1_process_context(p) for p in processes]
+    # V1 adapter has no pagination; request the max page (next_cursor ignored).
+    page, _ = service.list_teams(user_id="anonymous", limit=MAX_PAGE_LIMIT)
+    return [_to_v1_process_context(p) for p in page]
 
 
 @processes_router.get("/", response_model=list[V1ProcessContext])

--- a/src/akgentic/infra/server/routes/teams.py
+++ b/src/akgentic/infra/server/routes/teams.py
@@ -19,7 +19,11 @@ from akgentic.infra.server.models import (
     TeamListResponse,
     TeamResponse,
 )
-from akgentic.infra.server.services.team_service import TeamService
+from akgentic.infra.server.services.team_service import (
+    InvalidCursorError,
+    TeamCursor,
+    TeamService,
+)
 from akgentic.infra.server.state_keys import CONNECTION_MANAGER, TEAM_SERVICE
 from akgentic.team.models import Process
 
@@ -73,11 +77,22 @@ def create_team(
 def list_teams(
     user: RequestUser = Depends(get_request_user),
     service: TeamService = Depends(get_team_service),
+    limit: int = 50,
+    cursor: str | None = None,
 ) -> TeamListResponse:
-    """List all teams for the current user."""
-    logger.debug("GET /teams")
-    processes = service.list_teams(user_id=user.user_id)
-    return TeamListResponse(teams=[_process_to_response(p) for p in processes])
+    """List one keyset-paginated page of teams for the current user."""
+    logger.debug("GET /teams — limit=%s cursor=%s", limit, cursor is not None)
+    decoded = None
+    if cursor is not None:
+        try:
+            decoded = TeamCursor.decode(cursor)
+        except InvalidCursorError:
+            raise HTTPException(status_code=400, detail="Invalid cursor") from None
+    page, next_cursor = service.list_teams(user_id=user.user_id, limit=limit, cursor=decoded)
+    return TeamListResponse(
+        teams=[_process_to_response(p) for p in page],
+        next_cursor=next_cursor,
+    )
 
 
 @router.get("/{team_id}", response_model=TeamResponse)

--- a/src/akgentic/infra/server/services/team_service.py
+++ b/src/akgentic/infra/server/services/team_service.py
@@ -2,10 +2,16 @@
 
 from __future__ import annotations
 
+import base64
+import binascii
+import json
 import logging
 import shutil
 import uuid
+from datetime import datetime
 from pathlib import Path
+
+from pydantic import BaseModel, Field, ValidationError
 
 from akgentic.catalog.models.errors import CatalogValidationError, EntryNotFoundError
 from akgentic.core.messages.orchestrator import SentMessage
@@ -16,6 +22,45 @@ from akgentic.infra.server.deps import TierServices
 from akgentic.team.models import PersistedEvent, Process, TeamStatus
 
 logger = logging.getLogger(__name__)
+
+# Default and maximum page sizes for GET /teams (ADR-031 §Decision 1).
+DEFAULT_PAGE_LIMIT = 50
+MAX_PAGE_LIMIT = 200
+# Upper bound on an incoming cursor token; a well-formed cursor is well under
+# this, so anything larger is rejected before base64 decoding (ADR-031 §6).
+_MAX_CURSOR_LEN = 4096
+
+
+class InvalidCursorError(ValueError):
+    """Raised when a cursor token cannot be decoded into a TeamCursor."""
+
+
+class TeamCursor(BaseModel):
+    """Opaque keyset position for GET /teams pagination (ADR-031 §Decision 2)."""
+
+    created_at: datetime = Field(description="created_at of the last row on the previous page")
+    team_id: uuid.UUID = Field(description="team_id tie-breaker of that row")
+
+    def encode(self) -> str:
+        """Encode this position as a base64url(json) opaque token."""
+        payload = json.dumps(self.model_dump(mode="json")).encode("utf-8")
+        return base64.urlsafe_b64encode(payload).decode("ascii")
+
+    @classmethod
+    def decode(cls, token: str) -> TeamCursor:
+        """Decode an opaque token back into a TeamCursor.
+
+        Raises:
+            InvalidCursorError: On any malformed, oversized, or unparseable token.
+        """
+        if len(token) > _MAX_CURSOR_LEN:
+            raise InvalidCursorError("cursor token too long")
+        try:
+            raw = base64.urlsafe_b64decode(token.encode("ascii"))
+            data = json.loads(raw)
+            return cls.model_validate(data)
+        except (binascii.Error, ValueError, ValidationError, UnicodeDecodeError) as exc:
+            raise InvalidCursorError("malformed cursor token") from exc
 
 
 def _remove_workspace_dir(workspaces_root: Path, team_id: uuid.UUID) -> None:
@@ -128,15 +173,43 @@ class TeamService:
         )
         return process
 
-    def list_teams(self, user_id: str) -> list[Process]:
-        """List all teams for a given user.
+    def list_teams(
+        self,
+        *,
+        user_id: str,
+        limit: int = DEFAULT_PAGE_LIMIT,
+        cursor: TeamCursor | None = None,
+    ) -> tuple[list[Process], str | None]:
+        """Return one keyset-paginated page of the user's teams plus next cursor.
 
-        Pushes the ``user_id`` filter into the EventStore rather than loading
-        every team into Python and filtering here. Per-request cost scales with
-        the requesting user's team count, not with total teams across all
-        users. See team-package ADR-16 / Epic 19 for the Protocol change.
+        Phase 1: the store still returns the full owned set (ADR-031 §Decision 3);
+        the page is sorted ``created_at DESC, team_id DESC``, seeked past the
+        cursor, and sliced here. ``next_cursor`` is set only when the page is full
+        and rows remain after it; otherwise None.
         """
-        return self._services.event_store.list_teams(user_id=user_id)
+        limit = max(1, min(limit, MAX_PAGE_LIMIT))
+        rows = self._services.event_store.list_teams(user_id=user_id)
+        rows.sort(key=lambda p: (p.created_at, p.team_id), reverse=True)
+        start = self._seek(rows, cursor)
+        page = rows[start : start + limit]
+        more_remain = start + limit < len(rows)
+        next_cursor = (
+            TeamCursor(created_at=page[-1].created_at, team_id=page[-1].team_id).encode()
+            if len(page) == limit and more_remain
+            else None
+        )
+        return page, next_cursor
+
+    @staticmethod
+    def _seek(rows: list[Process], cursor: TeamCursor | None) -> int:
+        """Index of the first row strictly after the cursor in DESC keyset order."""
+        if cursor is None:
+            return 0
+        target = (cursor.created_at, cursor.team_id)
+        return next(
+            (i for i, p in enumerate(rows) if (p.created_at, p.team_id) < target),
+            len(rows),
+        )
 
     def get_team(self, team_id: uuid.UUID) -> Process | None:
         """Get a single team by ID."""

--- a/tests/server/models/test_server_models.py
+++ b/tests/server/models/test_server_models.py
@@ -55,6 +55,19 @@ def test_team_list_response_empty() -> None:
     assert resp.teams == []
 
 
+def test_team_list_response_next_cursor_defaults_none() -> None:
+    """TeamListResponse(teams=...) without next_cursor stays backward-compatible."""
+    resp = TeamListResponse(teams=[])
+    assert resp.next_cursor is None
+    assert resp.model_dump()["next_cursor"] is None
+
+
+def test_team_list_response_carries_next_cursor() -> None:
+    """next_cursor round-trips through serialization when provided."""
+    resp = TeamListResponse(teams=[], next_cursor="opaque-token")
+    assert resp.model_dump(mode="json")["next_cursor"] == "opaque-token"
+
+
 def test_team_list_response_with_items() -> None:
     """TeamListResponse serializes a list of TeamResponses."""
     tid = uuid.uuid4()

--- a/tests/server/routes/test_team_routes.py
+++ b/tests/server/routes/test_team_routes.py
@@ -9,7 +9,10 @@ import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
+from akgentic.infra.server.app import create_app
 from akgentic.infra.server.auth import RequestUser, get_request_user
+from akgentic.infra.server.settings import CommunitySettings
+from akgentic.infra.wiring import wire_community
 
 
 def test_create_team_success(client: TestClient) -> None:
@@ -29,20 +32,23 @@ def test_create_team_invalid_entry(client: TestClient) -> None:
 
 
 def test_list_teams_empty(client: TestClient) -> None:
-    """GET /teams returns empty list when no teams exist."""
+    """GET /teams returns empty list and a null next_cursor when no teams exist."""
     resp = client.get("/teams/")
     assert resp.status_code == 200
     assert resp.json()["teams"] == []
+    assert resp.json()["next_cursor"] is None
 
 
 def test_list_teams_after_create(client: TestClient) -> None:
-    """GET /teams returns created teams."""
+    """GET /teams returns created teams; a single-team set has a null next_cursor."""
     client.post("/teams/", json={"catalog_namespace": "test-team"})
     resp = client.get("/teams/")
     assert resp.status_code == 200
-    teams = resp.json()["teams"]
+    body = resp.json()
+    teams = body["teams"]
     assert len(teams) == 1
     assert teams[0]["name"] == "Test Team"
+    assert body["next_cursor"] is None
 
 
 def test_get_team_success(client: TestClient) -> None:
@@ -117,6 +123,107 @@ def test_list_teams_filters_by_overridden_identity(
     overridden_user_client.post("/teams/", json={"catalog_namespace": "test-team"})
     resp = overridden_user_client.get("/teams/")
     assert resp.status_code == 200
-    teams = resp.json()["teams"]
+    body = resp.json()
+    teams = body["teams"]
     assert len(teams) == 1
     assert teams[0]["user_id"] == "alice"
+    assert body["next_cursor"] is None
+
+
+# --- Cursor pagination (Story 36.1, ADR-031 §Decision 1-4) ---
+
+
+def _create_teams(client: TestClient, n: int) -> None:
+    """Create ``n`` teams for the default (anonymous) identity."""
+    for _ in range(n):
+        resp = client.post("/teams/", json={"catalog_namespace": "test-team"})
+        assert resp.status_code == 201
+
+
+def test_list_teams_limit_zero_clamped_no_500(client: TestClient) -> None:
+    """(d) ?limit=0 is clamped (>=1) and returns 200, never a 500."""
+    _create_teams(client, 2)
+    resp = client.get("/teams/", params={"limit": 0})
+    assert resp.status_code == 200
+    assert 1 <= len(resp.json()["teams"]) <= 200
+
+
+def test_list_teams_limit_huge_clamped_no_500(client: TestClient) -> None:
+    """(d) ?limit=99999 is clamped to <=200 and returns 200."""
+    _create_teams(client, 3)
+    resp = client.get("/teams/", params={"limit": 99999})
+    assert resp.status_code == 200
+    assert len(resp.json()["teams"]) <= 200
+
+
+def test_list_teams_malformed_cursor_returns_400(client: TestClient) -> None:
+    """(#6) A malformed cursor returns a 400, never a 500 or unhandled error."""
+    resp = client.get("/teams/", params={"cursor": "not-a-valid-token"})
+    assert resp.status_code == 400
+
+
+def test_list_teams_walk_visits_every_team_once(client: TestClient) -> None:
+    """(#6) An end-to-end HTTP walk over a multi-page set visits every team once."""
+    _create_teams(client, 5)
+    seen: list[str] = []
+    cursor: str | None = None
+    pages = 0
+    while True:
+        params: dict[str, object] = {"limit": 2}
+        if cursor is not None:
+            params["cursor"] = cursor
+        resp = client.get("/teams/", params=params)
+        assert resp.status_code == 200
+        body = resp.json()
+        seen.extend(t["team_id"] for t in body["teams"])
+        cursor = body["next_cursor"]
+        pages += 1
+        assert pages < 10  # guard against an infinite walk
+        if cursor is None:
+            break
+    assert len(seen) == 5
+    assert len(set(seen)) == 5  # no duplicates, no gaps
+
+
+# --- Statelessness (Story 36.1 AC #12): cursor is the only pagination state ---
+
+
+@pytest.fixture()
+def second_replica_client(
+    seeded_settings: CommunitySettings,
+) -> Generator[TestClient, None, None]:
+    """A second, independently-wired app over the SAME on-disk event store.
+
+    Simulates a different worker/replica: it shares no in-process state with the
+    primary ``client`` — only the persisted store contents (same event_store_path).
+    """
+    services = wire_community(seeded_settings)
+    application = create_app(services, seeded_settings)
+    yield TestClient(application)
+    services.actor_system.shutdown()
+
+
+def test_cursor_followable_across_independent_replicas(
+    client: TestClient,
+    second_replica_client: TestClient,
+) -> None:
+    """AC #12: a cursor minted by one replica is followable by another replica
+    serving the same store — no reliance on the minting request's in-process state.
+    """
+    _create_teams(client, 5)
+
+    # Replica A mints page 1 + cursor.
+    resp_a = client.get("/teams/", params={"limit": 2})
+    assert resp_a.status_code == 200
+    body_a = resp_a.json()
+    cursor = body_a["next_cursor"]
+    assert cursor is not None
+    page1 = {t["team_id"] for t in body_a["teams"]}
+
+    # Replica B (separate app/services) follows that cursor over the shared store.
+    resp_b = second_replica_client.get("/teams/", params={"limit": 2, "cursor": cursor})
+    assert resp_b.status_code == 200
+    page2 = {t["team_id"] for t in resp_b.json()["teams"]}
+
+    assert page1.isdisjoint(page2)  # B did not re-show A's page
+    assert len(page1 | page2) == 4  # contiguous walk across the replica boundary

--- a/tests/server/services/test_team_service.py
+++ b/tests/server/services/test_team_service.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import logging
 import shutil
 import uuid
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from unittest.mock import MagicMock
 
@@ -12,7 +13,11 @@ import pytest
 from akgentic.catalog.models.errors import EntryNotFoundError
 from akgentic.team.models import Process, TeamStatus
 
-from akgentic.infra.server.services.team_service import TeamService
+from akgentic.infra.server.services.team_service import (
+    InvalidCursorError,
+    TeamCursor,
+    TeamService,
+)
 
 
 def test_create_team_returns_process(team_service: TeamService) -> None:
@@ -68,17 +73,18 @@ def test_create_team_forwards_user_email_and_team_id(team_service: TeamService) 
 
 
 def test_list_teams_empty(team_service: TeamService) -> None:
-    """Listing teams when none exist returns empty list."""
-    result = team_service.list_teams(user_id="anonymous")
-    assert result == []
+    """Listing teams when none exist returns an empty page and no cursor."""
+    page, next_cursor = team_service.list_teams(user_id="anonymous")
+    assert page == []
+    assert next_cursor is None
 
 
 def test_list_teams_filters_by_user(team_service: TeamService) -> None:
     """list_teams returns only teams belonging to the given user."""
     team_service.create_team(catalog_namespace="test-team", user_id="alice")
     team_service.create_team(catalog_namespace="test-team", user_id="bob")
-    alice_teams = team_service.list_teams(user_id="alice")
-    bob_teams = team_service.list_teams(user_id="bob")
+    alice_teams, _ = team_service.list_teams(user_id="alice")
+    bob_teams, _ = team_service.list_teams(user_id="bob")
     assert len(alice_teams) == 1
     assert len(bob_teams) == 1
     assert alice_teams[0].user_id == "alice"
@@ -97,16 +103,16 @@ def test_list_teams_delegates_to_event_store_with_user_id(team_service: TeamServ
     # SkipValidation on the field allows direct assignment without re-validation.
     team_service._services.event_store = mock_event_store  # type: ignore[assignment]
 
-    result = team_service.list_teams(user_id="alice")
+    page, next_cursor = team_service.list_teams(user_id="alice")
 
     # The delegating call shape — exactly one call, user_id="alice" as kwarg.
+    # Phase-2 (store-side keyset pushdown) is out of scope: NO limit/cursor here.
     mock_event_store.list_teams.assert_called_once_with(user_id="alice")
-    # The call must NOT be a no-arg call followed by an in-Python filter.
     assert mock_event_store.list_teams.call_args.args == ()
     assert mock_event_store.list_teams.call_args.kwargs == {"user_id": "alice"}
-    # And the returned list is the event store's return value verbatim
-    # (no intermediate Python comprehension repacking it).
-    assert result == []
+    # Empty owned set -> empty page, no next cursor.
+    assert page == []
+    assert next_cursor is None
 
 
 def test_list_teams_passes_empty_string_user_id_verbatim(team_service: TeamService) -> None:
@@ -387,3 +393,243 @@ class TestDeleteTeamWorkspaceCleanup:
 
         assert rmtree_calls == []
         service._services.worker_handle.delete_team.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Story 36.1 — keyset (cursor) pagination on list_teams.
+#
+# These tests use a MagicMock event store returning hand-built Process
+# snapshots so created_at / team_id are deterministic (the real fixture
+# stamps near-identical timestamps). team_card is a MagicMock per the
+# established `Process.model_construct` pattern.
+# ---------------------------------------------------------------------------
+
+_BASE_TIME = datetime(2026, 1, 1, tzinfo=UTC)
+
+
+def _make_process(created_at: datetime, team_id: uuid.UUID) -> Process:
+    """Build a Process snapshot with explicit keyset columns."""
+    return Process.model_construct(
+        team_id=team_id,
+        team_card=MagicMock(),
+        status=TeamStatus.RUNNING,
+        user_id="alice",
+        user_email="",
+        created_at=created_at,
+        updated_at=created_at,
+    )
+
+
+def _service_over(rows: list[Process]) -> TeamService:
+    """TeamService whose event store returns a fresh copy of ``rows`` each call."""
+    services = MagicMock()
+    services.event_store.list_teams.side_effect = lambda **_kw: list(rows)
+    return TeamService(services, workspaces_root=Path("/unused"))
+
+
+def _distinct_rows(n: int) -> list[Process]:
+    """``n`` processes with strictly increasing created_at (distinct positions)."""
+    return [
+        _make_process(_BASE_TIME + timedelta(minutes=i), uuid.uuid4()) for i in range(n)
+    ]
+
+
+def test_default_limit_over_50_returns_50_and_cursor() -> None:
+    """(a) >50 set with default limit returns exactly 50 + a non-null cursor."""
+    service = _service_over(_distinct_rows(60))
+    page, next_cursor = service.list_teams(user_id="alice")
+    assert len(page) == 50
+    assert next_cursor is not None
+
+
+def test_set_at_or_below_limit_returns_all_and_none() -> None:
+    """(a) <=50 set returns every team and a None cursor."""
+    service = _service_over(_distinct_rows(50))
+    page, next_cursor = service.list_teams(user_id="alice")
+    assert len(page) == 50
+    assert next_cursor is None
+
+
+def test_walk_multipage_set_visits_every_team_once() -> None:
+    """(b) Following next_cursor over a >2-page set yields every team exactly once."""
+    rows = _distinct_rows(7)
+    service = _service_over(rows)
+    seen: list[uuid.UUID] = []
+    cursor: TeamCursor | None = None
+    pages = 0
+    while True:
+        page, token = service.list_teams(user_id="alice", limit=3, cursor=cursor)
+        pages += 1
+        seen.extend(p.team_id for p in page)
+        if token is None:
+            break
+        cursor = TeamCursor.decode(token)
+        assert pages < 10  # guard against an accidental infinite walk
+    assert pages == 3  # 3 + 3 + 1
+    assert seen == sorted(
+        (p.team_id for p in rows),
+        key=lambda tid: next(
+            (r.created_at, r.team_id) for r in rows if r.team_id == tid
+        ),
+        reverse=True,
+    )
+    assert len(set(seen)) == len(rows)  # no duplicates, no gaps
+
+
+def test_ordering_is_created_at_then_team_id_desc() -> None:
+    """(c) Order is created_at DESC, team_id DESC, with a tie broken by team_id."""
+    t0 = _BASE_TIME
+    t1 = _BASE_TIME + timedelta(minutes=1)
+    low = uuid.UUID(int=1)
+    high = uuid.UUID(int=2)
+    # Two rows share created_at=t0 to exercise the team_id tie-breaker.
+    rows = [
+        _make_process(t0, low),
+        _make_process(t1, high),
+        _make_process(t0, high),
+    ]
+    service = _service_over(rows)
+    page, _ = service.list_teams(user_id="alice", limit=10)
+    keys = [(p.created_at, p.team_id) for p in page]
+    assert keys == sorted(keys, reverse=True)
+    # Newest timestamp first; among the t0 tie, the higher team_id leads.
+    assert keys == [(t1, high), (t0, high), (t0, low)]
+
+
+def test_cursor_encode_decode_roundtrip() -> None:
+    """(e) encode -> decode round-trips to an equal keyset position."""
+    cursor = TeamCursor(created_at=_BASE_TIME, team_id=uuid.uuid4())
+    restored = TeamCursor.decode(cursor.encode())
+    assert restored == cursor
+
+
+def test_decode_malformed_token_raises() -> None:
+    """(e) A malformed token raises the well-defined InvalidCursorError."""
+    with pytest.raises(InvalidCursorError):
+        TeamCursor.decode("not-a-valid-token")
+
+
+def test_decode_oversized_token_raises() -> None:
+    """(e) An oversized token is rejected before decoding."""
+    with pytest.raises(InvalidCursorError):
+        TeamCursor.decode("A" * 5000)
+
+
+def test_insert_newer_team_between_pages_no_dup_or_skip() -> None:
+    """(f) Inserting a newer team between fetches does not re-show/skip seen rows."""
+    rows = _distinct_rows(5)  # created_at increasing => newest is rows[-1]
+    services = MagicMock()
+    services.event_store.list_teams.side_effect = lambda **_kw: list(rows)
+    service = TeamService(services, workspaces_root=Path("/unused"))
+
+    page1, token = service.list_teams(user_id="alice", limit=2)
+    assert token is not None
+    seen = [p.team_id for p in page1]
+
+    # A new, NEWER team appears before page 2 is fetched.
+    newer = _make_process(_BASE_TIME + timedelta(hours=1), uuid.uuid4())
+    rows.append(newer)
+
+    cursor = TeamCursor.decode(token)
+    page2, _ = service.list_teams(user_id="alice", limit=2, cursor=cursor)
+    seen += [p.team_id for p in page2]
+
+    assert newer.team_id not in seen  # newer row sits before the held cursor
+    assert len(set(seen)) == len(seen)  # no duplicates among already-seen rows
+
+
+def test_delete_unseen_team_between_pages_no_dup_or_gap() -> None:
+    """(f) Deleting a not-yet-seen row between fetches leaves seen rows intact."""
+    rows = _distinct_rows(6)
+    services = MagicMock()
+    services.event_store.list_teams.side_effect = lambda **_kw: list(rows)
+    service = TeamService(services, workspaces_root=Path("/unused"))
+
+    page1, token = service.list_teams(user_id="alice", limit=2)
+    assert token is not None
+    seen = {p.team_id for p in page1}
+
+    # Delete an OLDER (not-yet-seen) row before continuing.
+    oldest = min(rows, key=lambda p: (p.created_at, p.team_id))
+    rows.remove(oldest)
+
+    cursor = TeamCursor.decode(token)
+    page2, _ = service.list_teams(user_id="alice", limit=2, cursor=cursor)
+    page2_ids = {p.team_id for p in page2}
+
+    assert seen.isdisjoint(page2_ids)  # no row re-shown
+    assert oldest.team_id not in page2_ids  # deleted row never surfaces
+
+
+def test_limit_clamped_to_range() -> None:
+    """(d) limit is clamped to [1, 200]: 0 -> 1 row, 99999 -> all (<=200)."""
+    rows = _distinct_rows(3)
+    service = _service_over(rows)
+    page_low, _ = service.list_teams(user_id="alice", limit=0)
+    assert len(page_low) == 1
+    page_high, _ = service.list_teams(user_id="alice", limit=99999)
+    assert len(page_high) == 3
+
+
+# ---------------------------------------------------------------------------
+# Story 36.1 AC #12 — the server is stateless: the opaque cursor is the ONLY
+# pagination state and it lives on the client. list_teams is a pure function of
+# (user_id, limit, cursor) + current store contents; nothing is cached between
+# requests, so a page is correct regardless of which replica serves it.
+# ---------------------------------------------------------------------------
+
+
+def test_list_teams_refetches_store_every_call() -> None:
+    """Every list_teams call re-reads the store — no cached sorted list."""
+    service = _service_over(_distinct_rows(5))
+    service.list_teams(user_id="alice", limit=2)
+    _, token = service.list_teams(user_id="alice", limit=2)
+    assert token is not None
+    service.list_teams(user_id="alice", limit=2, cursor=TeamCursor.decode(token))
+    # One store read per request — no request reused a prior request's fetch.
+    assert service._services.event_store.list_teams.call_count == 3
+
+
+def test_same_cursor_yields_same_page_independent_requests() -> None:
+    """Two independent requests with the same cursor return the same page."""
+    rows = _distinct_rows(7)
+    service = _service_over(rows)
+    _, token = service.list_teams(user_id="alice", limit=2)
+    assert token is not None
+    cursor = TeamCursor.decode(token)
+    page_a, next_a = service.list_teams(user_id="alice", limit=2, cursor=cursor)
+    page_b, next_b = service.list_teams(user_id="alice", limit=2, cursor=cursor)
+    assert [p.team_id for p in page_a] == [p.team_id for p in page_b]
+    assert next_a == next_b
+
+
+def test_cursor_works_on_fresh_service_instance() -> None:
+    """A cursor minted by one service instance is followable by a SEPARATE,
+    freshly constructed instance over the same store contents — simulating a
+    different worker/replica with no shared in-process state.
+    """
+    rows = _distinct_rows(7)
+    minting_service = _service_over(rows)
+    page1, token = minting_service.list_teams(user_id="alice", limit=3)
+    assert token is not None
+
+    # A brand-new instance (different "replica"), no prior request primed.
+    fresh_service = _service_over(rows)
+    page2, _ = fresh_service.list_teams(
+        user_id="alice", limit=3, cursor=TeamCursor.decode(token)
+    )
+
+    seen = {p.team_id for p in page1} | {p.team_id for p in page2}
+    assert {p.team_id for p in page1}.isdisjoint({p.team_id for p in page2})
+    assert len(seen) == 6  # 3 + 3, no overlap, no gap across the replica boundary
+
+
+def test_list_teams_holds_no_per_request_state() -> None:
+    """list_teams mutates no instance attribute that survives the call."""
+    service = _service_over(_distinct_rows(5))
+    before = dict(vars(service))
+    service.list_teams(user_id="alice", limit=2)
+    after = dict(vars(service))
+    # No new attribute, and the wired collaborators are unchanged identities.
+    assert before.keys() == after.keys()
+    assert all(before[k] is after[k] for k in before)


### PR DESCRIPTION
## Epic 36 — Cursor-Paginated Team Listing

Phase-1 keyset (cursor) pagination for `GET /teams`, computed in the infra service
layer. The endpoint returns a bounded page ordered `created_at DESC, team_id DESC`
plus an opaque `next_cursor` the client follows to walk the rest. The team store
still returns the full owned set (no `limit`/`cursor` push-down — that is the
deferred Phase-2 `akgentic-team` work).

### Stories

- [x] 36-1-cursor-paginated-get-teams — cursor-paginate `GET /teams` (`limit` + `cursor` + `next_cursor`, keyset in the service layer) (Relates to #317)

### What changed

- `TeamListResponse` gains a nullable, shape-backward-compatible `next_cursor: str | None`.
- `TeamCursor` (typed Pydantic boundary value) encodes the keyset position
  `{created_at, team_id}` as `base64url(json(...))`; `decode` folds every failure path
  (bad base64 / JSON / pydantic / oversized) into `InvalidCursorError`.
- `TeamService.list_teams(*, user_id, limit=50, cursor=None) -> (page, next_cursor)`:
  re-fetches the owned set, sorts `created_at DESC, team_id DESC`, seeks strictly past
  the cursor, slices `limit`, and emits `next_cursor` only on a full page with rows
  remaining (so the last page is `None`). `limit` clamped to `[1, 200]`.
- `GET /teams` accepts `limit` + `cursor`; a malformed/oversized cursor maps to HTTP 400
  (never 500). The Angular V1 adapter requests the max page and ignores `next_cursor`.

## Review status

**36-1: APPROVED -> done (Rex).** Reviewed commit `600d184` (single-commit story diff;
`600d184^` is master). Implementation is correct and stateless. No fix-worthy issues found;
no review-fix commit was required.

- Statelessness invariant verified — the server holds no cross-request pagination state.
  Covered by 4 service-level tests (per-call store re-fetch / `call_count==3`,
  same-cursor -> same-page across independent requests, a SEPARATE freshly-constructed
  service instance following a cursor minted elsewhere, and `vars(service)` identical
  before/after a call) plus a route-level cross-replica test (a 2nd independently-wired
  app+services over the same on-disk event store follows app A's cursor).
- Typed boundary (Golden Rule #1): `next_cursor` / `TeamCursor` are Pydantic, no `dict[str, Any]`.
- No ADR-string assertions or ADR-branching logic (Golden Rule #8).

## Scope guard

All changes stay inside `packages/akgentic-infra/`. No file under `packages/akgentic-team/`
(or any other submodule) was touched — the `EventStore.list_teams` keyset push-down is the
deferred Phase-2 follow-up (Golden Rule #4).

## Epic 36 slice complete

36-1 is the only story in this slice — this PR completes its infra work.

Local gate: `ruff` clean, `mypy --strict` clean (112 source files), full infra suite
**1542 passed, 39 skipped**, coverage **90.37%** (>= 90% threshold).

Closes #317
