### PR TITLE
fix(akgentic-infra): evict runtime_cache on worker team stop/delete

### DIFF
--- a/src/akgentic/infra/worker/routes/teams.py
+++ b/src/akgentic/infra/worker/routes/teams.py
@@ -215,6 +215,7 @@ def stop_team(
     logger.info("POST /teams/%s/stop", team_id)
     try:
         services.worker_handle.stop_team(team_id)
+        services.runtime_cache.remove(team_id)
     except ValueError as exc:
         _raise_action_error(exc)
 
@@ -228,6 +229,7 @@ def delete_team(
     logger.info("DELETE /teams/%s", team_id)
     try:
         services.worker_handle.delete_team(team_id)
+        services.runtime_cache.remove(team_id)
     except ValueError as exc:
         _raise_action_error(exc)
 

--- a/tests/worker/test_routes_teams.py
+++ b/tests/worker/test_routes_teams.py
@@ -26,7 +26,9 @@ from akgentic.infra.server.models import SendMessageRequest
 from akgentic.infra.worker.routes.teams import (
     WorkerCreateTeamRequest,
     create_team,
+    delete_team,
     send_message,
+    stop_team,
 )
 
 _TEAM_CARD_PAYLOAD = {
@@ -181,6 +183,61 @@ def test_create_team_store_is_idempotent_overwrite() -> None:
     assert isinstance(second_handle, LocalTeamHandle)
     assert second_handle is not first_handle
     assert second_handle.team_id == team_id
+
+
+def _build_lifecycle_services(
+    runtime: _FakeRuntime,
+    process: Process,
+    cache: LocalRuntimeCache,
+) -> SimpleNamespace:
+    """WorkerServices stub whose worker_handle also supports stop/delete (no-ops)."""
+    return SimpleNamespace(
+        team_manager=SimpleNamespace(create_team=lambda **_kwargs: runtime),
+        worker_handle=SimpleNamespace(
+            get_team=lambda _tid: process,
+            stop_team=lambda _tid: None,
+            delete_team=lambda _tid: None,
+        ),
+        runtime_cache=cache,
+    )
+
+
+def test_stop_team_evicts_handle_from_cache() -> None:
+    """Regression: stopping a team removes its handle so the cache cannot pin it.
+
+    Without the eviction the worker-lifetime LocalRuntimeCache retains the whole
+    TeamRuntime graph (proxies, ActorRefs, pykka AttrInfo) of every stopped team.
+    """
+    team_id = uuid.uuid4()
+    team_card = _build_team_card()
+    cache = LocalRuntimeCache()
+    services = _build_lifecycle_services(
+        _FakeRuntime(team_id), _build_process(team_id, team_card), cache
+    )
+
+    create_team(_make_create_body(team_id, team_card), services)  # type: ignore[arg-type]
+    assert cache.get(team_id) is not None
+
+    stop_team(team_id, services)  # type: ignore[arg-type]
+
+    assert cache.get(team_id) is None, "stop_team must evict the handle from runtime_cache"
+
+
+def test_delete_team_evicts_handle_from_cache() -> None:
+    """Regression: deleting a team removes its handle from the cache."""
+    team_id = uuid.uuid4()
+    team_card = _build_team_card()
+    cache = LocalRuntimeCache()
+    services = _build_lifecycle_services(
+        _FakeRuntime(team_id), _build_process(team_id, team_card), cache
+    )
+
+    create_team(_make_create_body(team_id, team_card), services)  # type: ignore[arg-type]
+    assert cache.get(team_id) is not None
+
+    delete_team(team_id, services)  # type: ignore[arg-type]
+
+    assert cache.get(team_id) is None, "delete_team must evict the handle from runtime_cache"
 
 
 def test_send_message_without_create_returns_404() -> None:


### PR DESCRIPTION
## Summary

The shared worker teams router (`worker/routes/teams.py`, mounted by both the department and enterprise workers) stored a `TeamHandle` in `runtime_cache` on create/resume but never removed it on stop/delete. The worker-lifetime `LocalRuntimeCache` therefore pinned every team ever created — `LocalTeamHandle → TeamRuntime → ActorProxy/AttrInfo/ActorRef/mailbox` — so worker RSS plateaued under create/stop load even though Pykka's registry reported no live actors.

`stop_team` and `delete_team` now call `runtime_cache.remove(team_id)` after the action succeeds. This is the `.remove()` twin of the `.store()` call lifted into the shared create handler in #313, and closes the route-level half of the worker memory leak.

## Changes

- `worker/routes/teams.py`: `runtime_cache.remove(team_id)` after a successful `stop_team` and after a successful `delete_team`.
- Regression tests asserting the handle is evicted on both the stop and the delete route.

## Notes

- One fix covers both the department and enterprise workers — both mount `akgentic.infra.worker.routes.teams`.
- `LocalRuntimeCache.remove` pops with a default, so the eviction is idempotent (safe against a double-remove).
- This covers the **HTTP stop/delete** paths. Making eviction path-independent so it also fires on the **inactivity-timer auto-stop** path is the `RuntimeCacheEvictionSubscriber` follow-on (epic-38), which references this fix as its precursor.

Relates to #321
