### PR TITLE
feat(akgentic-infra): epic 37 — classic offset+total paginated team listing (37-1)

### DIFF
--- a/src/akgentic/infra/server/models.py
+++ b/src/akgentic/infra/server/models.py
@@ -32,13 +32,10 @@ class TeamResponse(BaseModel):
 
 
 class TeamListResponse(BaseModel):
-    """Response body for GET /teams."""
+    """Response body for GET /teams (one numbered page + full owned count)."""
 
-    teams: list[TeamResponse] = Field(description="List of team metadata entries")
-    next_cursor: str | None = Field(
-        default=None,
-        description="Opaque token for the next page; null when this is the last page.",
-    )
+    teams: list[TeamResponse] = Field(description="Current page of team metadata entries")
+    total_count: int = Field(description="Total teams for the user across all pages")
 
 
 class SendMessageRequest(BaseModel):

--- a/src/akgentic/infra/server/routes/frontend_adapter/angular_v1/router.py
+++ b/src/akgentic/infra/server/routes/frontend_adapter/angular_v1/router.py
@@ -33,7 +33,7 @@ from akgentic.infra.server.routes.frontend_adapter.angular_v1.models import (
     V1StateUpdateBody,
     V1StatusResponse,
 )
-from akgentic.infra.server.services.team_service import MAX_PAGE_LIMIT, TeamService
+from akgentic.infra.server.services.team_service import MAX_PAGE_SIZE, TeamService
 from akgentic.team.models import PersistedEvent, Process, TeamStatus
 
 process_router = APIRouter(prefix="/process", tags=["v1-compat"])
@@ -148,8 +148,8 @@ def list_processes(
     service: TeamService = Depends(get_team_service),
 ) -> list[V1ProcessContext]:
     """GET /process/ -> list teams as flat list."""
-    # V1 adapter has no pagination; request the max page (next_cursor ignored).
-    page, _ = service.list_teams(user_id="anonymous", limit=MAX_PAGE_LIMIT)
+    # V1 adapter has no pagination; request the max page (total_count ignored).
+    page, _ = service.list_teams(user_id="anonymous", size=MAX_PAGE_SIZE)
     return [_to_v1_process_context(p) for p in page]
 
 

--- a/src/akgentic/infra/server/routes/teams.py
+++ b/src/akgentic/infra/server/routes/teams.py
@@ -21,11 +21,7 @@ from akgentic.infra.server.models import (
     TeamListResponse,
     TeamResponse,
 )
-from akgentic.infra.server.services.team_service import (
-    InvalidCursorError,
-    TeamCursor,
-    TeamService,
-)
+from akgentic.infra.server.services.team_service import TeamService
 from akgentic.infra.server.state_keys import CONNECTION_MANAGER, TEAM_SERVICE
 from akgentic.team.models import Process
 
@@ -79,21 +75,15 @@ def create_team(
 def list_teams(
     user: RequestUser = Depends(get_request_user),
     service: TeamService = Depends(get_team_service),
-    limit: int = 50,
-    cursor: str | None = None,
+    page: int = 1,
+    size: int = 250,
 ) -> TeamListResponse:
-    """List one keyset-paginated page of teams for the current user."""
-    logger.debug("GET /teams — limit=%s cursor=%s", limit, cursor is not None)
-    decoded = None
-    if cursor is not None:
-        try:
-            decoded = TeamCursor.decode(cursor)
-        except InvalidCursorError:
-            raise HTTPException(status_code=400, detail="Invalid cursor") from None
-    page, next_cursor = service.list_teams(user_id=user.user_id, limit=limit, cursor=decoded)
+    """List one numbered page of teams for the current user, plus the total count."""
+    logger.debug("GET /teams — page=%s size=%s", page, size)
+    page_slice, total = service.list_teams(user_id=user.user_id, page=page, size=size)
     return TeamListResponse(
-        teams=[_process_to_response(p) for p in page],
-        next_cursor=next_cursor,
+        teams=[_process_to_response(p) for p in page_slice],
+        total_count=total,
     )
 
 

--- a/src/akgentic/infra/server/services/team_service.py
+++ b/src/akgentic/infra/server/services/team_service.py
@@ -2,16 +2,10 @@
 
 from __future__ import annotations
 
-import base64
-import binascii
-import json
 import logging
 import shutil
 import uuid
-from datetime import datetime
 from pathlib import Path
-
-from pydantic import BaseModel, Field, ValidationError
 
 from akgentic.catalog.models.errors import CatalogValidationError, EntryNotFoundError
 from akgentic.core.messages.orchestrator import SentMessage
@@ -24,44 +18,8 @@ from akgentic.team.models import AgentStateSnapshot, PersistedEvent, Process, Te
 
 logger = logging.getLogger(__name__)
 
-# Default and maximum page sizes for GET /teams (ADR-031 §Decision 1).
-DEFAULT_PAGE_LIMIT = 50
-MAX_PAGE_LIMIT = 200
-# Upper bound on an incoming cursor token; a well-formed cursor is well under
-# this, so anything larger is rejected before base64 decoding (ADR-031 §6).
-_MAX_CURSOR_LEN = 4096
-
-
-class InvalidCursorError(ValueError):
-    """Raised when a cursor token cannot be decoded into a TeamCursor."""
-
-
-class TeamCursor(BaseModel):
-    """Opaque keyset position for GET /teams pagination (ADR-031 §Decision 2)."""
-
-    created_at: datetime = Field(description="created_at of the last row on the previous page")
-    team_id: uuid.UUID = Field(description="team_id tie-breaker of that row")
-
-    def encode(self) -> str:
-        """Encode this position as a base64url(json) opaque token."""
-        payload = json.dumps(self.model_dump(mode="json")).encode("utf-8")
-        return base64.urlsafe_b64encode(payload).decode("ascii")
-
-    @classmethod
-    def decode(cls, token: str) -> TeamCursor:
-        """Decode an opaque token back into a TeamCursor.
-
-        Raises:
-            InvalidCursorError: On any malformed, oversized, or unparseable token.
-        """
-        if len(token) > _MAX_CURSOR_LEN:
-            raise InvalidCursorError("cursor token too long")
-        try:
-            raw = base64.urlsafe_b64decode(token.encode("ascii"))
-            data = json.loads(raw)
-            return cls.model_validate(data)
-        except (binascii.Error, ValueError, ValidationError, UnicodeDecodeError) as exc:
-            raise InvalidCursorError("malformed cursor token") from exc
+# Maximum page size for GET /teams; the default is 250 (ADR-032 §Decision 1).
+MAX_PAGE_SIZE = 500
 
 
 def _remove_workspace_dir(workspaces_root: Path, team_id: uuid.UUID) -> None:
@@ -178,39 +136,23 @@ class TeamService:
         self,
         *,
         user_id: str,
-        limit: int = DEFAULT_PAGE_LIMIT,
-        cursor: TeamCursor | None = None,
-    ) -> tuple[list[Process], str | None]:
-        """Return one keyset-paginated page of the user's teams plus next cursor.
+        page: int = 1,
+        size: int = 250,
+    ) -> tuple[list[Process], int]:
+        """Return one numbered page of the user's teams plus the full owned count.
 
