### PR TITLE
feat(akgentic-infra): epic 38 — RuntimeCacheEvictionSubscriber for all stop paths (38-1)

### DIFF
--- a/src/akgentic/infra/adapters/shared/__init__.py
+++ b/src/akgentic/infra/adapters/shared/__init__.py
@@ -15,6 +15,9 @@ from akgentic.infra.adapters.shared.channel_parser_registry import (
 )
 from akgentic.infra.adapters.shared.event_stream_subscriber import EventStreamSubscriber
 from akgentic.infra.adapters.shared.null_event_stream import NullEventStream, NullStreamReader
+from akgentic.infra.adapters.shared.runtime_cache_eviction_subscriber import (
+    RuntimeCacheEvictionSubscriber,
+)
 from akgentic.infra.adapters.shared.telegram_adapter import TelegramChannelAdapter
 from akgentic.infra.adapters.shared.telegram_parser import TelegramChannelParser
 from akgentic.infra.adapters.shared.telemetry_subscriber import TelemetrySubscriber
@@ -26,6 +29,7 @@ __all__ = [
     "InteractionChannelDispatcher",
     "NullEventStream",
     "NullStreamReader",
+    "RuntimeCacheEvictionSubscriber",
     "TelegramChannelAdapter",
     "TelegramChannelParser",
     "TelemetrySubscriber",

--- a/src/akgentic/infra/adapters/shared/runtime_cache_eviction_subscriber.py
+++ b/src/akgentic/infra/adapters/shared/runtime_cache_eviction_subscriber.py
@@ -1,0 +1,84 @@
+"""RuntimeCacheEvictionSubscriber -- shared subscriber that evicts stopped teams.
+
+Implements the ``EventSubscriber`` protocol from ``akgentic.core.orchestrator``.
+A single instance is shared across all teams on a worker. On ``on_stop(team_id)``
+it removes the stopping team's handle from the worker's ``runtime_cache`` so the
+team graph is released on EVERY stop path (HTTP stop/delete routes AND the
+inactivity-timer auto-stop), not just the routes. ``remove`` is idempotent, so the
+route-level eviction in ``worker/routes/teams.py`` stays as belt-and-suspenders.
+"""
+
+from __future__ import annotations
+
+import logging
+import uuid
+from typing import TYPE_CHECKING
+
+from akgentic.core.orchestrator import EventSubscriber
+
+if TYPE_CHECKING:
+    from akgentic.core.messages import Message
+    from akgentic.infra.protocols.runtime_cache import RuntimeCache
+
+logger = logging.getLogger(__name__)
+
+
+class RuntimeCacheEvictionSubscriber(EventSubscriber):
+    """Evicts a stopped team's handle from the shared RuntimeCache.
+
+    On ``on_stop(team_id)``, removes the team's handle from the injected
+    ``RuntimeCache`` — the path-independent per-team cleanup hook that releases
+    the team graph on both the HTTP stop/delete routes and the inactivity-timer
+    auto-stop. ``RuntimeCache.remove`` is idempotent, so the route-level eviction
+    remains as belt-and-suspenders (double-evict is harmless).
+    """
+
+    def __init__(self, runtime_cache: RuntimeCache) -> None:
+        self._runtime_cache = runtime_cache
+        logger.debug("RuntimeCacheEvictionSubscriber initialized")
+
+    def set_restoring(self, team_id: uuid.UUID, restoring: bool) -> None:  # noqa: FBT001, ARG002
+        """No-op — restore replay does not touch the runtime cache.
+
+        Args:
+            team_id: ``team_id`` from the orchestrator. Ignored.
+            restoring: ``True`` while restore replay is in progress, ``False``
+                otherwise. Ignored.
+        """
+
+    def on_stop_request(self, team_id: uuid.UUID) -> None:  # noqa: ARG002
+        """No-op — stop handling is bridged by ``TimerStopSubscriber`` in ``akgentic-team``.
+
+        Eviction happens in ``on_stop()`` once the team actually stops, not on
+        the stop-request signal.
+
+        Args:
+            team_id: ``team_id`` from the orchestrator. Ignored.
+        """
+
+    def on_stop(self, team_id: uuid.UUID) -> None:
+        """Remove the stopping team's handle from the runtime cache.
+
+        Any error raised by ``runtime_cache.remove`` (e.g. handle already
+        removed by the route-level eviction as a belt-and-suspenders) is
+        swallowed and logged at DEBUG — ``on_stop`` must never propagate an
+        exception back to the orchestrator.
+
+        Args:
+            team_id: ``team_id`` of the stopping team.
+        """
+        try:
+            self._runtime_cache.remove(team_id)
+        except Exception:  # noqa: BLE001
+            logger.debug(
+                "RuntimeCacheEvictionSubscriber: remove() failed for team_id=%s",
+                team_id,
+            )
+        logger.debug("RuntimeCacheEvictionSubscriber stopped, team_id=%s", team_id)
+
+    def on_message(self, msg: Message) -> None:  # noqa: ARG002
+        """No-op — the runtime cache is not message-driven.
+
+        Args:
+            msg: Orchestrator message. Ignored.
+        """

--- a/src/akgentic/infra/worker/routes/teams.py
+++ b/src/akgentic/infra/worker/routes/teams.py
@@ -215,6 +215,7 @@ def stop_team(
     logger.info("POST /teams/%s/stop", team_id)
     try:
         services.worker_handle.stop_team(team_id)
+        services.runtime_cache.remove(team_id)
     except ValueError as exc:
         _raise_action_error(exc)
 
@@ -228,6 +229,7 @@ def delete_team(
     logger.info("DELETE /teams/%s", team_id)
     try:
         services.worker_handle.delete_team(team_id)
+        services.runtime_cache.remove(team_id)
     except ValueError as exc:
         _raise_action_error(exc)
 

--- a/tests/adapters/shared/test_runtime_cache_eviction_subscriber.py
+++ b/tests/adapters/shared/test_runtime_cache_eviction_subscriber.py
@@ -1,0 +1,146 @@
+"""Tests for RuntimeCacheEvictionSubscriber adapter.
+
+Story 38.1: ``on_stop(team_id)`` evicts the stopping team's handle from the
+worker's ``runtime_cache`` so eviction is path-independent (HTTP routes AND
+the inactivity-timer auto-stop). The other three ``EventSubscriber`` hooks are
+documented no-ops. ``remove`` is idempotent (double-evict is harmless).
+"""
+
+from __future__ import annotations
+
+import logging
+import uuid
+from typing import TYPE_CHECKING
+
+import pytest
+from akgentic.core.messages import Message
+from akgentic.core.orchestrator import EventSubscriber
+from akgentic.infra.adapters.community.local_runtime_cache import LocalRuntimeCache
+from akgentic.infra.adapters.shared.runtime_cache_eviction_subscriber import (
+    RuntimeCacheEvictionSubscriber,
+)
+
+if TYPE_CHECKING:
+    from akgentic.infra.protocols.team_handle import TeamHandle
+
+_TEAM_ID = uuid.uuid4()
+
+
+class FakeRuntimeCache:
+    """In-test fake RuntimeCache that records store/get/remove calls.
+
+    Satisfies the ``RuntimeCache`` Protocol structurally. ``remove`` optionally
+    raises to exercise the exception-swallow path in ``on_stop``.
+    """
+
+    def __init__(self, *, remove_raises: bool = False) -> None:
+        self.removed: list[uuid.UUID] = []
+        self.stored: list[uuid.UUID] = []
+        self.got: list[uuid.UUID] = []
+        self._remove_raises = remove_raises
+
+    def store(self, team_id: uuid.UUID, handle: TeamHandle) -> None:  # noqa: ARG002
+        self.stored.append(team_id)
+
+    def get(self, team_id: uuid.UUID) -> TeamHandle | None:
+        self.got.append(team_id)
+        return None
+
+    def remove(self, team_id: uuid.UUID) -> None:
+        self.removed.append(team_id)
+        if self._remove_raises:
+            raise RuntimeError("remove failed")
+
+
+class TestProtocolCompliance:
+    """AC #2: RuntimeCacheEvictionSubscriber structurally satisfies EventSubscriber."""
+
+    def test_satisfies_event_subscriber_protocol(self) -> None:
+        subscriber: EventSubscriber = RuntimeCacheEvictionSubscriber(
+            runtime_cache=FakeRuntimeCache()
+        )
+        assert callable(subscriber.set_restoring)
+        assert callable(subscriber.on_stop_request)
+        assert callable(subscriber.on_stop)
+        assert callable(subscriber.on_message)
+
+
+class TestOnStop:
+    """AC #4, #5, #6: ``on_stop(team_id)`` evicts the stopping team."""
+
+    def test_on_stop_removes_supplied_team_once(self) -> None:
+        """AC #4: ``on_stop(team)`` calls ``remove(team)`` exactly once."""
+        cache = FakeRuntimeCache()
+        subscriber = RuntimeCacheEvictionSubscriber(runtime_cache=cache)
+        team_id = uuid.uuid4()
+
+        subscriber.on_stop(team_id)
+
+        assert cache.removed == [team_id]
+
+    def test_on_stop_twice_is_idempotent(self) -> None:
+        """AC #5: two ``on_stop`` calls for the same team do not raise.
+
+        Asserted against the real ``LocalRuntimeCache`` whose ``remove`` pops
+        with a default, so the second remove is a genuine no-op.
+        """
+        cache = LocalRuntimeCache()
+        subscriber = RuntimeCacheEvictionSubscriber(runtime_cache=cache)
+        team_id = uuid.uuid4()
+
+        subscriber.on_stop(team_id)
+        subscriber.on_stop(team_id)
+
+        assert cache.get(team_id) is None
+
+    def test_on_stop_swallows_remove_exception(self, caplog: pytest.LogCaptureFixture) -> None:
+        """AC #6: a ``remove`` that raises is swallowed and logged at DEBUG."""
+        cache = FakeRuntimeCache(remove_raises=True)
+        subscriber = RuntimeCacheEvictionSubscriber(runtime_cache=cache)
+        team_id = uuid.uuid4()
+
+        with caplog.at_level(
+            logging.DEBUG,
+            logger="akgentic.infra.adapters.shared.runtime_cache_eviction_subscriber",
+        ):
+            result = subscriber.on_stop(team_id)
+
+        assert result is None
+        assert cache.removed == [team_id]
+        assert len(caplog.records) >= 1
+
+
+class TestNoOps:
+    """AC #7: ``set_restoring``/``on_stop_request``/``on_message`` are no-ops."""
+
+    def test_set_restoring_is_noop(self) -> None:
+        cache = FakeRuntimeCache()
+        subscriber = RuntimeCacheEvictionSubscriber(runtime_cache=cache)
+
+        assert subscriber.set_restoring(_TEAM_ID, True) is None
+        assert subscriber.set_restoring(_TEAM_ID, False) is None
+
+        assert cache.removed == []
+        assert cache.stored == []
+        assert cache.got == []
+
+    def test_on_stop_request_is_noop(self) -> None:
+        cache = FakeRuntimeCache()
+        subscriber = RuntimeCacheEvictionSubscriber(runtime_cache=cache)
+
+        assert subscriber.on_stop_request(_TEAM_ID) is None
+
+        assert cache.removed == []
+        assert cache.stored == []
+        assert cache.got == []
+
+    def test_on_message_is_noop(self) -> None:
+        cache = FakeRuntimeCache()
+        subscriber = RuntimeCacheEvictionSubscriber(runtime_cache=cache)
+        msg = Message(team_id=_TEAM_ID)
+
+        assert subscriber.on_message(msg) is None
+
+        assert cache.removed == []
+        assert cache.stored == []
+        assert cache.got == []

--- a/tests/worker/test_routes_teams.py
+++ b/tests/worker/test_routes_teams.py
@@ -26,7 +26,9 @@ from akgentic.infra.server.models import SendMessageRequest
 from akgentic.infra.worker.routes.teams import (
     WorkerCreateTeamRequest,
     create_team,
+    delete_team,
     send_message,
+    stop_team,
 )
 
 _TEAM_CARD_PAYLOAD = {
@@ -181,6 +183,61 @@ def test_create_team_store_is_idempotent_overwrite() -> None:
     assert isinstance(second_handle, LocalTeamHandle)
     assert second_handle is not first_handle
     assert second_handle.team_id == team_id
+
+
+def _build_lifecycle_services(
+    runtime: _FakeRuntime,
+    process: Process,
+    cache: LocalRuntimeCache,
+) -> SimpleNamespace:
+    """WorkerServices stub whose worker_handle also supports stop/delete (no-ops)."""
+    return SimpleNamespace(
+        team_manager=SimpleNamespace(create_team=lambda **_kwargs: runtime),
+        worker_handle=SimpleNamespace(
+            get_team=lambda _tid: process,
+            stop_team=lambda _tid: None,
+            delete_team=lambda _tid: None,
+        ),
+        runtime_cache=cache,
+    )
+
+
+def test_stop_team_evicts_handle_from_cache() -> None:
+    """Regression: stopping a team removes its handle so the cache cannot pin it.
+
+    Without the eviction the worker-lifetime LocalRuntimeCache retains the whole
+    TeamRuntime graph (proxies, ActorRefs, pykka AttrInfo) of every stopped team.
+    """
+    team_id = uuid.uuid4()
+    team_card = _build_team_card()
+    cache = LocalRuntimeCache()
+    services = _build_lifecycle_services(
+        _FakeRuntime(team_id), _build_process(team_id, team_card), cache
+    )
+
+    create_team(_make_create_body(team_id, team_card), services)  # type: ignore[arg-type]
+    assert cache.get(team_id) is not None
+
+    stop_team(team_id, services)  # type: ignore[arg-type]
+
+    assert cache.get(team_id) is None, "stop_team must evict the handle from runtime_cache"
+
+
+def test_delete_team_evicts_handle_from_cache() -> None:
+    """Regression: deleting a team removes its handle from the cache."""
+    team_id = uuid.uuid4()
+    team_card = _build_team_card()
+    cache = LocalRuntimeCache()
+    services = _build_lifecycle_services(
+        _FakeRuntime(team_id), _build_process(team_id, team_card), cache
+    )
+
+    create_team(_make_create_body(team_id, team_card), services)  # type: ignore[arg-type]
+    assert cache.get(team_id) is not None
+
+    delete_team(team_id, services)  # type: ignore[arg-type]
+
+    assert cache.get(team_id) is None, "delete_team must evict the handle from runtime_cache"
 
 
 def test_send_message_without_create_returns_404() -> None:


### PR DESCRIPTION
Adds a generic, tier-agnostic `RuntimeCacheEvictionSubscriber(EventSubscriber)` in `adapters/shared/` whose `on_stop(team_id)` evicts the stopping team's handle from the worker's `runtime_cache`, making per-team eviction fire on **every** stop path (the HTTP stop/delete routes AND the inactivity-timer auto-stop) instead of leaking the whole team graph on the auto-stop path.

## Stories

- [x] 38-1-add-and-export-runtime-cache-eviction-subscriber — add+export `RuntimeCacheEvictionSubscriber` (Relates to #323)

## Review status

**38-1 — PASS.** Faithful mirror of the established `EventStreamSubscriber.on_stop → event_stream.remove` precedent, swapping the dependency to `RuntimeCache` (TYPE_CHECKING-only import). All 9 acceptance criteria implemented and verified file-by-file; all 5 `[x]` tasks genuinely done. No fix-worthy issues found, so no review fixup commit was added.

- `on_stop(team_id)` removes exactly once, swallows any `remove()` exception (`# noqa: BLE001`) and logs at DEBUG, and is idempotent on a double-stop (verified against the real `LocalRuntimeCache` whose `remove` pops with a default).
- `set_restoring`, `on_stop_request`, and `on_message` are documented no-ops that touch nothing. `on_stop_request` is retained intentionally: the orchestrator's inactivity-timer handler calls it by name on every subscriber (`Orchestrator._notify_subscribers_lifecycle` → `getattr(subscriber, "on_stop_request")(team_id)`), so dropping it would raise `AttributeError` on every timeout.
- Exported from `adapters/shared/__init__.py` (import + `__all__`, alphabetical).
- Route-level `runtime_cache.remove` calls in `worker/routes/teams.py` are left in place as belt-and-suspenders (AC #9) — no route change here.

Local gates (submodule config): full `akgentic-infra` pytest suite **1587 passed, 39 skipped** at **90.50%** coverage (new module **100%** line+branch); `ruff check` + `ruff format --check` clean on the three story files; `mypy --strict` clean on the new module.

## Scope guard

Every change stays inside `packages/akgentic-infra/` (Golden Rule #4). The commit under review (`d63b29e`) touches exactly three files, all in this submodule:

- `src/akgentic/infra/adapters/shared/runtime_cache_eviction_subscriber.py` (new)
- `src/akgentic/infra/adapters/shared/__init__.py` (import + `__all__`)
- `tests/adapters/shared/test_runtime_cache_eviction_subscriber.py` (new)

No edit to `akgentic-core`, `akgentic-team`, `akgentic-infra-department`, or `akgentic-infra-enterprise`.

## Stacked PR

This PR is based on `fix/worker-runtime-cache-evict` (PR #322 / issue #321 — the route-level `runtime_cache.remove` fix), so the diff shows **only** the new subscriber. It should merge **after** #322; GitHub auto-retargets this PR to `master` once #322 lands.

## Epic 38 slice complete

The `akgentic-infra` slice of Epic 38 (RuntimeCacheEvictionSubscriber for all stop paths) is delivered: the shared adapter and its export. Downstream wiring into the worker subscriber lists is each consumer's own epic — `akgentic-infra-department` Epic 18 and `akgentic-infra-enterprise` Epic 31 — and depends on this landing first.