-        Phase 1: the store still returns the full owned set (ADR-031 §Decision 3);
-        the page is sorted ``created_at DESC, team_id DESC``, seeked past the
-        cursor, and sliced here. ``next_cursor`` is set only when the page is full
-        and rows remain after it; otherwise None.
+        Phase 1: the store returns the full owned set, sorted ``created_at DESC,
+        team_id DESC`` and sliced here (ADR-032 §Decision 2). Stateless — a pure
+        function of ``user_id`` + ``page`` + ``size`` + store contents. An
+        out-of-range page yields an empty list with the correct total.
         """
-        limit = max(1, min(limit, MAX_PAGE_LIMIT))
         rows = self._services.event_store.list_teams(user_id=user_id)
         rows.sort(key=lambda p: (p.created_at, p.team_id), reverse=True)
-        start = self._seek(rows, cursor)
-        page = rows[start : start + limit]
-        more_remain = start + limit < len(rows)
-        next_cursor = (
-            TeamCursor(created_at=page[-1].created_at, team_id=page[-1].team_id).encode()
-            if len(page) == limit and more_remain
-            else None
-        )
-        return page, next_cursor
-
-    @staticmethod
-    def _seek(rows: list[Process], cursor: TeamCursor | None) -> int:
-        """Index of the first row strictly after the cursor in DESC keyset order."""
-        if cursor is None:
-            return 0
-        target = (cursor.created_at, cursor.team_id)
-        return next(
-            (i for i, p in enumerate(rows) if (p.created_at, p.team_id) < target),
-            len(rows),
-        )
+        total = len(rows)
+        size = max(1, min(size, MAX_PAGE_SIZE))
+        page = max(1, page)
+        start = (page - 1) * size
+        return rows[start : start + size], total
 
     def get_team(self, team_id: uuid.UUID) -> Process | None:
         """Get a single team by ID."""

--- a/tests/server/models/test_server_models.py
+++ b/tests/server/models/test_server_models.py
@@ -5,6 +5,9 @@ from __future__ import annotations
 import uuid
 from datetime import UTC, datetime
 
+import pytest
+from pydantic import ValidationError
+
 from akgentic.infra.server.models import (
     CreateTeamRequest,
     EventListResponse,
@@ -50,26 +53,27 @@ def test_team_response_serialization() -> None:
 
 
 def test_team_list_response_empty() -> None:
-    """TeamListResponse can hold an empty list."""
-    resp = TeamListResponse(teams=[])
+    """TeamListResponse can hold an empty list with a zero total_count."""
+    resp = TeamListResponse(teams=[], total_count=0)
     assert resp.teams == []
+    assert resp.total_count == 0
 
 
-def test_team_list_response_next_cursor_defaults_none() -> None:
-    """TeamListResponse(teams=...) without next_cursor stays backward-compatible."""
-    resp = TeamListResponse(teams=[])
-    assert resp.next_cursor is None
-    assert resp.model_dump()["next_cursor"] is None
+def test_team_list_response_requires_total_count() -> None:
+    """total_count is required — omitting it raises a ValidationError."""
+    with pytest.raises(ValidationError):
+        TeamListResponse(teams=[])  # type: ignore[call-arg]
 
 
-def test_team_list_response_carries_next_cursor() -> None:
-    """next_cursor round-trips through serialization when provided."""
-    resp = TeamListResponse(teams=[], next_cursor="opaque-token")
-    assert resp.model_dump(mode="json")["next_cursor"] == "opaque-token"
+def test_team_list_response_total_count_round_trips() -> None:
+    """total_count round-trips through serialization (full owned count before paging)."""
+    resp = TeamListResponse(teams=[], total_count=1234)
+    assert resp.total_count == 1234
+    assert resp.model_dump(mode="json")["total_count"] == 1234
 
 
 def test_team_list_response_with_items() -> None:
-    """TeamListResponse serializes a list of TeamResponses."""
+    """TeamListResponse serializes a list of TeamResponses plus the total."""
     tid = uuid.uuid4()
     now = datetime.now(tz=UTC)
     item = TeamResponse(
@@ -80,9 +84,10 @@ def test_team_list_response_with_items() -> None:
         created_at=now,
         updated_at=now,
     )
-    resp = TeamListResponse(teams=[item])
+    resp = TeamListResponse(teams=[item], total_count=1)
     assert len(resp.teams) == 1
     assert resp.teams[0].team_id == tid
+    assert resp.total_count == 1
 
 
 def test_send_message_request() -> None:

--- a/tests/server/routes/test_team_routes.py
+++ b/tests/server/routes/test_team_routes.py
@@ -32,15 +32,16 @@ def test_create_team_invalid_entry(client: TestClient) -> None:
 
 
 def test_list_teams_empty(client: TestClient) -> None:
-    """GET /teams returns empty list and a null next_cursor when no teams exist."""
+    """GET /teams returns an empty list and total_count == 0 when no teams exist."""
     resp = client.get("/teams/")
     assert resp.status_code == 200
-    assert resp.json()["teams"] == []
-    assert resp.json()["next_cursor"] is None
+    body = resp.json()
+    assert body["teams"] == []
+    assert body["total_count"] == 0
 
 
 def test_list_teams_after_create(client: TestClient) -> None:
-    """GET /teams returns created teams; a single-team set has a null next_cursor."""
+    """GET /teams returns created teams and total_count == the owned count."""
     client.post("/teams/", json={"catalog_namespace": "test-team"})
     resp = client.get("/teams/")
     assert resp.status_code == 200
@@ -48,7 +49,7 @@ def test_list_teams_after_create(client: TestClient) -> None:
     teams = body["teams"]
     assert len(teams) == 1
     assert teams[0]["name"] == "Test Team"
-    assert body["next_cursor"] is None
+    assert body["total_count"] == 1
 
 
 def test_get_team_success(client: TestClient) -> None:
@@ -127,10 +128,10 @@ def test_list_teams_filters_by_overridden_identity(
     teams = body["teams"]
     assert len(teams) == 1
     assert teams[0]["user_id"] == "alice"
-    assert body["next_cursor"] is None
+    assert body["total_count"] == 1
 
 
-# --- Cursor pagination (Story 36.1, ADR-031 §Decision 1-4) ---
+# --- Classic offset+total pagination (Story 37.1, ADR-032 §Decision 1-2) ---
 
 
 def _create_teams(client: TestClient, n: int) -> None:
@@ -140,52 +141,64 @@ def _create_teams(client: TestClient, n: int) -> None:
         assert resp.status_code == 201
 
 
-def test_list_teams_limit_zero_clamped_no_500(client: TestClient) -> None:
-    """(d) ?limit=0 is clamped (>=1) and returns 200, never a 500."""
-    _create_teams(client, 2)
-    resp = client.get("/teams/", params={"limit": 0})
-    assert resp.status_code == 200
-    assert 1 <= len(resp.json()["teams"]) <= 200
-
-
-def test_list_teams_limit_huge_clamped_no_500(client: TestClient) -> None:
-    """(d) ?limit=99999 is clamped to <=200 and returns 200."""
+def test_list_teams_default_page_returns_total_count(client: TestClient) -> None:
+    """No query params: total_count == full owned count; teams capped at the default."""
     _create_teams(client, 3)
-    resp = client.get("/teams/", params={"limit": 99999})
+    resp = client.get("/teams/")
     assert resp.status_code == 200
-    assert len(resp.json()["teams"]) <= 200
+    body = resp.json()
+    assert body["total_count"] == 3
+    assert len(body["teams"]) == 3  # well under the 250 default
 
 
-def test_list_teams_malformed_cursor_returns_400(client: TestClient) -> None:
-    """(#6) A malformed cursor returns a 400, never a 500 or unhandled error."""
-    resp = client.get("/teams/", params={"cursor": "not-a-valid-token"})
-    assert resp.status_code == 400
-
-
-def test_list_teams_walk_visits_every_team_once(client: TestClient) -> None:
-    """(#6) An end-to-end HTTP walk over a multi-page set visits every team once."""
+def test_list_teams_page_size_slices_and_orders(client: TestClient) -> None:
+    """?page=&size= slice the owned set; total_count stays full; pages don't overlap."""
     _create_teams(client, 5)
-    seen: list[str] = []
-    cursor: str | None = None
-    pages = 0
-    while True:
-        params: dict[str, object] = {"limit": 2}
-        if cursor is not None:
-            params["cursor"] = cursor
-        resp = client.get("/teams/", params=params)
-        assert resp.status_code == 200
-        body = resp.json()
-        seen.extend(t["team_id"] for t in body["teams"])
-        cursor = body["next_cursor"]
-        pages += 1
-        assert pages < 10  # guard against an infinite walk
-        if cursor is None:
-            break
-    assert len(seen) == 5
-    assert len(set(seen)) == 5  # no duplicates, no gaps
+    resp1 = client.get("/teams/", params={"page": 1, "size": 2})
+    resp2 = client.get("/teams/", params={"page": 2, "size": 2})
+    resp3 = client.get("/teams/", params={"page": 3, "size": 2})
+    assert resp1.status_code == resp2.status_code == resp3.status_code == 200
+    body1, body2, body3 = resp1.json(), resp2.json(), resp3.json()
+
+    # total_count is the full owned count on every page.
+    assert body1["total_count"] == body2["total_count"] == body3["total_count"] == 5
+    assert len(body1["teams"]) == 2
+    assert len(body2["teams"]) == 2
+    assert len(body3["teams"]) == 1  # last partial page
+
+    ids = [t["team_id"] for t in body1["teams"] + body2["teams"] + body3["teams"]]
+    assert len(set(ids)) == 5  # contiguous, no overlap, no gap
+
+    # Ordering is created_at DESC, team_id DESC — newest first across all pages.
+    created = [
+        (t["created_at"], t["team_id"]) for t in body1["teams"] + body2["teams"] + body3["teams"]
+    ]
+    assert created == sorted(created, reverse=True)
 
 
-# --- Statelessness (Story 36.1 AC #12): cursor is the only pagination state ---
+def test_list_teams_out_of_range_page_empty_with_total(client: TestClient) -> None:
+    """An out-of-range page returns an empty list with the correct total_count."""
+    _create_teams(client, 3)
+    resp = client.get("/teams/", params={"page": 99, "size": 10})
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["teams"] == []
+    assert body["total_count"] == 3
+
+
+def test_list_teams_size_clamped_no_500(client: TestClient) -> None:
+    """size <= 0 and size > 500 are clamped to [1, 500]; the request never 500s."""
+    _create_teams(client, 2)
+    resp_low = client.get("/teams/", params={"size": 0})
+    assert resp_low.status_code == 200
+    assert len(resp_low.json()["teams"]) == 1  # clamped to 1
+
+    resp_high = client.get("/teams/", params={"size": 99999})
+    assert resp_high.status_code == 200
+    assert len(resp_high.json()["teams"]) <= 500
+
+
+# --- Statelessness (Story 37.1 AC #7): a page is a pure function of args + store ---
 
 
 @pytest.fixture()
@@ -203,27 +216,27 @@ def second_replica_client(
     services.actor_system.shutdown()
 
 
-def test_cursor_followable_across_independent_replicas(
+def test_pages_consistent_across_independent_replicas(
     client: TestClient,
     second_replica_client: TestClient,
 ) -> None:
-    """AC #12: a cursor minted by one replica is followable by another replica
-    serving the same store — no reliance on the minting request's in-process state.
+    """AC #7: page 1 from one replica and page 2 from another serving the same
+    store form a contiguous, non-overlapping walk — no reliance on per-request state.
     """
     _create_teams(client, 5)
 
-    # Replica A mints page 1 + cursor.
-    resp_a = client.get("/teams/", params={"limit": 2})
+    resp_a = client.get("/teams/", params={"page": 1, "size": 2})
     assert resp_a.status_code == 200
     body_a = resp_a.json()
-    cursor = body_a["next_cursor"]
-    assert cursor is not None
+    assert body_a["total_count"] == 5
     page1 = {t["team_id"] for t in body_a["teams"]}
 
-    # Replica B (separate app/services) follows that cursor over the shared store.
-    resp_b = second_replica_client.get("/teams/", params={"limit": 2, "cursor": cursor})
+    # Replica B (separate app/services) serves page 2 over the shared store.
+    resp_b = second_replica_client.get("/teams/", params={"page": 2, "size": 2})
     assert resp_b.status_code == 200
-    page2 = {t["team_id"] for t in resp_b.json()["teams"]}
+    body_b = resp_b.json()
+    assert body_b["total_count"] == 5
+    page2 = {t["team_id"] for t in body_b["teams"]}
 
     assert page1.isdisjoint(page2)  # B did not re-show A's page
     assert len(page1 | page2) == 4  # contiguous walk across the replica boundary

--- a/tests/server/services/test_team_service.py
+++ b/tests/server/services/test_team_service.py
@@ -13,11 +13,7 @@ import pytest
 from akgentic.catalog.models.errors import EntryNotFoundError
 from akgentic.team.models import Process, TeamStatus
 
-from akgentic.infra.server.services.team_service import (
-    InvalidCursorError,
-    TeamCursor,
-    TeamService,
-)
+from akgentic.infra.server.services.team_service import MAX_PAGE_SIZE, TeamService
 
 
 def test_create_team_returns_process(team_service: TeamService) -> None:
@@ -73,20 +69,22 @@ def test_create_team_forwards_user_email_and_team_id(team_service: TeamService) 
 
 
 def test_list_teams_empty(team_service: TeamService) -> None:
-    """Listing teams when none exist returns an empty page and no cursor."""
-    page, next_cursor = team_service.list_teams(user_id="anonymous")
+    """Listing teams when none exist returns an empty page and a zero total."""
+    page, total = team_service.list_teams(user_id="anonymous")
     assert page == []
-    assert next_cursor is None
+    assert total == 0
 
 
 def test_list_teams_filters_by_user(team_service: TeamService) -> None:
     """list_teams returns only teams belonging to the given user."""
     team_service.create_team(catalog_namespace="test-team", user_id="alice")
     team_service.create_team(catalog_namespace="test-team", user_id="bob")
-    alice_teams, _ = team_service.list_teams(user_id="alice")
-    bob_teams, _ = team_service.list_teams(user_id="bob")
+    alice_teams, alice_total = team_service.list_teams(user_id="alice")
+    bob_teams, bob_total = team_service.list_teams(user_id="bob")
     assert len(alice_teams) == 1
+    assert alice_total == 1
     assert len(bob_teams) == 1
+    assert bob_total == 1
     assert alice_teams[0].user_id == "alice"
 
 
@@ -103,16 +101,16 @@ def test_list_teams_delegates_to_event_store_with_user_id(team_service: TeamServ
     # SkipValidation on the field allows direct assignment without re-validation.
     team_service._services.event_store = mock_event_store  # type: ignore[assignment]
 
-    page, next_cursor = team_service.list_teams(user_id="alice")
+    page, total = team_service.list_teams(user_id="alice")
 
     # The delegating call shape — exactly one call, user_id="alice" as kwarg.
-    # Phase-2 (store-side keyset pushdown) is out of scope: NO limit/cursor here.
+    # Phase-2 (store-side offset pushdown) is out of scope: NO page/size here.
     mock_event_store.list_teams.assert_called_once_with(user_id="alice")
     assert mock_event_store.list_teams.call_args.args == ()
     assert mock_event_store.list_teams.call_args.kwargs == {"user_id": "alice"}
-    # Empty owned set -> empty page, no next cursor.
+    # Empty owned set -> empty page, zero total.
     assert page == []
-    assert next_cursor is None
+    assert total == 0
 
 
 def test_list_teams_passes_empty_string_user_id_verbatim(team_service: TeamService) -> None:
@@ -396,7 +394,7 @@ class TestDeleteTeamWorkspaceCleanup:
 
 
 # ---------------------------------------------------------------------------
-# Story 36.1 — keyset (cursor) pagination on list_teams.
+# Story 37.1 — classic offset+total pagination on list_teams (ADR-032).
 #
 # These tests use a MagicMock event store returning hand-built Process
 # snapshots so created_at / team_id are deterministic (the real fixture
@@ -408,7 +406,7 @@ _BASE_TIME = datetime(2026, 1, 1, tzinfo=UTC)
 
 
 def _make_process(created_at: datetime, team_id: uuid.UUID) -> Process:
-    """Build a Process snapshot with explicit keyset columns."""
+    """Build a Process snapshot with explicit sort-key columns."""
     return Process.model_construct(
         team_id=team_id,
         team_card=MagicMock(),
@@ -429,55 +427,53 @@ def _service_over(rows: list[Process]) -> TeamService:
 
 def _distinct_rows(n: int) -> list[Process]:
     """``n`` processes with strictly increasing created_at (distinct positions)."""
-    return [
-        _make_process(_BASE_TIME + timedelta(minutes=i), uuid.uuid4()) for i in range(n)
-    ]
+    return [_make_process(_BASE_TIME + timedelta(minutes=i), uuid.uuid4()) for i in range(n)]
 
 
-def test_default_limit_over_50_returns_50_and_cursor() -> None:
-    """(a) >50 set with default limit returns exactly 50 + a non-null cursor."""
-    service = _service_over(_distinct_rows(60))
-    page, next_cursor = service.list_teams(user_id="alice")
-    assert len(page) == 50
-    assert next_cursor is not None
+def test_page1_returns_size_rows_with_full_total() -> None:
+    """(a) page 1 returns <= size rows; total_count is the full owned count."""
+    service = _service_over(_distinct_rows(300))
+    page, total = service.list_teams(user_id="alice")  # default page=1, size=250
+    assert len(page) == 250
+    assert total == 300
 
 
-def test_set_at_or_below_limit_returns_all_and_none() -> None:
-    """(a) <=50 set returns every team and a None cursor."""
-    service = _service_over(_distinct_rows(50))
-    page, next_cursor = service.list_teams(user_id="alice")
-    assert len(page) == 50
-    assert next_cursor is None
+def test_page1_under_size_returns_all_with_full_total() -> None:
+    """(a) a set smaller than size returns every team with the full total."""
+    service = _service_over(_distinct_rows(40))
+    page, total = service.list_teams(user_id="alice", size=250)
+    assert len(page) == 40
+    assert total == 40
 
 
-def test_walk_multipage_set_visits_every_team_once() -> None:
-    """(b) Following next_cursor over a >2-page set yields every team exactly once."""
-    rows = _distinct_rows(7)
+def test_page_n_returns_correct_slice_in_order() -> None:
+    """(b) page N returns the offset slice in created_at DESC, team_id DESC order."""
+    rows = _distinct_rows(10)
     service = _service_over(rows)
-    seen: list[uuid.UUID] = []
-    cursor: TeamCursor | None = None
-    pages = 0
-    while True:
-        page, token = service.list_teams(user_id="alice", limit=3, cursor=cursor)
-        pages += 1
-        seen.extend(p.team_id for p in page)
-        if token is None:
-            break
-        cursor = TeamCursor.decode(token)
-        assert pages < 10  # guard against an accidental infinite walk
-    assert pages == 3  # 3 + 3 + 1
-    assert seen == sorted(
-        (p.team_id for p in rows),
-        key=lambda tid: next(
-            (r.created_at, r.team_id) for r in rows if r.team_id == tid
-        ),
-        reverse=True,
-    )
-    assert len(set(seen)) == len(rows)  # no duplicates, no gaps
+    expected = sorted(rows, key=lambda p: (p.created_at, p.team_id), reverse=True)
+
+    page1, total1 = service.list_teams(user_id="alice", page=1, size=3)
+    page2, total2 = service.list_teams(user_id="alice", page=2, size=3)
+    page4, total4 = service.list_teams(user_id="alice", page=4, size=3)
+
+    assert total1 == total2 == total4 == 10
+    assert [p.team_id for p in page1] == [p.team_id for p in expected[0:3]]
+    assert [p.team_id for p in page2] == [p.team_id for p in expected[3:6]]
+    # Last partial page: rows 9..10 of 10 (size-3 slice at offset 9).
+    assert [p.team_id for p in page4] == [p.team_id for p in expected[9:12]]
+    assert len(page4) == 1
+
+
+def test_out_of_range_page_returns_empty_with_correct_total() -> None:
+    """(c) a page past the end returns [] with the correct total (no error)."""
+    service = _service_over(_distinct_rows(5))
+    page, total = service.list_teams(user_id="alice", page=99, size=10)
+    assert page == []
+    assert total == 5
 
 
 def test_ordering_is_created_at_then_team_id_desc() -> None:
-    """(c) Order is created_at DESC, team_id DESC, with a tie broken by team_id."""
+    """(d) order is created_at DESC, team_id DESC, with a tie broken by team_id."""
     t0 = _BASE_TIME
     t1 = _BASE_TIME + timedelta(minutes=1)
     low = uuid.UUID(int=1)
@@ -489,92 +485,68 @@ def test_ordering_is_created_at_then_team_id_desc() -> None:
         _make_process(t0, high),
     ]
     service = _service_over(rows)
-    page, _ = service.list_teams(user_id="alice", limit=10)
+    page, total = service.list_teams(user_id="alice", size=10)
     keys = [(p.created_at, p.team_id) for p in page]
+    assert total == 3
     assert keys == sorted(keys, reverse=True)
     # Newest timestamp first; among the t0 tie, the higher team_id leads.
     assert keys == [(t1, high), (t0, high), (t0, low)]
 
 
-def test_cursor_encode_decode_roundtrip() -> None:
-    """(e) encode -> decode round-trips to an equal keyset position."""
-    cursor = TeamCursor(created_at=_BASE_TIME, team_id=uuid.uuid4())
-    restored = TeamCursor.decode(cursor.encode())
-    assert restored == cursor
+def test_size_clamps_to_lower_bound() -> None:
+    """(e) size <= 0 clamps to 1 (returns a single row)."""
+    service = _service_over(_distinct_rows(3))
+    page_zero, total_zero = service.list_teams(user_id="alice", size=0)
+    page_neg, _ = service.list_teams(user_id="alice", size=-5)
+    assert len(page_zero) == 1
+    assert total_zero == 3
+    assert len(page_neg) == 1
 
 
-def test_decode_malformed_token_raises() -> None:
-    """(e) A malformed token raises the well-defined InvalidCursorError."""
-    with pytest.raises(InvalidCursorError):
-        TeamCursor.decode("not-a-valid-token")
+def test_size_clamps_to_upper_bound() -> None:
+    """(e) size > MAX_PAGE_SIZE clamps to MAX_PAGE_SIZE (500)."""
+    service = _service_over(_distinct_rows(600))
+    page, total = service.list_teams(user_id="alice", size=99999)
+    assert len(page) == MAX_PAGE_SIZE
+    assert total == 600
 
 
-def test_decode_oversized_token_raises() -> None:
-    """(e) An oversized token is rejected before decoding."""
-    with pytest.raises(InvalidCursorError):
-        TeamCursor.decode("A" * 5000)
+def test_size_250_default_and_explicit() -> None:
+    """(e) default size is 250, and size=250 (cap raised above 200) works."""
+    service_default = _service_over(_distinct_rows(300))
+    page_default, _ = service_default.list_teams(user_id="alice")
+    assert len(page_default) == 250
+
+    service_explicit = _service_over(_distinct_rows(300))
+    page_explicit, _ = service_explicit.list_teams(user_id="alice", size=250)
+    assert len(page_explicit) == 250
 
 
-def test_insert_newer_team_between_pages_no_dup_or_skip() -> None:
-    """(f) Inserting a newer team between fetches does not re-show/skip seen rows."""
-    rows = _distinct_rows(5)  # created_at increasing => newest is rows[-1]
-    services = MagicMock()
-    services.event_store.list_teams.side_effect = lambda **_kw: list(rows)
-    service = TeamService(services, workspaces_root=Path("/unused"))
-
-    page1, token = service.list_teams(user_id="alice", limit=2)
-    assert token is not None
-    seen = [p.team_id for p in page1]
-
-    # A new, NEWER team appears before page 2 is fetched.
-    newer = _make_process(_BASE_TIME + timedelta(hours=1), uuid.uuid4())
-    rows.append(newer)
-
-    cursor = TeamCursor.decode(token)
-    page2, _ = service.list_teams(user_id="alice", limit=2, cursor=cursor)
-    seen += [p.team_id for p in page2]
-
-    assert newer.team_id not in seen  # newer row sits before the held cursor
-    assert len(set(seen)) == len(seen)  # no duplicates among already-seen rows
-
-
-def test_delete_unseen_team_between_pages_no_dup_or_gap() -> None:
-    """(f) Deleting a not-yet-seen row between fetches leaves seen rows intact."""
-    rows = _distinct_rows(6)
-    services = MagicMock()
-    services.event_store.list_teams.side_effect = lambda **_kw: list(rows)
-    service = TeamService(services, workspaces_root=Path("/unused"))
-
-    page1, token = service.list_teams(user_id="alice", limit=2)
-    assert token is not None
-    seen = {p.team_id for p in page1}
-
-    # Delete an OLDER (not-yet-seen) row before continuing.
-    oldest = min(rows, key=lambda p: (p.created_at, p.team_id))
-    rows.remove(oldest)
-
-    cursor = TeamCursor.decode(token)
-    page2, _ = service.list_teams(user_id="alice", limit=2, cursor=cursor)
-    page2_ids = {p.team_id for p in page2}
-
-    assert seen.isdisjoint(page2_ids)  # no row re-shown
-    assert oldest.team_id not in page2_ids  # deleted row never surfaces
-
-
-def test_limit_clamped_to_range() -> None:
-    """(d) limit is clamped to [1, 200]: 0 -> 1 row, 99999 -> all (<=200)."""
-    rows = _distinct_rows(3)
+def test_default_page_is_1() -> None:
+    """(f) default page is 1: omitting page returns the first slice."""
+    rows = _distinct_rows(10)
     service = _service_over(rows)
-    page_low, _ = service.list_teams(user_id="alice", limit=0)
-    assert len(page_low) == 1
-    page_high, _ = service.list_teams(user_id="alice", limit=99999)
-    assert len(page_high) == 3
+    expected = sorted(rows, key=lambda p: (p.created_at, p.team_id), reverse=True)
+    default_page, _ = service.list_teams(user_id="alice", size=3)
+    explicit_page1, _ = service.list_teams(user_id="alice", page=1, size=3)
+    assert [p.team_id for p in default_page] == [p.team_id for p in expected[0:3]]
+    assert [p.team_id for p in default_page] == [p.team_id for p in explicit_page1]
+
+
+def test_page_clamps_to_lower_bound() -> None:
+    """(f) page <= 0 clamps to 1 (same slice as page 1)."""
+    rows = _distinct_rows(10)
+    service = _service_over(rows)
+    page_zero, _ = service.list_teams(user_id="alice", page=0, size=3)
+    page_neg, _ = service.list_teams(user_id="alice", page=-3, size=3)
+    page1, _ = service.list_teams(user_id="alice", page=1, size=3)
+    assert [p.team_id for p in page_zero] == [p.team_id for p in page1]
+    assert [p.team_id for p in page_neg] == [p.team_id for p in page1]
 
 
 # ---------------------------------------------------------------------------
-# Story 36.1 AC #12 — the server is stateless: the opaque cursor is the ONLY
-# pagination state and it lives on the client. list_teams is a pure function of
-# (user_id, limit, cursor) + current store contents; nothing is cached between
+# Story 37.1 AC #7 — list_teams is stateless: a pure function of
+# (user_id, page, size) + current store contents; nothing is cached between
 # requests, so a page is correct regardless of which replica serves it.
 # ---------------------------------------------------------------------------
 
@@ -582,42 +554,35 @@ def test_limit_clamped_to_range() -> None:
 def test_list_teams_refetches_store_every_call() -> None:
     """Every list_teams call re-reads the store — no cached sorted list."""
     service = _service_over(_distinct_rows(5))
-    service.list_teams(user_id="alice", limit=2)
-    _, token = service.list_teams(user_id="alice", limit=2)
-    assert token is not None
-    service.list_teams(user_id="alice", limit=2, cursor=TeamCursor.decode(token))
+    service.list_teams(user_id="alice", page=1, size=2)
+    service.list_teams(user_id="alice", page=2, size=2)
+    service.list_teams(user_id="alice", page=3, size=2)
     # One store read per request — no request reused a prior request's fetch.
     assert service._services.event_store.list_teams.call_count == 3
 
 
-def test_same_cursor_yields_same_page_independent_requests() -> None:
-    """Two independent requests with the same cursor return the same page."""
+def test_same_args_yield_same_page_independent_requests() -> None:
+    """Two independent requests with the same (page, size) return the same page."""
     rows = _distinct_rows(7)
     service = _service_over(rows)
-    _, token = service.list_teams(user_id="alice", limit=2)
-    assert token is not None
-    cursor = TeamCursor.decode(token)
-    page_a, next_a = service.list_teams(user_id="alice", limit=2, cursor=cursor)
-    page_b, next_b = service.list_teams(user_id="alice", limit=2, cursor=cursor)
+    page_a, total_a = service.list_teams(user_id="alice", page=2, size=2)
+    page_b, total_b = service.list_teams(user_id="alice", page=2, size=2)
     assert [p.team_id for p in page_a] == [p.team_id for p in page_b]
-    assert next_a == next_b
+    assert total_a == total_b
 
 
-def test_cursor_works_on_fresh_service_instance() -> None:
-    """A cursor minted by one service instance is followable by a SEPARATE,
-    freshly constructed instance over the same store contents — simulating a
-    different worker/replica with no shared in-process state.
+def test_page_followable_on_fresh_service_instance() -> None:
+    """A page minted by one service instance matches a SEPARATE, freshly
+    constructed instance over the same store contents — simulating a different
+    worker/replica with no shared in-process state.
     """
     rows = _distinct_rows(7)
     minting_service = _service_over(rows)
-    page1, token = minting_service.list_teams(user_id="alice", limit=3)
-    assert token is not None
+    page1, _ = minting_service.list_teams(user_id="alice", page=1, size=3)
 
     # A brand-new instance (different "replica"), no prior request primed.
     fresh_service = _service_over(rows)
-    page2, _ = fresh_service.list_teams(
-        user_id="alice", limit=3, cursor=TeamCursor.decode(token)
-    )
+    page2, _ = fresh_service.list_teams(user_id="alice", page=2, size=3)
 
     seen = {p.team_id for p in page1} | {p.team_id for p in page2}
     assert {p.team_id for p in page1}.isdisjoint({p.team_id for p in page2})
@@ -628,7 +593,7 @@ def test_list_teams_holds_no_per_request_state() -> None:
     """list_teams mutates no instance attribute that survives the call."""
     service = _service_over(_distinct_rows(5))
     before = dict(vars(service))
-    service.list_teams(user_id="alice", limit=2)
+    service.list_teams(user_id="alice", page=1, size=2)
     after = dict(vars(service))
     # No new attribute, and the wired collaborators are unchanged identities.
     assert before.keys() == after.keys()


### PR DESCRIPTION
## Epic 37 — Classic Offset+Total Paginated Team Listing

Replaces the merged cursor-paginated `GET /teams` backend with classic
offset+total pagination per ADR-032 (which supersedes ADR-031). `master` tip
(73993ae) shipped the cursor endpoint (`limit`/`cursor`/`next_cursor`); this
branch removes that cursor machinery and delivers a numbered-page contract:
`page`/`size` query params plus a `total_count` of the full owned set.

### Stories

- [x] 37-1-offset-total-paginated-get-teams — classic offset+total `GET /teams` (Relates to #319)

### What changed

- **Boundary model** — `TeamListResponse` gains required `total_count: int`; `next_cursor` removed (typed Pydantic, no `dict[str, Any]`).
- **Service** — `MAX_PAGE_SIZE = 500`; `TeamService.list_teams(*, user_id, page=1, size=250) -> tuple[list[Process], int]`: loads the full owned set via the existing `event_store.list_teams(user_id=...)`, sorts `(created_at, team_id)` DESC, computes `total = len(rows)` before slicing, clamps `size` to `[1, 500]` and `page` to `>= 1`, slices `rows[(page-1)*size : (page-1)*size + size]`, returns `(slice, total)`. Stateless; out-of-range page → `([], total)`.
- **Route** — `GET /teams` takes optional `page: int = 1` / `size: int = 250`, unpacks the tuple, returns `TeamListResponse(teams=[...], total_count=total)`.
- **V1 adapter** — `list_processes` requests `size=MAX_PAGE_SIZE` and ignores `total_count`, preserving its flat list-all behaviour.
- **Cursor machinery removed** — `TeamCursor`, `InvalidCursorError`, `_seek`, `DEFAULT_PAGE_LIMIT`, `MAX_PAGE_LIMIT`, `_MAX_CURSOR_LEN`, `next_cursor`. The merged Story-36.1 cursor tests were migrated/replaced with offset+total tests (page-1/total, page-N slice+order, out-of-range, ordering with `team_id` tiebreak, size clamp lo/hi/250, default/clamped page, statelessness incl. cross-replica).

### Review status

APPROVE (Rex). No HIGH/MEDIUM findings. AC #1–#16 all implemented; cursor backend fully removed with no dangling references; V1 list-all contract preserved.

**Local gate (submodule config):**
- `pytest packages/akgentic-infra/tests/` — 1578 passed, 39 skipped, 130 deselected; coverage 90.43% (≥ 80%).
- `ruff check packages/akgentic-infra/src/` — clean.
- `mypy --strict packages/akgentic-infra/src/` — no issues in 114 files.

### Scope guard

All changes are inside `packages/akgentic-infra/` (Golden Rule #4). The
`akgentic-team` `EventStore.list_teams` is consumed through its existing public
API only — no cross-submodule edit. The Phase-2 store-side offset/count pushdown
stays deferred to a separate `akgentic-team` epic.

### Replaces the merged cursor backend

This PR REPLACES the cursor-paginated `GET /teams` (Epic 36 / PR #318, merged to
`master`) with classic offset+total per ADR-032, which supersedes ADR-031. The
diff intentionally removes the cursor code and migrates its tests.

### Epic 37 slice complete

Epic 37 has a single story (37-1), delivered here. With this PR the epic's
infra-side contract (`page`/`size`/`total_count`) is complete. The frontend
classic paginated-table epic (akgentic-frontend Epic 28, ADR-032 §Decision 3)
consumes this `total_count` contract and is a separate submodule/epic.

Closes #319
